### PR TITLE
Add ValidationContext to When predicate

### DIFF
--- a/src/FluentValidation.Tests/RuleBuilderTests.cs
+++ b/src/FluentValidation.Tests/RuleBuilderTests.cs
@@ -101,7 +101,12 @@ namespace FluentValidation.Tests {
 
 		[Fact]
 		public void Should_throw_when_predicate_is_null() {
-			typeof(ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator(new TestPropertyValidator()).When(null));
+			typeof(ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator(new TestPropertyValidator()).When((Func<Person, bool>)null));
+		}
+
+		[Fact]
+		public void Should_throw_when_context_predicate_is_null() {
+			typeof(ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator(new TestPropertyValidator()).When((Func<Person, ValidationContext<Person>, bool>)null));
 		}
 
 		[Fact]
@@ -110,8 +115,13 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
+		public void Should_throw_when_inverse_context_predicate_is_null() {
+			typeof(ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator(new TestPropertyValidator()).Unless((Func<Person, ValidationContext<Person>, bool>)null));
+		}
+
+		[Fact]
 		public void Should_throw_when_inverse_predicate_is_null() {
-			typeof(ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator(new TestPropertyValidator()).Unless(null));
+			typeof(ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator(new TestPropertyValidator()).Unless((Func<Person, bool>)null));
 		}
 
 		[Fact]

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -225,7 +225,7 @@ namespace FluentValidation {
 		/// <param name="action">Action that encapsulates the rules.</param>
 		/// <returns></returns>
 		public IConditionBuilder When(Func<T, bool> predicate, Action action) {
-			return new ConditionBuilder<T>(Rules).When(predicate, action);
+			return new ConditionBuilder<T>(Rules).When((x, ctx) => predicate(x), action);
 		}
 
     /// <summary>
@@ -234,7 +234,7 @@ namespace FluentValidation {
     /// <param name="predicate">The condition that should apply to multiple rules</param>
     /// <param name="action">Action that encapsulates the rules.</param>
     /// <returns></returns>
-    public IConditionBuilder When(Func<T, ValidationContext, bool> predicate, Action action) {
+    public IConditionBuilder When(Func<T, ValidationContext<T>, bool> predicate, Action action) {
       return new ConditionBuilder<T>(Rules).When(predicate, action);
     }
 
@@ -244,10 +244,10 @@ namespace FluentValidation {
     /// <param name="predicate">The condition that should be applied to multiple rules</param>
     /// <param name="action">Action that encapsulates the rules</param>
     public IConditionBuilder Unless(Func<T, bool> predicate, Action action) {
-			return new ConditionBuilder<T>(Rules).Unless(predicate, action);
+			return new ConditionBuilder<T>(Rules).Unless((x, ctx) => predicate(x), action);
 		}
 
-    public IConditionBuilder Unless(Func<T, ValidationContext, bool> predicate, Action action) {
+    public IConditionBuilder Unless(Func<T, ValidationContext<T>, bool> predicate, Action action) {
       return new ConditionBuilder<T>(Rules).Unless(predicate, action);
     }
 
@@ -258,10 +258,10 @@ namespace FluentValidation {
     /// <param name="action">Action that encapsulates the rules.</param>
     /// <returns></returns>
     public IConditionBuilder WhenAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
-			return new AsyncConditionBuilder<T>(Rules).WhenAsync(predicate, action);
+			return new AsyncConditionBuilder<T>(Rules).WhenAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
-    public IConditionBuilder WhenAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
+    public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
       return new AsyncConditionBuilder<T>(Rules).WhenAsync(predicate, action);
     }
 
@@ -271,7 +271,7 @@ namespace FluentValidation {
     /// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
     /// <param name="action">Action that encapsulates the rules</param>
     public IConditionBuilder UnlessAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
-			return new AsyncConditionBuilder<T>(Rules).UnlessAsync(predicate, action);
+			return new AsyncConditionBuilder<T>(Rules).UnlessAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
     public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -228,76 +228,76 @@ namespace FluentValidation {
 			return new ConditionBuilder<T>(Rules).When((x, ctx) => predicate(x), action);
 		}
 
-    /// <summary>
-    /// Defines a condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The condition that should apply to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules.</param>
-    /// <returns></returns>
-    public IConditionBuilder When(Func<T, ValidationContext<T>, bool> predicate, Action action) {
-      return new ConditionBuilder<T>(Rules).When(predicate, action);
-    }
+		/// <summary>
+		/// Defines a condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The condition that should apply to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules.</param>
+		/// <returns></returns>
+		public IConditionBuilder When(Func<T, ValidationContext<T>, bool> predicate, Action action) {
+			return new ConditionBuilder<T>(Rules).When(predicate, action);
+		}
 
-    /// <summary>
-    /// Defines an inverse condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The condition that should be applied to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules</param>
-    public IConditionBuilder Unless(Func<T, bool> predicate, Action action) {
+		/// <summary>
+		/// Defines an inverse condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The condition that should be applied to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules</param>
+		public IConditionBuilder Unless(Func<T, bool> predicate, Action action) {
 			return new ConditionBuilder<T>(Rules).Unless((x, ctx) => predicate(x), action);
 		}
 
-    /// <summary>
-    /// Defines an inverse condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The condition that should be applied to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules</param>
-    public IConditionBuilder Unless(Func<T, ValidationContext<T>, bool> predicate, Action action) {
-      return new ConditionBuilder<T>(Rules).Unless(predicate, action);
-    }
+		/// <summary>
+		/// Defines an inverse condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The condition that should be applied to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules</param>
+		public IConditionBuilder Unless(Func<T, ValidationContext<T>, bool> predicate, Action action) {
+			return new ConditionBuilder<T>(Rules).Unless(predicate, action);
+		}
 
-    /// <summary>
-    /// Defines an asynchronous condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules.</param>
-    /// <returns></returns>
-    public IConditionBuilder WhenAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
+		/// <summary>
+		/// Defines an asynchronous condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules.</param>
+		/// <returns></returns>
+		public IConditionBuilder WhenAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
 			return new AsyncConditionBuilder<T>(Rules).WhenAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
-    /// <summary>
-    /// Defines an asynchronous condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules.</param>
-    /// <returns></returns>
-    public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
-      return new AsyncConditionBuilder<T>(Rules).WhenAsync(predicate, action);
-    }
+		/// <summary>
+		/// Defines an asynchronous condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules.</param>
+		/// <returns></returns>
+		public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
+			return new AsyncConditionBuilder<T>(Rules).WhenAsync(predicate, action);
+		}
 
-    /// <summary>
-    /// Defines an inverse asynchronous condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules</param>
-    public IConditionBuilder UnlessAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
+		/// <summary>
+		/// Defines an inverse asynchronous condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules</param>
+		public IConditionBuilder UnlessAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
 			return new AsyncConditionBuilder<T>(Rules).UnlessAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
-    /// <summary>
-    /// Defines an inverse asynchronous condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules</param>
-    public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
-      return new AsyncConditionBuilder<T>(Rules).UnlessAsync(predicate, action);
-    }
+		/// <summary>
+		/// Defines an inverse asynchronous condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules</param>
+		public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
+			return new AsyncConditionBuilder<T>(Rules).UnlessAsync(predicate, action);
+		}
 
-    /// <summary>
-    /// Includes the rules from the specified validator
-    /// </summary>
-    public void Include(IValidator<T> rulesToInclude) {
+		/// <summary>
+		/// Includes the rules from the specified validator
+		/// </summary>
+		public void Include(IValidator<T> rulesToInclude) {
 			rulesToInclude.Guard("Cannot pass null to Include", nameof(rulesToInclude));
 			var rule = IncludeRule.Create<T>(rulesToInclude, () => CascadeMode);
 			AddRule(rule);

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -228,38 +228,60 @@ namespace FluentValidation {
 			return new ConditionBuilder<T>(Rules).When(predicate, action);
 		}
 
-		/// <summary>
-		/// Defines an inverse condition that applies to several rules
-		/// </summary>
-		/// <param name="predicate">The condition that should be applied to multiple rules</param>
-		/// <param name="action">Action that encapsulates the rules</param>
-		public IConditionBuilder Unless(Func<T, bool> predicate, Action action) {
+    /// <summary>
+    /// Defines a condition that applies to several rules
+    /// </summary>
+    /// <param name="predicate">The condition that should apply to multiple rules</param>
+    /// <param name="action">Action that encapsulates the rules.</param>
+    /// <returns></returns>
+    public IConditionBuilder When(Func<T, ValidationContext, bool> predicate, Action action) {
+      return new ConditionBuilder<T>(Rules).When(predicate, action);
+    }
+
+    /// <summary>
+    /// Defines an inverse condition that applies to several rules
+    /// </summary>
+    /// <param name="predicate">The condition that should be applied to multiple rules</param>
+    /// <param name="action">Action that encapsulates the rules</param>
+    public IConditionBuilder Unless(Func<T, bool> predicate, Action action) {
 			return new ConditionBuilder<T>(Rules).Unless(predicate, action);
 		}
 
-		/// <summary>
-		/// Defines an asynchronous condition that applies to several rules
-		/// </summary>
-		/// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
-		/// <param name="action">Action that encapsulates the rules.</param>
-		/// <returns></returns>
-		public IConditionBuilder WhenAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
+    public IConditionBuilder Unless(Func<T, ValidationContext, bool> predicate, Action action) {
+      return new ConditionBuilder<T>(Rules).Unless(predicate, action);
+    }
+
+    /// <summary>
+    /// Defines an asynchronous condition that applies to several rules
+    /// </summary>
+    /// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
+    /// <param name="action">Action that encapsulates the rules.</param>
+    /// <returns></returns>
+    public IConditionBuilder WhenAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
 			return new AsyncConditionBuilder<T>(Rules).WhenAsync(predicate, action);
 		}
 
-		/// <summary>
-		/// Defines an inverse asynchronous condition that applies to several rules
-		/// </summary>
-		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
-		/// <param name="action">Action that encapsulates the rules</param>
-		public IConditionBuilder UnlessAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
+    public IConditionBuilder WhenAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
+      return new AsyncConditionBuilder<T>(Rules).WhenAsync(predicate, action);
+    }
+
+    /// <summary>
+    /// Defines an inverse asynchronous condition that applies to several rules
+    /// </summary>
+    /// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
+    /// <param name="action">Action that encapsulates the rules</param>
+    public IConditionBuilder UnlessAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
 			return new AsyncConditionBuilder<T>(Rules).UnlessAsync(predicate, action);
 		}
 
-		/// <summary>
-		/// Includes the rules from the specified validator
-		/// </summary>
-		public void Include(IValidator<T> rulesToInclude) {
+    public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
+      return new AsyncConditionBuilder<T>(Rules).UnlessAsync(predicate, action);
+    }
+
+    /// <summary>
+    /// Includes the rules from the specified validator
+    /// </summary>
+    public void Include(IValidator<T> rulesToInclude) {
 			rulesToInclude.Guard("Cannot pass null to Include", nameof(rulesToInclude));
 			var rule = IncludeRule.Create<T>(rulesToInclude, () => CascadeMode);
 			AddRule(rule);

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -225,7 +225,7 @@ namespace FluentValidation {
 		/// <param name="action">Action that encapsulates the rules.</param>
 		/// <returns></returns>
 		public IConditionBuilder When(Func<T, bool> predicate, Action action) {
-			return new ConditionBuilder<T>(Rules).When((x, ctx) => predicate(x), action);
+			return When((x, ctx) => predicate(x), action);
 		}
 
 		/// <summary>
@@ -244,7 +244,7 @@ namespace FluentValidation {
 		/// <param name="predicate">The condition that should be applied to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules</param>
 		public IConditionBuilder Unless(Func<T, bool> predicate, Action action) {
-			return new ConditionBuilder<T>(Rules).Unless((x, ctx) => predicate(x), action);
+			return Unless((x, ctx) => predicate(x), action);
 		}
 
 		/// <summary>
@@ -263,7 +263,7 @@ namespace FluentValidation {
 		/// <param name="action">Action that encapsulates the rules.</param>
 		/// <returns></returns>
 		public IConditionBuilder WhenAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
-			return new AsyncConditionBuilder<T>(Rules).WhenAsync((x, ctx, cancel) => predicate(x, cancel), action);
+			return WhenAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
 		/// <summary>
@@ -282,7 +282,7 @@ namespace FluentValidation {
 		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules</param>
 		public IConditionBuilder UnlessAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
-			return new AsyncConditionBuilder<T>(Rules).UnlessAsync((x, ctx, cancel) => predicate(x, cancel), action);
+			return UnlessAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
 		/// <summary>
@@ -290,7 +290,7 @@ namespace FluentValidation {
 		/// </summary>
 		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules</param>
-		public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
+		public IConditionBuilder UnlessAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
 			return new AsyncConditionBuilder<T>(Rules).UnlessAsync(predicate, action);
 		}
 

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -247,6 +247,11 @@ namespace FluentValidation {
 			return new ConditionBuilder<T>(Rules).Unless((x, ctx) => predicate(x), action);
 		}
 
+    /// <summary>
+    /// Defines an inverse condition that applies to several rules
+    /// </summary>
+    /// <param name="predicate">The condition that should be applied to multiple rules</param>
+    /// <param name="action">Action that encapsulates the rules</param>
     public IConditionBuilder Unless(Func<T, ValidationContext<T>, bool> predicate, Action action) {
       return new ConditionBuilder<T>(Rules).Unless(predicate, action);
     }
@@ -261,6 +266,12 @@ namespace FluentValidation {
 			return new AsyncConditionBuilder<T>(Rules).WhenAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
+    /// <summary>
+    /// Defines an asynchronous condition that applies to several rules
+    /// </summary>
+    /// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
+    /// <param name="action">Action that encapsulates the rules.</param>
+    /// <returns></returns>
     public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
       return new AsyncConditionBuilder<T>(Rules).WhenAsync(predicate, action);
     }
@@ -274,6 +285,11 @@ namespace FluentValidation {
 			return new AsyncConditionBuilder<T>(Rules).UnlessAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
+    /// <summary>
+    /// Defines an inverse asynchronous condition that applies to several rules
+    /// </summary>
+    /// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
+    /// <param name="action">Action that encapsulates the rules</param>
     public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
       return new AsyncConditionBuilder<T>(Rules).UnlessAsync(predicate, action);
     }

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -165,7 +165,7 @@ namespace FluentValidation {
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> When<T,TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling When.", nameof(predicate));
-			return rule.When((x, ctx) => predicate(x));
+			return rule.When((x, ctx) => predicate(x), applyConditionTo);
 		}
 
 		/// <summary>

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -165,9 +165,22 @@ namespace FluentValidation {
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> When<T,TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling When.", nameof(predicate));
+			return rule.When((x, ctx) => predicate(x));
+		}
+
+		/// <summary>
+		/// Specifies a condition limiting when the validator should run.
+		/// The validator will only be executed if the result of the lambda returns true.
+		/// </summary>
+		/// <param name="rule">The current rule</param>
+		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should run</param>
+		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> When<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+			predicate.Guard("A predicate must be specified when calling When.", nameof(predicate));
 			// Default behaviour for When/Unless as of v1.3 is to apply the condition to all previous validators in the chain.
 			return rule.Configure(config => {
-				config.ApplyCondition(ctx => predicate((T)ctx.InstanceToValidate), applyConditionTo);
+				config.ApplyCondition(ctx => predicate((T)ctx.InstanceToValidate, (ValidationContext<T>)ctx.ParentContext), applyConditionTo);
 			});
 		}
 
@@ -181,7 +194,20 @@ namespace FluentValidation {
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> Unless<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling Unless", nameof(predicate));
-			return rule.When(x => !predicate(x), applyConditionTo);
+			return rule.Unless((x, ctx) => predicate(x), applyConditionTo);
+		}
+
+		/// <summary>
+		/// Specifies a condition limiting when the validator should not run.
+		/// The validator will only be executed if the result of the lambda returns false.
+		/// </summary>
+		/// <param name="rule">The current rule</param>
+		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should not run</param>
+		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> Unless<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+			predicate.Guard("A predicate must be specified when calling Unless", nameof(predicate));
+			return rule.When((x, ctx) => !predicate(x, ctx), applyConditionTo);
 		}
 
 		/// <summary>
@@ -194,9 +220,22 @@ namespace FluentValidation {
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
+			return rule.WhenAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
+		}
+
+		/// <summary>
+		/// Specifies an asynchronous condition limiting when the validator should run.
+		/// The validator will only be executed if the result of the lambda returns true.
+		/// </summary>
+		/// <param name="rule">The current rule</param>
+		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should run</param>
+		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+			predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
 			// Default behaviour for When/Unless as of v1.3 is to apply the condition to all previous validators in the chain.
 			return rule.Configure(config => {
-				config.ApplyAsyncCondition((ctx, ct) => predicate((T)ctx.InstanceToValidate, ct), applyConditionTo);
+				config.ApplyAsyncCondition((ctx, ct) => predicate((T)ctx.InstanceToValidate, (ValidationContext<T>)ctx.ParentContext, ct), applyConditionTo);
 			});
 		}
 
@@ -210,7 +249,20 @@ namespace FluentValidation {
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
-			return rule.WhenAsync(async (x, ct) => !await predicate(x, ct), applyConditionTo);
+			return rule.UnlessAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
+		}
+
+		/// <summary>
+		/// Specifies an asynchronous condition limiting when the validator should not run.
+		/// The validator will only be executed if the result of the lambda returns false.
+		/// </summary>
+		/// <param name="rule">The current rule</param>
+		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should not run</param>
+		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+			predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
+			return rule.WhenAsync(async (x, ctx, ct) => !await predicate(x, ctx, ct), applyConditionTo);
 		}
 
 		/// <summary>

--- a/src/FluentValidation/Internal/ConditionBuilder.cs
+++ b/src/FluentValidation/Internal/ConditionBuilder.cs
@@ -74,15 +74,57 @@ namespace FluentValidation.Internal {
 			return new ConditionOtherwiseBuilder(_rules, Condition);
 		}
 
-		/// <summary>
-		/// Defines an inverse condition that applies to several rules
-		/// </summary>
-		/// <param name="predicate">The condition that should be applied to multiple rules</param>
-		/// <param name="action">Action that encapsulates the rules</param>
-		public IConditionBuilder Unless(Func<T, bool> predicate, Action action) {
+    public IConditionBuilder When(Func<T, ValidationContext, bool> predicate, Action action) {
+      var propertyRules = new List<IValidationRule>();
+
+      using (_rules.OnItemAdded(propertyRules.Add)) {
+        action();
+      }
+
+      // Generate unique ID for this shared condition.
+      var id = "_FV_Condition_" + Guid.NewGuid();
+
+      bool Condition(ValidationContext context) {
+        string cacheId = null;
+
+        if (context.InstanceToValidate != null) {
+          cacheId = id + context.InstanceToValidate.GetHashCode();
+
+          if (context.RootContextData.TryGetValue(cacheId, out var value)) {
+            if (value is bool result) {
+              return result;
+            }
+          }
+        }
+
+        var executionResult = predicate((T)context.InstanceToValidate, context);
+        if (context.InstanceToValidate != null) {
+          context.RootContextData[cacheId] = executionResult;
+        }
+        return executionResult;
+      }
+
+      // Must apply the predicate after the rule has been fully created to ensure any rules-specific conditions have already been applied.
+      foreach (var rule in propertyRules) {
+        rule.ApplySharedCondition(Condition);
+      }
+
+      return new ConditionOtherwiseBuilder(_rules, Condition);
+    }
+
+    /// <summary>
+    /// Defines an inverse condition that applies to several rules
+    /// </summary>
+    /// <param name="predicate">The condition that should be applied to multiple rules</param>
+    /// <param name="action">Action that encapsulates the rules</param>
+    public IConditionBuilder Unless(Func<T, bool> predicate, Action action) {
 			return When(x => !predicate(x), action);
 		}
-	}
+
+    public IConditionBuilder Unless(Func<T, ValidationContext, bool> predicate, Action action) {
+      return When((x, context) => !predicate(x, context), action);
+    }
+  }
 
 	internal class AsyncConditionBuilder<T> {
 		private TrackingCollection<IValidationRule> _rules;
@@ -133,15 +175,55 @@ namespace FluentValidation.Internal {
 			return new AsyncConditionOtherwiseBuilder(_rules, Condition);
 		}
 
-		/// <summary>
-		/// Defines an inverse asynchronous condition that applies to several rules
-		/// </summary>
-		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
-		/// <param name="action">Action that encapsulates the rules</param>
-		public IConditionBuilder UnlessAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
+    public IConditionBuilder WhenAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
+      var propertyRules = new List<IValidationRule>();
+
+      using (_rules.OnItemAdded(propertyRules.Add)) {
+        action();
+      }
+
+      // Generate unique ID for this shared condition.
+      var id = "_FV_AsyncCondition_" + Guid.NewGuid();
+
+      async Task<bool> Condition(ValidationContext context, CancellationToken ct) {
+        string cacheId = null;
+        if (context.InstanceToValidate != null) {
+          cacheId = id + context.InstanceToValidate.GetHashCode();
+
+          if (context.RootContextData.TryGetValue(cacheId, out var value)) {
+            if (value is bool result) {
+              return result;
+            }
+          }
+        }
+
+        var executionResult = await predicate((T)context.InstanceToValidate, context, ct);
+        if (context.InstanceToValidate != null) {
+          context.RootContextData[cacheId] = executionResult;
+        }
+        return executionResult;
+      }
+
+      foreach (var rule in propertyRules) {
+        rule.ApplySharedAsyncCondition(Condition);
+      }
+
+      return new AsyncConditionOtherwiseBuilder(_rules, Condition);
+    }
+
+    /// <summary>
+    /// Defines an inverse asynchronous condition that applies to several rules
+    /// </summary>
+    /// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
+    /// <param name="action">Action that encapsulates the rules</param>
+    public IConditionBuilder UnlessAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
 			return WhenAsync(async (x, ct) => !await predicate(x, ct), action);
 		}
-	}
+
+    public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
+      return WhenAsync(async (x, context, ct) => !await predicate(x, context, ct), action);
+    }
+  }
 
 	internal class ConditionOtherwiseBuilder : IConditionBuilder {
 		private TrackingCollection<IValidationRule> _rules;

--- a/src/FluentValidation/Internal/ConditionBuilder.cs
+++ b/src/FluentValidation/Internal/ConditionBuilder.cs
@@ -30,59 +30,59 @@ namespace FluentValidation.Internal {
 			_rules = rules;
 		}
 
-    /// <summary>
-    /// Defines a condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The condition that should apply to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules.</param>
-    /// <returns></returns>
-    public IConditionBuilder When(Func<T, ValidationContext<T>, bool> predicate, Action action) {
-      var propertyRules = new List<IValidationRule>();
+		/// <summary>
+		/// Defines a condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The condition that should apply to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules.</param>
+		/// <returns></returns>
+		public IConditionBuilder When(Func<T, ValidationContext<T>, bool> predicate, Action action) {
+			var propertyRules = new List<IValidationRule>();
 
-      using (_rules.OnItemAdded(propertyRules.Add)) {
-        action();
-      }
+			using (_rules.OnItemAdded(propertyRules.Add)) {
+				action();
+			}
 
-      // Generate unique ID for this shared condition.
-      var id = "_FV_Condition_" + Guid.NewGuid();
+			// Generate unique ID for this shared condition.
+			var id = "_FV_Condition_" + Guid.NewGuid();
 
-      bool Condition(ValidationContext context) {
-        string cacheId = null;
+			bool Condition(ValidationContext context) {
+				string cacheId = null;
 
-        if (context.InstanceToValidate != null) {
-          cacheId = id + context.InstanceToValidate.GetHashCode();
+				if (context.InstanceToValidate != null) {
+					cacheId = id + context.InstanceToValidate.GetHashCode();
 
-          if (context.RootContextData.TryGetValue(cacheId, out var value)) {
-            if (value is bool result) {
-              return result;
-            }
-          }
-        }
+					if (context.RootContextData.TryGetValue(cacheId, out var value)) {
+						if (value is bool result) {
+							return result;
+						}
+					}
+				}
 
-        var executionResult = predicate((T)context.InstanceToValidate, context.ToGeneric<T>());
-        if (context.InstanceToValidate != null) {
-          context.RootContextData[cacheId] = executionResult;
-        }
-        return executionResult;
-      }
+				var executionResult = predicate((T)context.InstanceToValidate, (ValidationContext<T>)context);
+				if (context.InstanceToValidate != null) {
+					context.RootContextData[cacheId] = executionResult;
+				}
+				return executionResult;
+			}
 
-      // Must apply the predicate after the rule has been fully created to ensure any rules-specific conditions have already been applied.
-      foreach (var rule in propertyRules) {
-        rule.ApplySharedCondition(Condition);
-      }
+			// Must apply the predicate after the rule has been fully created to ensure any rules-specific conditions have already been applied.
+			foreach (var rule in propertyRules) {
+				rule.ApplySharedCondition(Condition);
+			}
 
-      return new ConditionOtherwiseBuilder(_rules, Condition);
-    }
+			return new ConditionOtherwiseBuilder(_rules, Condition);
+		}
 
-    /// <summary>
-    /// Defines an inverse condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The condition that should be applied to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules</param>
-    public IConditionBuilder Unless(Func<T, ValidationContext<T>, bool> predicate, Action action) {
-      return When((x, context) => !predicate(x, context), action);
-    }
-  }
+		/// <summary>
+		/// Defines an inverse condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The condition that should be applied to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules</param>
+		public IConditionBuilder Unless(Func<T, ValidationContext<T>, bool> predicate, Action action) {
+			return When((x, context) => !predicate(x, context), action);
+		}
+	}
 
 	internal class AsyncConditionBuilder<T> {
 		private TrackingCollection<IValidationRule> _rules;
@@ -97,51 +97,51 @@ namespace FluentValidation.Internal {
 		/// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules.</param>
 		/// <returns></returns>
-    public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
-      var propertyRules = new List<IValidationRule>();
+		public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
+			var propertyRules = new List<IValidationRule>();
 
-      using (_rules.OnItemAdded(propertyRules.Add)) {
-        action();
-      }
+			using (_rules.OnItemAdded(propertyRules.Add)) {
+				action();
+			}
 
-      // Generate unique ID for this shared condition.
-      var id = "_FV_AsyncCondition_" + Guid.NewGuid();
+			// Generate unique ID for this shared condition.
+			var id = "_FV_AsyncCondition_" + Guid.NewGuid();
 
-      async Task<bool> Condition(ValidationContext context, CancellationToken ct) {
-        string cacheId = null;
-        if (context.InstanceToValidate != null) {
-          cacheId = id + context.InstanceToValidate.GetHashCode();
+			async Task<bool> Condition(ValidationContext context, CancellationToken ct) {
+				string cacheId = null;
+				if (context.InstanceToValidate != null) {
+					cacheId = id + context.InstanceToValidate.GetHashCode();
 
-          if (context.RootContextData.TryGetValue(cacheId, out var value)) {
-            if (value is bool result) {
-              return result;
-            }
-          }
-        }
+					if (context.RootContextData.TryGetValue(cacheId, out var value)) {
+						if (value is bool result) {
+							return result;
+						}
+					}
+				}
 
-        var executionResult = await predicate((T)context.InstanceToValidate, context.ToGeneric<T>(), ct);
-        if (context.InstanceToValidate != null) {
-          context.RootContextData[cacheId] = executionResult;
-        }
-        return executionResult;
-      }
+				var executionResult = await predicate((T)context.InstanceToValidate, (ValidationContext<T>)context, ct);
+				if (context.InstanceToValidate != null) {
+					context.RootContextData[cacheId] = executionResult;
+				}
+				return executionResult;
+			}
 
-      foreach (var rule in propertyRules) {
-        rule.ApplySharedAsyncCondition(Condition);
-      }
+			foreach (var rule in propertyRules) {
+				rule.ApplySharedAsyncCondition(Condition);
+			}
 
-      return new AsyncConditionOtherwiseBuilder(_rules, Condition);
-    }
+			return new AsyncConditionOtherwiseBuilder(_rules, Condition);
+		}
 
