### PR TITLE
Allow use of CustomizeValidatorAttribute in PageModel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - net5
 
 jobs:
   build:

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -2,6 +2,7 @@
 Support for .NET 5
 Improvements to LanguageManager's lazy loading of resources.
 Deprecate IStringSource and its implementors. Use delegates instead.
+CustomizeValidatorAttribute now works in Razor pages (netcore 3.1 and net 5.0 only) (#1541)
 
 9.2.1 - 19 September 2020
 Add non-generic Add method to inheritance validator.

--- a/docs/aspnet.md
+++ b/docs/aspnet.md
@@ -335,10 +335,10 @@ Please be aware that `InjectValidator` can *only* be used when using automatic v
 
 ### Use with Page Models
 
-Configuration for use with ASP.NET Web Pages and PageModels is exactly the same as with MVC above, but there are several limitations:
+Configuration for use with ASP.NET Razor Pages and PageModels is exactly the same as with MVC above, but there are several limitations:
 
 - You can't define a validator for the whole page-model, only for models exposed as properties on the page model.
-- The `[CustomizeValidator]` attribute is not supported
+- The `[CustomizeValidator]` attribute is not supported on .net core 2.1 (only 3.1 and 5.0)
 - the `[RuleSetForClientSideMessages]` attribute is not supported
 
-These are limitations of ASP.NET Web Pages and are not currently something that FluentValidation can work around.
+These are limitations of ASP.NET Razor Pages and are not currently something that FluentValidation can work around.

--- a/src/FluentValidation.AspNetCore/CustomizeValidatorAttribute.cs
+++ b/src/FluentValidation.AspNetCore/CustomizeValidatorAttribute.cs
@@ -24,7 +24,7 @@ namespace FluentValidation.AspNetCore {
 	using Microsoft.Extensions.DependencyInjection;
 	using System.Linq;
 
-	[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false)]
 	public class CustomizeValidatorAttribute : Attribute {
 
 		/// <summary>

--- a/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
+++ b/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
@@ -8,6 +8,7 @@
     <PackageReleaseNotes>
 Changes in 9.3.0:
 * Support for .net 5
+* CustomizeValidatorAttribute now works in Razor pages (netcore 3.1 and net 5.0 only)
 
 Changes in 9.0.0:
 * Compatibility with FluentValidation 9.0

--- a/src/FluentValidation.Tests.AspNetCore/RazorPagesTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/RazorPagesTests.cs
@@ -51,6 +51,24 @@
 
 			errors.Count.ShouldEqual(1);
 		}
+
+#if NETCOREAPP3_1 || NET5_0
+		[Fact]
+		public async void Should_only_validate_specified_ruleset() {
+			var form = new FormData {
+				{"Email", "foo"},
+				{"Surname", "foo"},
+				{"Forename", "foo"},
+			};
+
+			var result = await _client.PostResponse("/RuleSetTest", form);
+			var errors = JsonConvert.DeserializeObject<List<SimpleError>>(result);
+
+			errors.IsValidField("Forename").ShouldBeFalse();
+			errors.IsValidField("Surname").ShouldBeFalse();
+			errors.IsValidField("Email").ShouldBeTrue();
+		}
+#endif
 	}
 
 	public class RazorPagesTestsWithImplicitValidationEnabled : IClassFixture<WebAppFixture> {
@@ -87,6 +105,24 @@
 
 			errors.Count.ShouldEqual(1);
 		}
+
+#if NETCOREAPP3_1 || NET5_0
+		[Fact]
+		public async void Should_only_validate_specified_ruleset() {
+			var form = new FormData {
+				{"Email", "foo"},
+				{"Surname", "foo"},
+				{"Forename", "foo"},
+			};
+
+			var result = await _client.PostResponse("/RuleSetTest", form);
+			var errors = JsonConvert.DeserializeObject<List<SimpleError>>(result);
+
+			errors.IsValidField("Forename").ShouldBeFalse();
+			errors.IsValidField("Surname").ShouldBeFalse();
+			errors.IsValidField("Email").ShouldBeTrue();
+		}
+#endif
 	}
 
 }

--- a/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
+++ b/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
@@ -3,8 +3,8 @@ namespace FluentValidation.Tests {
 	using System.Threading.Tasks;
 	using AspNetCore;
 	using AspNetCore.Controllers;
-		using FluentValidation.AspNetCore;
-		using Microsoft.AspNetCore.Mvc;
+	using FluentValidation.AspNetCore;
+	using Microsoft.AspNetCore.Mvc;
 	using Microsoft.AspNetCore.Mvc.RazorPages;
 
 	[IgnoreAntiforgeryToken(Order = 1001)]

--- a/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
+++ b/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
@@ -3,7 +3,8 @@ namespace FluentValidation.Tests {
 	using System.Threading.Tasks;
 	using AspNetCore;
 	using AspNetCore.Controllers;
-	using Microsoft.AspNetCore.Mvc;
+		using FluentValidation.AspNetCore;
+		using Microsoft.AspNetCore.Mvc;
 	using Microsoft.AspNetCore.Mvc.RazorPages;
 
 	[IgnoreAntiforgeryToken(Order = 1001)]
@@ -33,6 +34,7 @@ namespace FluentValidation.Tests {
 	public class RulesetTestPageModel : PageModel {
 
 		[BindProperty]
+		[CustomizeValidator(RuleSet = "Names")]
 		public RulesetTestModel Test { get; set; }
 
 		public Task<IActionResult> OnPostAsync() {

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -7,7 +7,8 @@ FluentValidation 9 is a major release. Please read the upgrade notes at https://
 
 Changes in 9.3.0:
 * Improvements to LanguageManager's lazy loading of resources.
-* Deprecate IStringSource and its implementors. Use delegates instead. 
+* Deprecate IStringSource and its implementors. Use delegates instead.
+* CustomizeValidatorAttribute now works in Razor pages (netcore 3.1 and net 5.0 only)
 
 Changes in 9.2.1:
 * Add non-generic Add method to inheritance validator.


### PR DESCRIPTION
PR for #1541 

Notes:

I have changed `CustomizeValidatorAttribute` to be allowed on properties as well as parameters which is a fairly major change. This could alternatively be done by creating a derived attribute or something. But I think it would be better to add an analyser to show a warning when using the attribute on a property not in a `PageModel` and not with a `BindAttribute`.

Also, I think I may have done the branching thing slightly wrong but hopefully it's ok?