### PR TITLE
remove razor dependency

### DIFF
--- a/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
+++ b/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
@@ -72,7 +72,7 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
     <Compile Include="..\CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
The razor dependencies in `Microsoft.AspNetCore.Mvc` bring in several additional megabytes of unused binaries to each of our applications. This library does not require any of the features for cshtml file compilation, so we can change the dependency to `Microsoft.AspNetCore.ViewFeatures`.