### PR TITLE
Allow nullable target properties for greater/less validators

### DIFF
--- a/src/FluentValidation.Tests/GreaterThanOrEqualToValidatorTester.cs
+++ b/src/FluentValidation.Tests/GreaterThanOrEqualToValidatorTester.cs
@@ -68,6 +68,36 @@ namespace FluentValidation.Tests {
 		}
 
 		[Test]
+		public void Validates_with_nullable_property() {
+			validator = new TestValidator(v => v.RuleFor(x => x.Id).GreaterThanOrEqualTo(x => x.NullableInt));
+
+			var resultNull = validator.Validate(new Person { Id = 0, NullableInt = null });
+			var resultLess = validator.Validate(new Person { Id = 0, NullableInt = -1 });
+			var resultEqual = validator.Validate(new Person { Id = 0, NullableInt = 0 });
+			var resultMore = validator.Validate(new Person { Id = 0, NullableInt = 1 });
+
+			resultNull.IsValid.ShouldBeFalse();
+			resultLess.IsValid.ShouldBeTrue();
+			resultEqual.IsValid.ShouldBeTrue();
+			resultMore.IsValid.ShouldBeFalse();
+		}
+
+		[Test]
+		public void Validates_nullable_with_nullable_property() {
+			validator = new TestValidator(v => v.RuleFor(x => x.NullableInt).GreaterThanOrEqualTo(x => x.OtherNullableInt));
+
+			var resultNull = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = null });
+			var resultLess = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = -1 });
+			var resultEqual = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = 0 });
+			var resultMore = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = 1 });
+
+			resultNull.IsValid.ShouldBeFalse();
+			resultLess.IsValid.ShouldBeTrue();
+			resultEqual.IsValid.ShouldBeTrue();
+			resultMore.IsValid.ShouldBeFalse();
+		}
+
+		[Test]
 		public void Comparison_type() {
 			var propertyValidator = validator.CreateDescriptor()
 				.GetValidatorsForMember("Id").Cast<GreaterThanOrEqualValidator>().Single();

--- a/src/FluentValidation.Tests/GreaterThanValidatorTester.cs
+++ b/src/FluentValidation.Tests/GreaterThanValidatorTester.cs
@@ -69,6 +69,36 @@ namespace FluentValidation.Tests {
 		}
 
 		[Test]
+		public void Validates_with_nullable_property() {
+			validator = new TestValidator(v => v.RuleFor(x => x.Id).GreaterThan(x => x.NullableInt));
+
+			var resultNull = validator.Validate(new Person { Id = 0, NullableInt = null });
+			var resultLess = validator.Validate(new Person { Id = 0, NullableInt = -1 });
+			var resultEqual = validator.Validate(new Person { Id = 0, NullableInt = 0 });
+			var resultMore = validator.Validate(new Person { Id = 0, NullableInt = 1 });
+
+			resultNull.IsValid.ShouldBeFalse();
+			resultLess.IsValid.ShouldBeTrue();
+			resultEqual.IsValid.ShouldBeFalse();
+			resultMore.IsValid.ShouldBeFalse();
+		}
+
+		[Test]
+		public void Validates_nullable_with_nullable_property() {
+			validator = new TestValidator(v => v.RuleFor(x => x.NullableInt).GreaterThan(x => x.OtherNullableInt));
+
+			var resultNull = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = null });
+			var resultLess = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = -1 });
+			var resultEqual = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = 0 });
+			var resultMore = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = 1 });
+
+			resultNull.IsValid.ShouldBeFalse();
+			resultLess.IsValid.ShouldBeTrue();
+			resultEqual.IsValid.ShouldBeFalse();
+			resultMore.IsValid.ShouldBeFalse();
+		}
+
+		[Test]
 		public void Comparison_Type() {
 			var propertyValidator = validator.CreateDescriptor()
 				.GetValidatorsForMember("Id").OfType<GreaterThanValidator>().Single();

--- a/src/FluentValidation.Tests/LessThanOrEqualToValidatorTester.cs
+++ b/src/FluentValidation.Tests/LessThanOrEqualToValidatorTester.cs
@@ -78,6 +78,36 @@ namespace FluentValidation.Tests {
 		}
 
 		[Test]
+		public void Validates_with_nullable_property() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.Id).LessThanOrEqualTo(x => x.NullableInt));
+
+			var resultNull = validator.Validate(new Person { Id = 0, NullableInt = null });
+			var resultLess = validator.Validate(new Person { Id = 0, NullableInt = -1 });
+			var resultEqual = validator.Validate(new Person { Id = 0, NullableInt = 0 });
+			var resultMore = validator.Validate(new Person { Id = 0, NullableInt = 1 });
+
+			resultNull.IsValid.ShouldBeFalse();
+			resultLess.IsValid.ShouldBeFalse();
+			resultEqual.IsValid.ShouldBeTrue();
+			resultMore.IsValid.ShouldBeTrue();
+		}
+
+		[Test]
+		public void Validates_nullable_with_nullable_property() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.NullableInt).LessThanOrEqualTo(x => x.OtherNullableInt));
+
+			var resultNull = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = null });
+			var resultLess = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = -1 });
+			var resultEqual = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = 0 });
+			var resultMore = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = 1 });
+
+			resultNull.IsValid.ShouldBeFalse();
+			resultLess.IsValid.ShouldBeFalse();
+			resultEqual.IsValid.ShouldBeTrue();
+			resultMore.IsValid.ShouldBeTrue();
+		}
+
+		[Test]
 		public void Validates_with_nullable_when_property_is_null() {
 			validator = new TestValidator(v => v.RuleFor(x => x.NullableInt).LessThanOrEqualTo(5));
 			var result = validator.Validate(new Person());

--- a/src/FluentValidation.Tests/LessThanValidatorTester.cs
+++ b/src/FluentValidation.Tests/LessThanValidatorTester.cs
@@ -73,8 +73,9 @@ namespace FluentValidation.Tests {
 
 		[Test]
 		public void Should_throw_when_value_to_compare_is_null() {
-			typeof(ArgumentNullException).ShouldBeThrownBy(() => 
-				new TestValidator(v => v.RuleFor(x => x.Id).LessThan(null))
+			Expression<Func<Person, int>> nullExpression = null;
+			typeof(ArgumentNullException).ShouldBeThrownBy(() =>
+				new TestValidator(v => v.RuleFor(x => x.Id).LessThan(nullExpression))
 			);
 		}
 
@@ -88,6 +89,36 @@ namespace FluentValidation.Tests {
 			var validator = new TestValidator(v => v.RuleFor(x => x.Id).LessThan(x => x.AnotherInt));
 			var propertyValidator = validator.CreateDescriptor().GetValidatorsForMember("Id").OfType<LessThanValidator>().Single();
 			propertyValidator.MemberToCompare.ShouldEqual(typeof(Person).GetProperty("AnotherInt"));
+		}
+
+		[Test]
+		public void Validates_with_nullable_property() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.Id).LessThan(x => x.NullableInt));
+
+			var resultNull = validator.Validate(new Person { Id = 0, NullableInt = null });
+			var resultLess = validator.Validate(new Person { Id = 0, NullableInt = -1 });
+			var resultEqual = validator.Validate(new Person { Id = 0, NullableInt = 0 });
+			var resultMore = validator.Validate(new Person { Id = 0, NullableInt = 1 });
+
+			resultNull.IsValid.ShouldBeFalse();
+			resultLess.IsValid.ShouldBeFalse();
+			resultEqual.IsValid.ShouldBeFalse();
+			resultMore.IsValid.ShouldBeTrue();
+		}
+
+		[Test]
+		public void Validates_nullable_with_nullable_property() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.NullableInt).LessThan(x => x.OtherNullableInt));
+
+			var resultNull = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = null });
+			var resultLess = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = -1 });
+			var resultEqual = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = 0 });
+			var resultMore = validator.Validate(new Person { NullableInt = 0, OtherNullableInt = 1 });
+
+			resultNull.IsValid.ShouldBeFalse();
+			resultLess.IsValid.ShouldBeFalse();
+			resultEqual.IsValid.ShouldBeFalse();
+			resultMore.IsValid.ShouldBeTrue();
 		}
 
 		[Test]

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -436,8 +436,48 @@ namespace FluentValidation {
 		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
 		/// <param name="expression">A lambda that should return the value being compared</param>
 		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> LessThan<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder,
+																			   Expression<Func<T, Nullable<TProperty>>> expression)
+			where TProperty : struct, IComparable<TProperty>, IComparable {
+			expression.Guard("Cannot pass null to LessThan");
+
+			var func = expression.Compile();
+
+			return ruleBuilder.SetValidator(new LessThanValidator(func.CoerceToNonGeneric(), expression.GetMember()));
+		}
+
+		/// <summary>
+		/// Defines a 'less than' validator on the current rule builder using a lambda expression. 
+		/// The validation will succeed if the property value is less than the specified value.
+		/// The validation will fail if the property value is greater than or equal to the specified value.
+		/// </summary>
+		/// <typeparam name="T">Type of object being validated</typeparam>
+		/// <typeparam name="TProperty">Type of property being validated</typeparam>
+		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+		/// <param name="expression">A lambda that should return the value being compared</param>
+		/// <returns></returns>
 		public static IRuleBuilderOptions<T, Nullable<TProperty>> LessThan<T, TProperty>(this IRuleBuilder<T, Nullable<TProperty>> ruleBuilder,
 		                                                                                 Expression<Func<T, TProperty>> expression)
