### PR TITLE
global.json: latestPatch --> latestFeature

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "sdk": {
       "version": "3.1.201",
-      "rollForward": "latestPatch"
+      "rollForward": "latestFeature"
     },
     "others": ["2.2.105"]
 }


### PR DESCRIPTION
Hey! I attempted to open the solution in VS and hit a small snag so figured I'd offer a PR in case you're open to it.

global.json currently defines:

```json
{
    "sdk": {
      "version": "3.1.201",
      "rollForward": "latestPatch"
    },
    "others": ["2.2.105"]
}
```

However, I have `3.1.300`. In this scenario, I think we still want me to be able to open the solution.

Changing from `latestPatch` to `latestFeature` [appears to allow this](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x#rollforward). 

If that's not in line with what you want, feel free to close. 👍 