### PR TITLE
support netstandard2.0 and remove razor dependency

### DIFF
--- a/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
+++ b/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>FluentValidation.AspNetCore</AssemblyName>
     <PackageId>FluentValidation.AspNetCore</PackageId>
     <Product>FluentValidation.AspNetCore</Product>
@@ -71,8 +71,8 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netcoreapp2.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/FluentValidation.AspNetCore/FluentValidationClientModelValidatorProvider.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationClientModelValidatorProvider.cs
@@ -25,7 +25,7 @@ namespace FluentValidation.AspNetCore {
 	using FluentValidation.Internal;
 	using FluentValidation.Validators;
 	using Microsoft.AspNetCore.Http;
-#if NETCOREAPP2_1 || NETCOREAPP2_2
+#if NETSTANDARD2_0 || NETCOREAPP2_1 || NETCOREAPP2_2
 	using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
 #else
 	using Microsoft.AspNetCore.Mvc.DataAnnotations;

--- a/src/FluentValidation.AspNetCore/FluentValidationObjectModelValidator.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationObjectModelValidator.cs
@@ -22,7 +22,7 @@ namespace FluentValidation.AspNetCore {
 	using Microsoft.AspNetCore.Mvc;
 	using Microsoft.AspNetCore.Mvc.ModelBinding;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-#if NETCOREAPP2_1 || NETCOREAPP2_2
+#if NETSTANDARD2_0 || NETCOREAPP2_1 || NETCOREAPP2_2
 	// For aspnetcore 2.x (targetting NS2.0), the ValidationVisitor class lives in the .Internal namespace
 	using Microsoft.AspNetCore.Mvc.Internal;
 #endif

--- a/src/FluentValidation.AspNetCore/FluentValidationVisitor.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationVisitor.cs
@@ -20,7 +20,7 @@ namespace FluentValidation.AspNetCore {
 	using Microsoft.AspNetCore.Mvc;
 	using Microsoft.AspNetCore.Mvc.ModelBinding;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-#if NETCOREAPP2_1 || NETCOREAPP2_2
+#if NETSTANDARD2_0 || NETCOREAPP2_1 || NETCOREAPP2_2
 	// For aspnetcore 2.x (targetting NS2.0), the ValidationVisitor class lives in the .Internal namespace
 	using Microsoft.AspNetCore.Mvc.Internal;
 #endif

--- a/src/FluentValidation.AspNetCore/ValidatorDescriptorCache.cs
+++ b/src/FluentValidation.AspNetCore/ValidatorDescriptorCache.cs
@@ -19,7 +19,6 @@
 namespace FluentValidation.AspNetCore {
 	using System;
 	using System.Collections.Generic;
-	using Microsoft.AspNetCore.DataProtection.KeyManagement.Internal;
 	using Microsoft.AspNetCore.Http;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 


### PR DESCRIPTION
We are in the process of migrating to .NET 5, but right now we are still using AspNetCore 2.1 on .NET Framework, and we would like to be able to continue to use the latest versions of FluentValidation.AspNetCore, so we still need the `netstandard2.0` target.

In addition, the razor dependencies in `Microsoft.AspNetCore.Mvc` bring in several additional megabytes of unused binaries to each of our applications.  This library does not require any of the features for cshtml file compilation, so we can change the dependency to `Microsoft.AspNetCore.ViewFeatures`.

Note that there will be a conflict with #1474 (you'll have to make a minor change to the conditional compilation in one place).