### PR TITLE
Allow Spaces in Credit Card Numbers

### DIFF
--- a/src/FluentValidation.Tests/CreditCardValidatorTests.cs
+++ b/src/FluentValidation.Tests/CreditCardValidatorTests.cs
@@ -24,6 +24,7 @@ namespace FluentValidation.Tests {
 			validator.Validate(new Person { CreditCard = "0000000000000000" }).IsValid.ShouldBeTrue(); // Simplest valid value
 			validator.Validate(new Person { CreditCard = "1234567890123452" }).IsValid.ShouldBeTrue(); // Good checksum
 			validator.Validate(new Person { CreditCard = "1234-5678-9012-3452" }).IsValid.ShouldBeTrue(); // Good checksum, with dashes
+			validator.Validate(new Person { CreditCard = "1234 5678 9012 3452" }).IsValid.ShouldBeTrue(); // Good checksum, with spaces
 			validator.Validate(new Person { CreditCard = "0000000000000001" }).IsValid.ShouldBeFalse(); // Bad checksum
 		}
 

--- a/src/FluentValidation/Validators/CreditCardValidator.cs
+++ b/src/FluentValidation/Validators/CreditCardValidator.cs
@@ -37,7 +37,7 @@ namespace FluentValidation.Validators {
 				return true;
 			}
 
-			value = value.Replace("-", "");
+			value = value.Replace("-", "").Replace(" ", "");
 
 			int checksum = 0;
 			bool evenDigit = false;


### PR DESCRIPTION
This provides consistency with the validation rule used by
jquery.validation:
https://github.com/jzaefferer/jquery-validation/blob/master/src/core.js#L1156
