### PR TITLE
Inconsistency with splitting ruleset

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,6 @@
+9.1 - 
+Make ruleset separator character splitting consistent (#1424)
+
 9.0 - 6 July 2020
 Removed support for netstandard1.1, netstandard1.6 and net45 (net461 still supported)
 Removed support for unsupported .NET Core versions (2.2 and 3.0). LTS versions are supported (2.1 and 3.1)

--- a/src/FluentValidation.AspNetCore/CustomizeValidatorAttribute.cs
+++ b/src/FluentValidation.AspNetCore/CustomizeValidatorAttribute.cs
@@ -63,7 +63,9 @@ namespace FluentValidation.AspNetCore {
 				selector = CreateRulesetValidatorSelector(mvContext, rulesets);
 			}
 			else if (!string.IsNullOrEmpty(Properties)) {
-				var properties = Properties.Split(',', ';');
+				var properties = Properties.Split(',', ';')
+					.Select(x => x.Trim())
+					.ToArray();
 				selector = CreateMemberNameValidatorSelector(mvContext, properties);
 			}
 			else {

--- a/src/FluentValidation.AspNetCore/CustomizeValidatorAttribute.cs
+++ b/src/FluentValidation.AspNetCore/CustomizeValidatorAttribute.cs
@@ -22,6 +22,7 @@ namespace FluentValidation.AspNetCore {
 	using System.Reflection;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 	using Microsoft.Extensions.DependencyInjection;
+	using System.Linq;
 
 	[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
 	public class CustomizeValidatorAttribute : Attribute {
@@ -56,7 +57,9 @@ namespace FluentValidation.AspNetCore {
 			IValidatorSelector selector;
 
 			if (!string.IsNullOrEmpty(RuleSet)) {
-				var rulesets = RuleSet.Split(',', ';');
+				var rulesets = RuleSet.Split(',', ';')
+					.Select(x => x.Trim())
+					.ToArray();
 				selector = CreateRulesetValidatorSelector(mvContext, rulesets);
 			}
 			else if (!string.IsNullOrEmpty(Properties)) {

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -914,8 +914,10 @@ namespace FluentValidation {
 			}
 
 			if (ruleSet != null) {
-				var ruleSetNames = ruleSet.Split(',', ';').Select(x => x.Trim());
-				selector = ValidatorOptions.ValidatorSelectors.RulesetValidatorSelectorFactory(ruleSetNames.ToArray());
+				var ruleSetNames = ruleSet.Split(',', ';')
+					.Select(x => x.Trim())
+					.ToArray();
+				selector = ValidatorOptions.ValidatorSelectors.RulesetValidatorSelectorFactory(ruleSetNames);
 			}
 
 			var context = new ValidationContext<T>(instance, new PropertyChain(), selector);
@@ -969,7 +971,9 @@ namespace FluentValidation {
 			}
 
 			if (ruleSet != null) {
-				var ruleSetNames = ruleSet.Split(',', ';');
+				var ruleSetNames = ruleSet.Split(',', ';')
+					.Select(x => x.Trim())
+					.ToArray();
 				selector = ValidatorOptions.ValidatorSelectors.RulesetValidatorSelectorFactory(ruleSetNames);
 			}
 

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -5,6 +5,9 @@
     <PackageReleaseNotes>
 FluentValidation 9 is a major release. Please read the upgrade notes at https://docs.fluentvalidation.net/en/latest/upgrading-to-9.html
 
+Changes in 9.1:
+* Make ruleset separator character splitting consistent (#1424)      
+
 Changes in 9.0.0:
 * Removed support for netstandard1.1 and netstandard1.6
 * Removed support for end-of-life .NET Core versions (2.2 and 3.0). LTS versions are supported (2.1 and 3.1)


### PR DESCRIPTION
For issue #1424

1. I didn't make any changes to documentation. We can also split by ";" and I think there is no info about this in the documentation.

2. I'm also change split behavior for properties by using trim(). So both splitting properties and rules are consistent. Do we need to separate them by issue/PR?

3. Before my changes, 32 tests failed, and my changes haven't change anything. Do we need any new tests for splitting rules? Should any tests fail o my local environment?