### PR TITLE
Ensure collection rules don't bypass accessor cache.

### DIFF
--- a/src/FluentValidation.Tests/AccessorCacheTests.cs
+++ b/src/FluentValidation.Tests/AccessorCacheTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace FluentValidation.Tests {
 	using System;
+	using System.Collections.Generic;
 	using System.ComponentModel.DataAnnotations;
 	using System.Diagnostics;
 	using System.Linq.Expressions;
@@ -31,7 +32,6 @@
 			Assert.Equal(compiled3, compiled4);
 		}
 
-
 		[Fact]
 		public void Equality_comparison_check() {
 			Expression<Func<Person, string>> expr1 = x => x.Surname;
@@ -59,6 +59,16 @@
 		public void Gets_member_for_nested_property() {
 			Expression<Func<Person, string>> expr1 = x => x.Address.Line1;
 			expr1.GetMember().ShouldNotBeNull();
+		}
+
+		[Fact]
+		public void No_error_when_accessing_same_property_via_different_collection_type_when_using_different_cache_prefix() {
+			Expression<Func<Person, IEnumerable<Order>>> expr1 = x => x.Orders;
+			Expression<Func<Person, IList<Order>>> expr2 = x => x.Orders;
+
+			var accessor1 = AccessorCache<Person>.GetCachedAccessor(typeof(Person).GetProperty("Orders"), expr1, false, "Prefix1");
+			var accessor2 = AccessorCache<Person>.GetCachedAccessor(typeof(Person).GetProperty("Orders"), expr2, false, "Prefix2");
+			Assert.NotEqual(accessor1, accessor2);
 		}
 
 		private Person DoStuffToPerson(Person p) {

--- a/src/FluentValidation.Tests/FluentValidation.Tests.csproj
+++ b/src/FluentValidation.Tests/FluentValidation.Tests.csproj
@@ -38,6 +38,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\FluentValidation\Internal\AccessorCache.cs">
+      <Link>AccessorCache.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\Internal\TrackingCollection.cs">
       <Link>TestExtensions.cs</Link>
     </Compile>

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -61,10 +61,17 @@ namespace FluentValidation.Internal {
 		/// <summary>
 		/// Creates a new property rule from a lambda expression.
 		/// </summary>
+		//TODO: Remove in FV10.
 		public static CollectionPropertyRule<T, TElement> Create(Expression<Func<T, IEnumerable<TElement>>> expression, Func<CascadeMode> cascadeModeThunk) {
-			var member = expression.GetMember();
-			var compiled = expression.Compile();
+			return Create(expression, cascadeModeThunk, false);
+		}
 
+		/// <summary>
+		/// Creates a new property rule from a lambda expression.
+		/// </summary>
+		public static CollectionPropertyRule<T, TElement> Create(Expression<Func<T, IEnumerable<TElement>>> expression, Func<CascadeMode> cascadeModeThunk, bool bypassCache = false) {
+			var member = expression.GetMember();
+			var compiled = AccessorCache<T>.GetCachedAccessor(member, expression, bypassCache, "FV_RuleForEach");
 			return new CollectionPropertyRule<T, TElement>(member, compiled.CoerceToNonGeneric(), expression, cascadeModeThunk, typeof(TElement), typeof(T));
 		}
 

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -57,15 +57,7 @@ namespace FluentValidation.Internal {
 		/// By default this is "[" + index + "]"
 		/// </summary>
 		public Func<object, IEnumerable<TElement>, TElement, int, string> IndexBuilder { get; set; }
-
-		/// <summary>
-		/// Creates a new property rule from a lambda expression.
-		/// </summary>
-		//TODO: Remove in FV10.
-		public static CollectionPropertyRule<T, TElement> Create(Expression<Func<T, IEnumerable<TElement>>> expression, Func<CascadeMode> cascadeModeThunk) {
-			return Create(expression, cascadeModeThunk, false);
-		}
-
+		
 		/// <summary>
 		/// Creates a new property rule from a lambda expression.
 		/// </summary>


### PR DESCRIPTION
CollectionPropertyRule bypasses the accessor cache. Some work will need to be done to handle covariance in the compiled accessor. 