### PR TITLE
Performance improvement with PropertyName.SplitPascalCase

### DIFF
--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -34,8 +34,9 @@ namespace FluentValidation.Internal {
 	public class PropertyRule : IValidationRule {
 		readonly List<IPropertyValidator> validators = new List<IPropertyValidator>();
 		Func<CascadeMode> cascadeModeThunk = () => ValidatorOptions.CascadeMode;
+	    readonly string propertyDisplayName;
 
-		/// <summary>
+	    /// <summary>
 		/// Property associated with this rule.
 		/// </summary>
 		public MemberInfo Member { get; private set; }
@@ -108,6 +109,7 @@ namespace FluentValidation.Internal {
 			this.cascadeModeThunk = cascadeModeThunk;
 
 			PropertyName = ValidatorOptions.PropertyNameResolver(containerType, member, expression);
+		    propertyDisplayName = PropertyName.SplitPascalCase();
 			DisplayName = new LazyStringSource(() => ValidatorOptions.DisplayNameResolver(containerType, member, expression));
 		}
 
@@ -192,7 +194,7 @@ namespace FluentValidation.Internal {
 			}
 
 			if (result == null) {
-				result = PropertyName.SplitPascalCase();				
+				result = propertyDisplayName;				
 			}
 
 			return result;


### PR DESCRIPTION
In PropertyRule, when DisplayName returns null, i.e. when DisplayAttributes are not used, then the PropertyName.SplitPascalCase method is called.  This method uses a Regex to add a space before every Capital Letter.  I'm using FluentValidation in a way where validation logic may be called over a million times.  By caching the property's display name in a local variable, additional calls to the Regex are avoided. This significantly improves performance across that many records.

Also, the DefaultNameResolver could benefit from a caching strategy as well.  By caching the memberInfo with the derived name, reflection over the display name attributes is only required once.   Since this is an extensibility point,  and the caching strategy can be plugged in, I'll include it in a separate pull request. 
