### PR TITLE
Fixed .net 4.5 reflection bug

### DIFF
--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -33,7 +33,9 @@ namespace FluentValidation {
 	public abstract class AbstractValidator<T> : IValidator<T>, IEnumerable<IValidationRule> {
 		readonly TrackingCollection<IValidationRule> nestedValidators = new TrackingCollection<IValidationRule>();
 
-		Func<CascadeMode> cascadeMode = () => ValidatorOptions.CascadeMode;
+        // Work-around for reflection bug in .NET 4.5
+        static Func<CascadeMode> s_cascadeMode = () => ValidatorOptions.CascadeMode;
+        Func<CascadeMode> cascadeMode = s_cascadeMode;
 
 		/// <summary>
 		/// Sets the cascade mode for all rules within this validator.

--- a/src/FluentValidation/Internal/DelegateValidator.cs
+++ b/src/FluentValidation/Internal/DelegateValidator.cs
@@ -29,7 +29,10 @@ namespace FluentValidation.Internal {
 	/// <typeparam name="T"></typeparam>
 	public class DelegateValidator<T> : IValidationRule {
 		private readonly Func<T, ValidationContext<T>, IEnumerable<ValidationFailure>> func;
-		private Func<object, bool> condition = x => true;
+
+        // Work-around for reflection bug in .NET 4.5
+        static Func<object, bool> s_condition = x => true;
+		private Func<object, bool> condition = s_condition;
 
 		/// <summary>
 		/// Rule set to which this rule belongs.


### PR DESCRIPTION
Applied the fix, that was suggested by the CLR team, to the
`AbstractValidator<T>` and `DelegateValidator<T>` types.
