### PR TITLE
Nested or Grouped Shared Conditions

### DIFF
--- a/src/FluentValidation.Tests/FluentValidation.Tests.csproj
+++ b/src/FluentValidation.Tests/FluentValidation.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="LessThanValidatorTester.cs" />
     <Compile Include="LocalisedMessagesTester.cs" />
     <Compile Include="NameResolutionPluggabilityTester.cs" />
+    <Compile Include="SharedConditionTests.cs" />
     <Compile Include="NotEmptyTester.cs" />
     <Compile Include="NotEqualValidatorTests.cs" />
     <Compile Include="NotNullTester.cs" />

--- a/src/FluentValidation.Tests/SharedConditionTests.cs
+++ b/src/FluentValidation.Tests/SharedConditionTests.cs
@@ -1,0 +1,135 @@
+namespace FluentValidation.Tests
+{
+	using NUnit.Framework;
+	using System;
+
+	[TestFixture]
+	public class SharedConditionTests
+	{
+		private class SharedConditionValidator : AbstractValidator<Person>
+		{
+			public SharedConditionValidator()
+			{
+				// Start with a predicate to group rules together.
+				// 
+				// The AbstractValidator appends this predicate
+				// to each inner RuleFor so you only need write,
+				// maintain, and think about it in one place.
+				//
+				// Each grouped RuleFor call must be wrapped in a 
+				// chained Add() calls in order to enable chaining
+				// RuleFor's that validate properties of multiple
+				// types.
+				// 
+				// You can finish with an Unless clause that will
+				// void the validation for the entire set when it's 
+				// predicate is true.
+				// 
+				When( x => x.Id > 0 )
+					.Add( RuleFor( x => x.Forename ).NotEmpty() )
+					.Add( RuleFor( x => x.Surname ).NotEmpty().Equal( "Smith" ) );
+			}
+		}
+
+		private class SharedConditionWithScopedUnlessValidator : AbstractValidator<Person>
+		{
+			public SharedConditionWithScopedUnlessValidator()
+			{
+				// inner RuleFor() calls can contain their own,
+				// locally scoped When and Unless calls that
+				// act only on that individual RuleFor() yet the
+				// RuleFor() respects the grouped When() and 
+				// Unless() predicates.
+				// 
+				When( x => x.Id > 0 )
+					.Add( RuleFor( x => x.Orders.Count ).Equal( 0 ).Unless( x => String.IsNullOrWhiteSpace( x.CreditCard ) == false ) )
+					.Unless( x => x.Age > 65 );
+			}
+		}
+
+		[Test]
+		public void Shared_When_is_not_applied_to_grouped_rules_when_initial_predicate_is_false()
+		{
+			var validator = new SharedConditionValidator();
+			var person = new Person();	// fails the shared When predicate
+
+			var result = validator.Validate( person );
+			result.Errors.Count.ShouldEqual( 0 );
+		}
+
+		[Test]
+		public void Shared_When_is_applied_to_grouped_rules_when_initial_predicate_is_true()
+		{
+			var validator = new SharedConditionValidator();
+			var person = new Person()
+			{
+				Id = 4					// triggers the shared When predicate
+			};
+
+			var result = validator.Validate( person );
+			result.Errors.Count.ShouldEqual( 3 );
+		}
+
+		[Test]
+		public void Shared_When_is_applied_to_groupd_rules_when_initial_predicate_is_true_and_all_individual_rules_are_satisfied()
+		{
+			var validator = new SharedConditionValidator();
+			var person = new Person()
+			{
+				Id       = 4,			// triggers the shared When predicate
+				Forename = "Kevin",		// satisfies RuleFor( x => x.Forename ).NotEmpty()
+				Surname  = "Smith",		// satisfies RuleFor( x => x.Surname ).NotEmpty().Equal( "Smith" )
+			};
+
+			var result = validator.Validate( person );
+			result.Errors.Count.ShouldEqual( 0 );
+		}
+
+		[Test]
+		public void Shared_When_respects_the_smaller_scope_of_an_inner_Unless_when_the_inner_Unless_predicate_is_satisfied()
+		{
+			var validator = new SharedConditionWithScopedUnlessValidator();
+			var person = new Person()
+			{
+				Id       = 4						// triggers the shared When predicate
+			};
+
+			person.CreditCard = "1234123412341234"; // satisfies the inner Unless predicate
+			person.Orders.Add( new Order() );
+
+			var result = validator.Validate( person );
+			result.Errors.Count.ShouldEqual( 0 );
+		}
+
+		[Test]
+		public void Shared_When_respects_the_smaller_scope_of_a_inner_Unless_when_the_inner_Unless_predicate_fails()
+		{
+			var validator = new SharedConditionWithScopedUnlessValidator();
+			var person = new Person()
+			{
+				Id  =  4							// triggers the shared When predicate
+			};
+
+			person.Orders.Add( new Order() );		// fails the inner Unless predicate
+
+			var result = validator.Validate( person );
+			result.Errors.Count.ShouldEqual( 1 );
+		}
+
+		[Test]
+		public void Outer_Until_clause_will_trump_an_inner_Until_clause_when_inner_fails_but_the_outer_is_satisfied()
+		{
+			var validator = new SharedConditionWithScopedUnlessValidator();
+			var person = new Person()
+			{
+				Id  =  4,							// triggers the shared When predicate
+				Age	= 70							// satisfies the outer Unless predicate
+			};
+
+			person.Orders.Add( new Order() );		// fails the inner Unless predicate
+
+			var result = validator.Validate( person );
+			result.Errors.Count.ShouldEqual( 0 );
+		}
+	}
+}

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -163,6 +163,11 @@ namespace FluentValidation {
 			}
 		}
 
