### PR TITLE
Added private no-arg constructor to ValidationFailure

### DIFF
--- a/src/FluentValidation/Results/ValidationFailure.cs
+++ b/src/FluentValidation/Results/ValidationFailure.cs
@@ -23,6 +23,10 @@ namespace FluentValidation.Results {
 	[Serializable]
 #endif
 	public class ValidationFailure {
+		private ValidationFailure() {
+			
+		}
+
 		/// <summary>
 		/// Creates a new validation failure.
 		/// </summary>


### PR DESCRIPTION
Howdy,

I was doing some serialisation work with the ValidationResult today and hit a small snag with the ValidationFailure failing to deserialize due to not having a default constructor.

I threw one in to assist with that.

Let me know if there is further work needs doing to the pull request.

Cheers
byron
