### PR TITLE
Docs: Move Some Examples to Improve Flow

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -17,7 +17,8 @@ public class PersonValidator : AbstractValidator<Person> {
   }
 }
 ```
-The above rule will run a NotNull check against each item in the `AddressLines` collection. 
+
+The above rule will run a NotNull check against each item in the `AddressLines` collection.
 
 As of version 8.5, if you want to access the index of the collection element that caused the validation failure, you can use the special `{CollectionIndex}` placeholder:
 
@@ -28,38 +29,6 @@ public class PersonValidator : AbstractValidator<Person> {
   }
 }
 ```
-
-You can optionally include or exclude certain items in the collection from being validated by using the `Where` method. Note this must come directly after the call to `RuleForEach`:
-
-```csharp
-RuleForEach(x => x.Orders)
-  .Where(x => x.Cost != null)
-  .SetValidator(new OrderValidator());
-```
-
-As of version 8.2, an alternative to using `RuleForEach` is to call `ForEach` as part of a regular `RuleFor`. With this approach you can combine rules that act upon the entire collection with rules which act upon individual elements within the collection. For example, imagine you have the following 2 rules:
-
-```csharp
-// This rule acts on the whole collection (using RuleFor)
-RuleFor(x => x.Orders)
-  .Must(x => x.Orders.Count <= 10).WithMessage("No more than 10 orders are allowed");
-
-// This rule acts on each individual element (using RuleForEach)
-RuleForEach(x => x.Orders)
-  .Must(order => order.Total > 0).WithMessage("Orders must have a total of more than 0")
-```
-
-The above 2 rules could be re-written as:
-
-```csharp
-RuleFor(x => x.Orders)
-  .Must(x => x.Orders.Count <= 10).WithMessage("No more than 10 orders are allowed")
-  .ForEach(orderRule => {
-    orderRule.Must(order => order.Total > 0).WithMessage("Orders must have a total of more than 0")
-  });
-```
-
-I personally think that using 2 rules is clearer and easier to read, but the option of combining them is available with the `ForEach` method.
 
 ## Collections of Complex Types
 
@@ -100,3 +69,35 @@ public class CustomerValidator : AbstractValidator<Customer> {
   }
 }
 ```
+
+You can optionally include or exclude certain items in the collection from being validated by using the `Where` method. Note this must come directly after the call to `RuleForEach`:
+
+```csharp
+RuleForEach(x => x.Orders)
+  .Where(x => x.Cost != null)
+  .SetValidator(new OrderValidator());
+```
+
+As of version 8.2, an alternative to using `RuleForEach` is to call `ForEach` as part of a regular `RuleFor`. With this approach you can combine rules that act upon the entire collection with rules which act upon individual elements within the collection. For example, imagine you have the following 2 rules:
+
+```csharp
+// This rule acts on the whole collection (using RuleFor)
+RuleFor(x => x.Orders)
+  .Must(x => x.Orders.Count <= 10).WithMessage("No more than 10 orders are allowed");
+
+// This rule acts on each individual element (using RuleForEach)
+RuleForEach(x => x.Orders)
+  .Must(order => order.Total > 0).WithMessage("Orders must have a total of more than 0")
+```
+
+The above 2 rules could be re-written as:
+
+```csharp
+RuleFor(x => x.Orders)
+  .Must(x => x.Orders.Count <= 10).WithMessage("No more than 10 orders are allowed")
+  .ForEach(orderRule => {
+    orderRule.Must(order => order.Total > 0).WithMessage("Orders must have a total of more than 0")
+  });
+```
+
+I personally think that using 2 rules is clearer and easier to read, but the option of combining them is available with the `ForEach` method.


### PR DESCRIPTION
Reorder some of the examples in the Collections doc page.  There were a couple of code snippets that used classes defined later in the page, so I moved those examples below the class definition snippets.

This should close #1211 