+			where TProperty : struct, IComparable<TProperty>, IComparable {
+			expression.Guard("Cannot pass null to LessThan");
+
+			var func = expression.Compile();
+
+			return ruleBuilder.SetValidator(new LessThanValidator(func.CoerceToNonGeneric(), expression.GetMember()));
+		}
+
+		/// <summary>
+		/// Defines a 'less than' validator on the current rule builder using a lambda expression. 
+		/// The validation will succeed if the property value is less than the specified value.
+		/// The validation will fail if the property value is greater than or equal to the specified value.
+		/// </summary>
+		/// <typeparam name="T">Type of object being validated</typeparam>
+		/// <typeparam name="TProperty">Type of property being validated</typeparam>
+		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+		/// <param name="expression">A lambda that should return the value being compared</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, Nullable<TProperty>> LessThan<T, TProperty>(this IRuleBuilder<T, Nullable<TProperty>> ruleBuilder,
+																						 Expression<Func<T, Nullable<TProperty>>> expression)
 			where TProperty : struct, IComparable<TProperty>, IComparable {
 			expression.Guard("Cannot pass null to LessThan");
 
@@ -474,10 +514,27 @@ namespace FluentValidation {
 		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
 		/// <param name="expression">The value being compared</param>
 		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> LessThanOrEqualTo<T, TProperty>(
+			this IRuleBuilder<T, TProperty> ruleBuilder, Expression<Func<T, Nullable<TProperty>>> expression)
+			where TProperty : struct, IComparable<TProperty>, IComparable {
+			var func = expression.Compile();
+
+			return ruleBuilder.SetValidator(new LessThanOrEqualValidator(func.CoerceToNonGeneric(), expression.GetMember()));
+		}
+
+		/// <summary>
+		/// Defines a 'less than or equal' validator on the current rule builder using a lambda expression. 
+		/// The validation will succeed if the property value is less than or equal to the specified value.
+		/// The validation will fail if the property value is greater than the specified value.
+		/// </summary>
+		/// <typeparam name="T">Type of object being validated</typeparam>
+		/// <typeparam name="TProperty">Type of property being validated</typeparam>
+		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+		/// <param name="expression">The value being compared</param>
+		/// <returns></returns>
 		public static IRuleBuilderOptions<T, Nullable<TProperty>> LessThanOrEqualTo<T, TProperty>(
 			this IRuleBuilder<T, Nullable<TProperty>> ruleBuilder, Expression<Func<T, TProperty>> expression)
-			where TProperty : struct, IComparable<TProperty>, IComparable
-		{
+			where TProperty : struct, IComparable<TProperty>, IComparable {
 			var func = expression.Compile();
 
 			return ruleBuilder.SetValidator(new LessThanOrEqualValidator(func.CoerceToNonGeneric(), expression.GetMember()));
@@ -519,6 +576,23 @@ namespace FluentValidation {
 			return ruleBuilder.SetValidator(new GreaterThanValidator(func.CoerceToNonGeneric(), expression.GetMember()));
 		}
 
+		/// <summary>
+		/// Defines a 'less than' validator on the current rule builder using a lambda expression. 
+		/// The validation will succeed if the property value is greater than the specified value.
+		/// The validation will fail if the property value is less than or equal to the specified value.
+		/// </summary>
+		/// <typeparam name="T">Type of object being validated</typeparam>
+		/// <typeparam name="TProperty">Type of property being validated</typeparam>
+		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+		/// <param name="expression">The value being compared</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> GreaterThan<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder,
+																				  Expression<Func<T, Nullable<TProperty>>> expression)
+			where TProperty : struct, IComparable<TProperty>, IComparable {
+			var func = expression.Compile();
+
+			return ruleBuilder.SetValidator(new GreaterThanValidator(func.CoerceToNonGeneric(), expression.GetMember()));
+		}
 
 		/// <summary>
 		/// Defines a 'less than' validator on the current rule builder using a lambda expression. 
@@ -532,16 +606,32 @@ namespace FluentValidation {
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, Nullable<TProperty>> GreaterThan<T, TProperty>(this IRuleBuilder<T, Nullable<TProperty>> ruleBuilder,
 																				  Expression<Func<T, TProperty>> expression)
-			where TProperty : struct, IComparable<TProperty>, IComparable
-		{
+			where TProperty : struct, IComparable<TProperty>, IComparable {
 			var func = expression.Compile();
 
 			return ruleBuilder.SetValidator(new GreaterThanValidator(func.CoerceToNonGeneric(), expression.GetMember()));
 		}
 
-
 		/// <summary>
 		/// Defines a 'less than' validator on the current rule builder using a lambda expression. 
+		/// The validation will succeed if the property value is greater than the specified value.
+		/// The validation will fail if the property value is less than or equal to the specified value.
+		/// </summary>
+		/// <typeparam name="T">Type of object being validated</typeparam>
+		/// <typeparam name="TProperty">Type of property being validated</typeparam>
+		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+		/// <param name="expression">The value being compared</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, Nullable<TProperty>> GreaterThan<T, TProperty>(this IRuleBuilder<T, Nullable<TProperty>> ruleBuilder,
+																				  Expression<Func<T, Nullable<TProperty>>> expression)
+			where TProperty : struct, IComparable<TProperty>, IComparable {
+			var func = expression.Compile();
+
+			return ruleBuilder.SetValidator(new GreaterThanValidator(func.CoerceToNonGeneric(), expression.GetMember()));
+		}
+
+		/// <summary>
+		/// Defines a 'greater than' validator on the current rule builder using a lambda expression. 
 		/// The validation will succeed if the property value is greater than or equal the specified value.
 		/// The validation will fail if the property value is less than the specified value.
 		/// </summary>
@@ -553,6 +643,24 @@ namespace FluentValidation {
 		public static IRuleBuilderOptions<T, TProperty> GreaterThanOrEqualTo<T, TProperty>(
 			this IRuleBuilder<T, TProperty> ruleBuilder, Expression<Func<T, TProperty>> valueToCompare)
 			where TProperty : IComparable<TProperty>, IComparable {
+			var func = valueToCompare.Compile();
+
+			return ruleBuilder.SetValidator(new GreaterThanOrEqualValidator(func.CoerceToNonGeneric(), valueToCompare.GetMember()));
+		}
+
+		/// <summary>
+		/// Defines a 'greater than' validator on the current rule builder using a lambda expression. 
+		/// The validation will succeed if the property value is greater than or equal the specified value.
+		/// The validation will fail if the property value is less than the specified value.
+		/// </summary>
+		/// <typeparam name="T">Type of object being validated</typeparam>
+		/// <typeparam name="TProperty">Type of property being validated</typeparam>
+		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+		/// <param name="valueToCompare">The value being compared</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> GreaterThanOrEqualTo<T, TProperty>(
+			this IRuleBuilder<T, TProperty> ruleBuilder, Expression<Func<T, Nullable<TProperty>>> valueToCompare)
+			where TProperty : struct, IComparable<TProperty>, IComparable {
 			var func = valueToCompare.Compile();
 
 			return ruleBuilder.SetValidator(new GreaterThanOrEqualValidator(func.CoerceToNonGeneric(), valueToCompare.GetMember()));

--- a/src/FluentValidation/Validators/GreaterThanOrEqualValidator.cs
+++ b/src/FluentValidation/Validators/GreaterThanOrEqualValidator.cs
@@ -31,6 +31,9 @@ namespace FluentValidation.Validators {
 		}
 
 		public override bool IsValid(IComparable value, IComparable valueToCompare) {
+			if (valueToCompare == null)
+				return false;
+
 			return Comparer.GetComparisonResult(value, valueToCompare) >= 0;
 		}
 

--- a/src/FluentValidation/Validators/GreaterThanValidator.cs
+++ b/src/FluentValidation/Validators/GreaterThanValidator.cs
@@ -32,6 +32,9 @@ namespace FluentValidation.Validators {
 		}
 
 		public override bool IsValid(IComparable value, IComparable valueToCompare) {
+			if (valueToCompare == null)
+				return false;
+
 			return Comparer.GetComparisonResult(value, valueToCompare) > 0;
 		}
 

--- a/src/FluentValidation/Validators/LessThanOrEqualValidator.cs
+++ b/src/FluentValidation/Validators/LessThanOrEqualValidator.cs
@@ -33,6 +33,9 @@ namespace FluentValidation.Validators {
 		}
 
 		public override bool IsValid(IComparable value, IComparable valueToCompare) {
+			if (valueToCompare == null)
+				return false;
+
 			return Comparer.GetComparisonResult(value, valueToCompare) <= 0;
 		}
 

--- a/src/FluentValidation/Validators/LessThanValidator.cs
+++ b/src/FluentValidation/Validators/LessThanValidator.cs
@@ -33,6 +33,9 @@ namespace FluentValidation.Validators {
 		}
 
 		public override bool IsValid(IComparable value, IComparable valueToCompare) {
+			if (valueToCompare == null)
+				return false;
+
 			return Comparer.GetComparisonResult(value, valueToCompare) < 0;
 		}
 


### PR DESCRIPTION
This change allows us to target nullable properties for Greater / GreaterOrEqual / Less / LessOrEqual validations.
- if property being validated is null, validation succeeds (= unchanged behavior)
- if target property is null, validation fails - as null is neither greater/equal/less than concrete value