+		public SharedConditionRuleHelper<T> When( Func<T, bool> predicate )
+		{
+			return new SharedConditionRuleHelper<T>( predicate );
+		}
+
 		/// <summary>
 		/// Returns an enumerator that iterates through the collection of validation rules.
 		/// </summary>

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Internal\MessageFormatter.cs" />
     <Compile Include="Internal\PropertyChain.cs" />
     <Compile Include="Internal\PropertyRule.cs" />
+    <Compile Include="SharedConditionRuleHelper.cs" />
     <Compile Include="Resources\IStringSource.cs" />
     <Compile Include="Resources\IResourceAccessorBuilder.cs" />
     <Compile Include="Resources\LocalizedStringSource.cs" />

--- a/src/FluentValidation/SharedConditionRuleHelper.cs
+++ b/src/FluentValidation/SharedConditionRuleHelper.cs
@@ -1,0 +1,83 @@
+namespace FluentValidation
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using Internal;
+    using Results;
+    using Validators;
+
+    public class SharedConditionRuleHelper<T>
+    {
+        Func<T, bool> whenPredicate;
+        Dictionary<Type, IList<object>> ruleOptions;
+
+        public SharedConditionRuleHelper()
+            : this(x => true)
+        {
+        }
+
+        public SharedConditionRuleHelper(Func<T, bool> whenPredicate)
+        {
+            this.whenPredicate = whenPredicate;
+            this.ruleOptions = new Dictionary<Type, IList<object>>();
+        }
+
+        public void Unless(Func<T, bool> predicate)
+        {
+            foreach (var pair in ruleOptions)
+            {
+                Type typeOfRuleOptions = pair.Key;
+
+                Type generic = typeof(UnlessVisistor<>);
+                Type specific = generic.MakeGenericType(typeof(T), typeOfRuleOptions);
+                ConstructorInfo ctorInfo = specific.GetConstructor(new Type[] { predicate.GetType() });
+                object o = ctorInfo.Invoke(new object[] { predicate });
+                IUnlessVisistor visitor = o as IUnlessVisistor;
+                visitor.Visit(pair.Value);
+            }
+        }
+
+        public interface IUnlessVisistor
+        {
+            void Visit(IList<object> rulesToVisit);
+        }
+
+        public class UnlessVisistor<TProperty> : IUnlessVisistor
+        {
+            Func<T, bool> unlessClause;
+
+            public UnlessVisistor(Func<T, bool> unlessClause)
+            {
+                this.unlessClause = unlessClause;
+            }
+
+            public void Visit(IList<object> rulesToVisit)
+            {
+                foreach (var rule in rulesToVisit.Cast<IRuleBuilderOptions<T, TProperty>>())
+                {
+                    rule.Unless(unlessClause);
+                }
+            }
+        }
+
+        public SharedConditionRuleHelper<T> Add<TProperty>(IRuleBuilderOptions<T, TProperty> builderOptions)
+        {
+            builderOptions.When(whenPredicate);
+
+            Type typeOfProperty = typeof(TProperty);
+
+            if (!ruleOptions.ContainsKey(typeOfProperty))
+            {
+                ruleOptions.Add(typeOfProperty, new List<object>());
+            }
+
+            ruleOptions[typeOfProperty].Add(builderOptions);
+
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
Jeremy, some months back you and I tossed some syntax concepts around via twitter for grouping shared conditions.

This pull request is now against the v3.0.0.1 branch as of Wednesday, July 27th and is intentionally left in a separate branch in my fork such that you can manage the merge as you see fit, if you decide to include it.

The syntax looks like:

```
  When(x => x.Id != 0)
      .Add( RuleFor(x => x.Name).NotNull() )
      .Add( RuleFor(x => x.Age).GreaterThan(0).Unless(x => x.Id < 0) )
      .Unless(x => x.Age == 42)
```

I understand not wanting to add complexity to the API but after poking at the chained-but-not-nested syntax that we mentioned over twitter, I believe this one is simpler.

My team has been using this syntax (or nearly identical) for some months now and find that being able to group several independent RuleFor() clauses under a common Where() or Unless() predicate makes that conditional validation logic more expressive and easier to understand.

Let me know what you think, if this is still too complicated. 
