### PR TITLE
WIP: Add option for SqlServerCompatible to ScalePrecisionValidator

### DIFF
--- a/src/FluentValidation.Tests/DefaultValidatorExtensionTester.cs
+++ b/src/FluentValidation.Tests/DefaultValidatorExtensionTester.cs
@@ -224,6 +224,12 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
+		public void ScalePrecision_should_create_ScalePrecisionValidator_with_sql_server_compatible() {
+			validator.RuleFor(x => x.Discount).ScalePrecision(2, 5, true, true);
+			AssertValidator<ScalePrecisionValidator>();
+		}
+
+		[Fact]
 		public void MustAsync_should_not_throw_InvalidCastException() {
 			var model = new Model
 			{

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1042,9 +1042,10 @@ namespace FluentValidation {
 		/// <param name="scale">Allowed scale of the value</param>
 		/// <param name="precision">Allowed precision of the value</param>
 		/// <param name="ignoreTrailingZeros">Whether the validator will ignore trailing zeros.</param>
+		/// <param name="sqlServerCompatible">Whether the validator will validate the digits to the left of the decimal are less than or equal to the precision - scale to match SQL Server decimal data type</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, TProperty> ScalePrecision<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, int scale, int precision, bool ignoreTrailingZeros = false) {
-			return ruleBuilder.SetValidator(new ScalePrecisionValidator(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
+		public static IRuleBuilderOptions<T, TProperty> ScalePrecision<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, int scale, int precision, bool ignoreTrailingZeros = false, bool sqlServerCompatible = false) {
+			return ruleBuilder.SetValidator(new ScalePrecisionValidator(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros, SqlServerCompatible = sqlServerCompatible});
 		}
 
 		/// <summary>


### PR DESCRIPTION
Closes #1008 

One thing that needs to be figured out is how to customize the validation error message to make it clear why it fails when using the SqlServerCompatible option.