### PR TITLE
add rollforward to SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
     "sdk": {
-      "version": "3.1.201"
+      "version": "3.1.201",
+      "rollForward": "latestPatch"
     },
     "others": ["2.2.105"]
 }


### PR DESCRIPTION
the rollforward makes life easier for opening the project in VS and with limiting it to latestpatch it should not create any unexpected side effects