### PR TITLE
Chained property expression in Rule

### DIFF
--- a/src/FluentValidation.Tests/ChainedValidationTester.cs
+++ b/src/FluentValidation.Tests/ChainedValidationTester.cs
@@ -1,0 +1,191 @@
+﻿#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at http://www.codeplex.com/FluentValidation
+#endregion
+
+namespace FluentValidation.Tests {
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class ChainedValidationTester {
+		PersonValidator validator;
+		Person person;
+
+		[SetUp]
+		public void Setup() {
+			validator = new PersonValidator();
+			person = new Person {
+				Address = new Address {
+					Country = new Country()
+				},
+				Orders = new List<Order> {
+					new Order() { Amount = 5 },
+					new Order() { ProductName = "Foo" }    	
+				}
+			};
+		}
+
+		[Test]
+		public void Validates_chained_property() {
+			var results = validator.Validate(person);
+
+			results.Errors.Count.ShouldEqual(3);
+			results.Errors[0].PropertyName.ShouldEqual("Forename");
+			results.Errors[1].PropertyName.ShouldEqual("Address.Postcode");
+			results.Errors[2].PropertyName.ShouldEqual("Address.Country.Name");
+		}
+
+		[Test]
+		public void Chained_validator_should_not_be_invoked_on_null_property() {
+			var results = validator.Validate(new Person());
+			results.Errors.Count.ShouldEqual(1);
+		}
+
+		[Test]
+		public void Should_allow_normal_rules_and_chained_property_on_same_property() {
+			validator.RuleFor(x => x.Address.Line1).NotNull();
+			var result = validator.Validate(person);
+			result.Errors.Count.ShouldEqual(4);
+		}
+
+		[Test]
+		public void Explicitly_included_properties_should_be_propogated_to_nested_validators() {
+			var results = validator.Validate(person, x => x.Address);
+			results.Errors.Count.ShouldEqual(2);
+			results.Errors.First().PropertyName.ShouldEqual("Address.Postcode");
+			results.Errors.Last().PropertyName.ShouldEqual("Address.Country.Name");
+		}
+
+		[Test]
+		public void Explicitly_included_properties_should_be_propogated_to_nested_validators_using_strings() {
+			var results = validator.Validate(person, "Address");
+			results.Errors.Count.ShouldEqual(2);
+			results.Errors.First().PropertyName.ShouldEqual("Address.Postcode");
+			results.Errors.Last().PropertyName.ShouldEqual("Address.Country.Name");
+		}
+
+		[Test]
+		public void Chained_property_should_be_excluded() {
+			var results = validator.Validate(person, x => x.Surname);
+			results.Errors.Count.ShouldEqual(0);
+		}
+
+		[Test]
+		public void Condition_should_work_with_chained_property() {
+			var person = new Person {
+				Address = new Address {
+					Line2 = "foo"
+				}
+			};
+			var result = validator.Validate(person);
+			result.Errors.Count.ShouldEqual(3);
+			result.Errors.Last().PropertyName.ShouldEqual("Address.Line1");
+		}
+
+		[Test]
+		public void Can_validate_using_validator_for_base_type() {
+			var addressValidator = new InlineValidator<IAddress>() {
+				v => v.RuleFor(x => x.Line1).NotNull()
+			};
+
+			var validator = new TestValidator {
+				v => v.RuleFor(x => x.Address).SetValidator(addressValidator)	
+			};
+
+			var result = validator.Validate(new Person { Address = new Address() });
+			result.IsValid.ShouldBeFalse();
+		}
+
+		[Test]
+		public void Separate_validation_on_chained_property() {
+			var validator = new DepartmentValidator();
+			var result = validator.Validate(new Department
+			{
+				Manager = new Person(),
+				Assistant = new Person()
+			});
+			result.IsValid.ShouldBeTrue();
+		}
+
+		[Test]
+		public void Separate_validation_on_chained_property_valid() {
+			var validator = new DepartmentValidator();
+			var result = validator.Validate(new Department {
+				Manager = new Person {
+					Surname = "foo"
+				}
+
+			});
+			result.Errors.IsValid().ShouldBeTrue();
+		}
+
+		[Test]
+		public void Separate_validation_on_chained_property_conditional() {
+			var validator = new DepartmentValidator();
+			var result = validator.Validate(new Department {
+				Manager = new Person {
+					Surname = "foo"
+				},
+				Assistant = new Person {
+					Surname = "foo"
+				}
+			});
+			result.Errors.Count.ShouldEqual(1);
+			result.Errors.First().PropertyName.ShouldEqual("Assistant.Surname");
+		}
+
+		[Test]
+		public void Chained_validator_descriptor() {
+			var descriptor = validator.CreateDescriptor();
+
+			var members = descriptor.GetMembersWithValidators().ToList();
+			members.Count.ShouldEqual(4);
+			members[0].Key.ShouldEqual("Forename");
+			members[1].Key.ShouldEqual("Address.Postcode");
+			members[2].Key.ShouldEqual("Address.Country.Name");
+			members[3].Key.ShouldEqual("Address.Line1");
+		}
+
+		public class DepartmentValidator : AbstractValidator<Department> {
+			public DepartmentValidator() {
+				CascadeMode = CascadeMode.StopOnFirstFailure; ;
+				RuleFor(x => x.Manager).NotNull();
+				RuleFor(x => x.Assistant.Surname).NotEqual(x => x.Manager.Surname).When(x => x.Assistant != null && x.Manager.Surname != null);
+			}
+		}
+
+		public class PersonValidator : AbstractValidator<Person> {
+			public PersonValidator() {
+				RuleFor(x => x.Forename).NotNull();
+				When(x => x.Address != null, () => {
+					RuleFor(x => x.Address.Postcode).NotNull();
+					RuleFor(x => x.Address.Country.Name).NotNull().When(x => x.Address.Country != null);
+					RuleFor(x => x.Address.Line1).NotNull().When(x => x.Address.Line2 != null);
+				});
+			}
+		}
+
+		public class Department {
+			public Person Manager { get; set; }
+			public Person Assistant { get; set; }
+			public IList<Person> Employees { get; set; }
+		}
+	
+	}
+}

