### PR TITLE
Fix tests

### DIFF
--- a/src/FluentValidation.Tests/LanguageManagerTests.cs
+++ b/src/FluentValidation.Tests/LanguageManagerTests.cs
@@ -182,7 +182,7 @@
 		public void Falls_back_to_default_localization_key_when_error_code_key_not_found() {
 			var originalLanguageManager = ValidatorOptions.LanguageManager;
 			ValidatorOptions.LanguageManager = new CustomLanguageManager();
-
+			ValidatorOptions.LanguageManager.Culture = new CultureInfo("en-US");
 			var validator = new InlineValidator<Person>();
 			validator.RuleFor(x => x.Forename).NotNull().WithErrorCode("DoesNotExist");
 			var result = validator.Validate(new Person());

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -35,6 +35,7 @@ namespace FluentValidation.Tests {
 			validator.RuleFor(x => x.CreditCard).Must(creditCard => !string.IsNullOrEmpty(creditCard)).WhenAsync((x, cancel) => Task.Run(() => { return x.Age >= 18; }));
 			validator.RuleFor(x => x.Forename).NotNull();
 			validator.RuleForEach(person => person.NickNames).MinimumLength(5);
+			CultureScope.SetDefaultCulture();
 		}
 
 		[Fact]


### PR DESCRIPTION
Two tests fail if the system culture is not en-US

ShouldNotHaveValidationError_should_have_validation_error_details_when_thrown_ruleforeach
Falls_back_to_default_localization_key_when_error_code_key_not_found