-    /// <summary>
-    /// Defines an inverse asynchronous condition that applies to several rules
-    /// </summary>
-    /// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
-    /// <param name="action">Action that encapsulates the rules</param>
-    public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
-      return WhenAsync(async (x, context, ct) => !await predicate(x, context, ct), action);
-    }
-  }
+		/// <summary>
+		/// Defines an inverse asynchronous condition that applies to several rules
+		/// </summary>
+		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
+		/// <param name="action">Action that encapsulates the rules</param>
+		public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
+			return WhenAsync(async (x, context, ct) => !await predicate(x, context, ct), action);
+		}
+	}
 
 	internal class ConditionOtherwiseBuilder : IConditionBuilder {
 		private TrackingCollection<IValidationRule> _rules;

--- a/src/FluentValidation/Internal/ConditionBuilder.cs
+++ b/src/FluentValidation/Internal/ConditionBuilder.cs
@@ -138,7 +138,7 @@ namespace FluentValidation.Internal {
 		/// </summary>
 		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules</param>
-		public IConditionBuilder UnlessAsync(Func<T, ValidationContext, CancellationToken, Task<bool>> predicate, Action action) {
+		public IConditionBuilder UnlessAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
 			return WhenAsync(async (x, context, ct) => !await predicate(x, context, ct), action);
 		}
 	}


### PR DESCRIPTION
My company is using FluentValidation to validate timesheet data, but the current methods are limiting us. We are populating the `RootContextData` with relevant information, but we cannot access it from within the `When` and `WhenAsync` methods.

We would like to do something like this:
```
When(
  (timesheetDetailEntry, context) => {
    // use context info to decide if a set of rules should run. example:
    var formType = (FormType)context.ParentContext.RootContextData[TimesheetContextKeys.FormType];
    return formType == "target form type";
  },
  () => {
    // set of rules to run
  }
);

RuleFor(timesheet => timesheet.Property)
  .NotNull()
  .WhenAsync(async (property, context, cancel) => {
    // use context info to decide if rule should run. example:
    var timesheet = (Timesheet)context.ParentContext.RootContextData[TimesheetContextKeys.Timesheet];
    var user = await UserClient.GetUserAsync(timesheet.userId);
    return user.Type == "target user type";
  });
```