--- a/src/FluentValidation.Tests/FluentValidation.Tests.csproj
+++ b/src/FluentValidation.Tests/FluentValidation.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AssemblyScannerTester.cs" />
     <Compile Include="AttributedValidatorFactoryTester.cs" />
     <Compile Include="CascadingFailuresTester.cs" />
+    <Compile Include="ChainedValidationTester.cs" />
     <Compile Include="ChainingValidatorsTester.cs" />
     <Compile Include="ChildValidatorInferenceTests.cs" />
     <Compile Include="ClientsideMessageTester.cs" />

--- a/src/FluentValidation/Internal/MemberNameValidatorSelector.cs
+++ b/src/FluentValidation/Internal/MemberNameValidatorSelector.cs
@@ -46,7 +46,7 @@ namespace FluentValidation.Internal {
 			// Validator selector only applies to the top level.
  			// If we're running in a child context then this means that the child validator has already been selected
 			// Because of this, we assume that the rule should continue (ie if the parent rule is valid, all children are valid)
-			return context.IsChildContext || memberNames.Any(x => x == propertyPath);
+			return context.IsChildContext || memberNames.Any(x => x == propertyPath || propertyPath.StartsWith(x + "."));
 		}
 
 		///<summary>

--- a/src/FluentValidation/ValidatorDescriptor.cs
+++ b/src/FluentValidation/ValidatorDescriptor.cs
@@ -37,7 +37,7 @@ namespace FluentValidation {
 		public virtual string GetName(string property) {
 			var nameUsed = Rules
 				.OfType<PropertyRule>()
-				.Where(x => x.Member.Name == property)
+				.Where(x => x.PropertyName == property)
 				.Select(x => x.GetDisplayName()).FirstOrDefault();
 
 			return nameUsed;
@@ -45,11 +45,11 @@ namespace FluentValidation {
 
 		public virtual ILookup<string, IPropertyValidator> GetMembersWithValidators() {
 			var query = from rule in Rules.OfType<PropertyRule>()
-						where rule.Member != null
+						where rule.PropertyName != null
 						from validator in rule.Validators
-						select new { memberName = rule.Member.Name, validator };
+						select new { propertyName = rule.PropertyName, validator };
 
-			return query.ToLookup(x => x.memberName, x => x.validator);
+			return query.ToLookup(x => x.propertyName, x => x.validator);
 		}
 
 		public IEnumerable<IPropertyValidator> GetValidatorsForMember(string name) {
@@ -58,7 +58,7 @@ namespace FluentValidation {
 
 		public IEnumerable<IValidationRule> GetRulesForMember(string name) {
 			var query = from rule in Rules.OfType<PropertyRule>()
-						where rule.Member.Name == name
+						where rule.PropertyName == name
 						select (IValidationRule)rule;
 
 			return query.ToList();


### PR DESCRIPTION
Two changes to allow chained property expressions to both validate and create a descriptor with the correct name.
