### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -1,6 +1,6 @@
 # Asynchronous Validation
 
-In some situations, you may wish to define asynchronous rules, for example when working with an external API. By default, FluentValidation allows custom rules defined with `MustAsync` or `CustomAsync` to be run asyhchronously, as well as defining asychronous coniditions with `WhenAsync`. 
+In some situations, you may wish to define asynchronous rules, for example when working with an external API. By default, FluentValidation allows custom rules defined with `MustAsync` or `CustomAsync` to be run asynchronously, as well as defining asynchronous conditions with `WhenAsync`. 
 
 A simplistic solution that checks if a user ID is already in use using an external web API: 
 


### PR DESCRIPTION
This PR fixes some typos in the asynchronous validation docs.