### PR TITLE
Razor pages client ruleset attribute

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ Support for .NET 5
 Improvements to LanguageManager's lazy loading of resources.
 Deprecate IStringSource and its implementors. Use delegates instead.
 CustomizeValidatorAttribute now works in Razor pages (netcore 3.1 and net 5.0 only) (#1541)
+RuleSetForClientSideMessagesAttribute now works in Razor pages (netcore 3.1 and net 5.0 only) (#1544)
 
 9.2.1 - 19 September 2020
 Add non-generic Add method to inheritance validator.

--- a/docs/aspnet.md
+++ b/docs/aspnet.md
@@ -339,6 +339,6 @@ Configuration for use with ASP.NET Razor Pages and PageModels is exactly the sam
 
 - You can't define a validator for the whole page-model, only for models exposed as properties on the page model.
 - The `[CustomizeValidator]` attribute is not supported on .net core 2.1 (only 3.1 and 5.0)
-- the `[RuleSetForClientSideMessages]` attribute is not supported
+- The `[RuleSetForClientSideMessages]` attribute is not supported on .net core 2.1 (only 3.1 and 5.0)
 
 These are limitations of ASP.NET Razor Pages and are not currently something that FluentValidation can work around.

--- a/docs/aspnet.md
+++ b/docs/aspnet.md
@@ -237,7 +237,7 @@ public ActionResult Save([CustomizeValidator(Skip=true)] Customer cust) {
 
 ### Validator Interceptors
 
-You can further customize this process by using an interceptor. An interceptor has to implement the IValidatorInterceptor interface from the FluentValidation.Mvc namespace:
+You can further customize this process by using an interceptor. An interceptor has to implement the IValidatorInterceptor interface from the FluentValidation.AspNetCore namespace:
 
 ```csharp
 public interface IValidatorInterceptor	{
@@ -290,7 +290,7 @@ public ActionResult Index() {
 }
 ```
 
-You can also use the `SetRulesetForClientsideMessages` extension method within your controller action (you must have the FluentValidation.Mvc namespace imported):
+You can also use the `SetRulesetForClientsideMessages` extension method within your controller action:
 
 ```csharp
 public ActionResult Index() {
@@ -340,5 +340,14 @@ Configuration for use with ASP.NET Razor Pages and PageModels is exactly the sam
 - You can't define a validator for the whole page-model, only for models exposed as properties on the page model.
 - The `[CustomizeValidator]` attribute is not supported on .net core 2.1 (only 3.1 and 5.0)
 - The `[RuleSetForClientSideMessages]` attribute is not supported on .net core 2.1 (only 3.1 and 5.0)
+
+You can also use the `SetRulesetForClientsideMessages` extension method within your page handler:
+
+```csharp
+public IActionResult OnGet() {
+   PageContext.SetRulesetForClientsideMessages("MyRuleset");
+   return Page();
+}
+```
 
 These are limitations of ASP.NET Razor Pages and are not currently something that FluentValidation can work around.

--- a/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
+++ b/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
@@ -9,6 +9,7 @@
 Changes in 9.3.0:
 * Support for .net 5
 * CustomizeValidatorAttribute now works in Razor pages (netcore 3.1 and net 5.0 only)
+* RuleSetForClientSideMessagesAttribute now works in Razor pages (netcore 3.1 and net 5.0 only)
 
 Changes in 9.0.0:
 * Compatibility with FluentValidation 9.0

--- a/src/FluentValidation.AspNetCore/RuleSetForClientSideMessagesAttribute.cs
+++ b/src/FluentValidation.AspNetCore/RuleSetForClientSideMessagesAttribute.cs
@@ -1,6 +1,5 @@
 namespace FluentValidation.AspNetCore {
 	using System;
-	using FluentValidation.Internal;
 	using Microsoft.AspNetCore.Http;
 	using Microsoft.AspNetCore.Mvc.Filters;
 
@@ -8,7 +7,7 @@ namespace FluentValidation.AspNetCore {
 	/// Specifies which ruleset should be used when deciding which validators should be used to generate client-side messages.
 	/// </summary>
 	public class RuleSetForClientSideMessagesAttribute : ActionFilterAttribute {
-		private const string _key = "_FV_ClientSideRuleSet";
+
 		private readonly string[] _ruleSets;
 
 		public RuleSetForClientSideMessagesAttribute(string ruleSet) {
@@ -34,7 +33,7 @@ namespace FluentValidation.AspNetCore {
 		/// <param name="context"></param>
 		/// <param name="ruleSets"></param>
 		public static void SetRulesetForClientValidation(HttpContext context, string[] ruleSets) {
-			context.Items[_key] = ruleSets;
+			context.SetRulesetForClientsideMessages(ruleSets);
 		}
 
 		/// <summary>
@@ -43,14 +42,7 @@ namespace FluentValidation.AspNetCore {
 		/// <param name="context"></param>
 		/// <returns></returns>
 		public static string[] GetRuleSetsForClientValidation(HttpContext context) {
-			// If the httpContext is null (for example, if IHttpContextProvider hasn't been registered) then just assume default ruleset.
-			// This is OK because if we're actually using the attribute, the OnActionExecuting will have caught the fact that the provider is not registered. 
-
-			if (context?.Items != null && context.Items.ContainsKey(_key)) {
-				return context?.Items[_key] as string[] ?? new[] { RulesetValidatorSelector.DefaultRuleSetName };
-
-			}
-			return new[] { RulesetValidatorSelector.DefaultRuleSetName };
+			return context.GetRuleSetsForClientValidation();
 		}
 
 		private void SetRulesetOnExecuting(FilterContext filterContext) {

--- a/src/FluentValidation.AspNetCore/RuleSetForClientSideMessagesAttribute.cs
+++ b/src/FluentValidation.AspNetCore/RuleSetForClientSideMessagesAttribute.cs
@@ -1,7 +1,7 @@
 namespace FluentValidation.AspNetCore {
 	using System;
-  using FluentValidation.Internal;
-  using Microsoft.AspNetCore.Http;
+	using FluentValidation.Internal;
+	using Microsoft.AspNetCore.Http;
 	using Microsoft.AspNetCore.Mvc.Filters;
 
 	/// <summary>
@@ -16,20 +16,17 @@ namespace FluentValidation.AspNetCore {
 		}
 
 		public RuleSetForClientSideMessagesAttribute(params string[] ruleSets) {
-			this._ruleSets = ruleSets;
+			_ruleSets = ruleSets;
 		}
 
 		public override void OnActionExecuting(ActionExecutingContext filterContext) {
-			var contextAccessor = filterContext.HttpContext.RequestServices.GetService(typeof(IHttpContextAccessor));
-
-			if(contextAccessor == null) {
-				throw new InvalidOperationException("Cannot use the RuleSetForClientSideMessagesAttribute unless the IHttpContextAccessor is registered with the service provider. Make sure the provider is registered by calling services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>(); in your Startup class's ConfigureServices method");
-			}
-
-			SetRulesetForClientValidation(filterContext.HttpContext, _ruleSets);
+			SetRulesetOnExecuting(filterContext);
 		}
 
-		
+		public override void OnResultExecuting(ResultExecutingContext context) {
+			SetRulesetOnExecuting(context);
+		}
+
 		/// <summary>
 		/// Allows the ruleset used for generating clientside metadata to be overriden.
 		/// By default, only rules not in a ruleset will be used.
@@ -53,7 +50,17 @@ namespace FluentValidation.AspNetCore {
 				return context?.Items[_key] as string[] ?? new[] { RulesetValidatorSelector.DefaultRuleSetName };
 
 			}
-			return new[] { RulesetValidatorSelector.DefaultRuleSetName};
+			return new[] { RulesetValidatorSelector.DefaultRuleSetName };
+		}
+
+		private void SetRulesetOnExecuting(FilterContext filterContext) {
+			var contextAccessor = filterContext.HttpContext.RequestServices.GetService(typeof(IHttpContextAccessor));
+
+			if (contextAccessor == null) {
+				throw new InvalidOperationException("Cannot use the RuleSetForClientSideMessagesAttribute unless the IHttpContextAccessor is registered with the service provider. Make sure the provider is registered by calling services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>(); in your Startup class's ConfigureServices method");
+			}
+
+			SetRulesetForClientValidation(filterContext.HttpContext, _ruleSets);
 		}
 	}
 }

--- a/src/FluentValidation.AspNetCore/RuleSetForClientSideMessagesAttribute.cs
+++ b/src/FluentValidation.AspNetCore/RuleSetForClientSideMessagesAttribute.cs
@@ -10,21 +10,13 @@ namespace FluentValidation.AspNetCore {
 
 		private readonly string[] _ruleSets;
 
-		public RuleSetForClientSideMessagesAttribute(string ruleSet) {
-			_ruleSets = new[] { ruleSet };
-		}
+		public RuleSetForClientSideMessagesAttribute(string ruleSet) => _ruleSets = new[] { ruleSet };
 
-		public RuleSetForClientSideMessagesAttribute(params string[] ruleSets) {
-			_ruleSets = ruleSets;
-		}
+		public RuleSetForClientSideMessagesAttribute(params string[] ruleSets) => _ruleSets = ruleSets;
 
-		public override void OnActionExecuting(ActionExecutingContext filterContext) {
-			SetRulesetOnExecuting(filterContext);
-		}
+		public override void OnActionExecuting(ActionExecutingContext filterContext) => SetRulesetOnExecuting(filterContext);
 
-		public override void OnResultExecuting(ResultExecutingContext context) {
-			SetRulesetOnExecuting(context);
-		}
+		public override void OnResultExecuting(ResultExecutingContext context) => SetRulesetOnExecuting(context);
 
 		/// <summary>
 		/// Allows the ruleset used for generating clientside metadata to be overriden.
@@ -32,18 +24,14 @@ namespace FluentValidation.AspNetCore {
 		/// </summary>
 		/// <param name="context"></param>
 		/// <param name="ruleSets"></param>
-		public static void SetRulesetForClientValidation(HttpContext context, string[] ruleSets) {
-			context.SetRulesetForClientsideMessages(ruleSets);
-		}
+		public static void SetRulesetForClientValidation(HttpContext context, string[] ruleSets) => context.SetRulesetForClientsideMessages(ruleSets);
 
 		/// <summary>
 		/// Gets the rulesets used to generate clientside validation metadata.
 		/// </summary>
 		/// <param name="context"></param>
 		/// <returns></returns>
-		public static string[] GetRuleSetsForClientValidation(HttpContext context) {
-			return context.GetRuleSetsForClientValidation();
-		}
+		public static string[] GetRuleSetsForClientValidation(HttpContext context) => context.GetRuleSetsForClientValidation();
 
 		private void SetRulesetOnExecuting(FilterContext filterContext) {
 			var contextAccessor = filterContext.HttpContext.RequestServices.GetService(typeof(IHttpContextAccessor));
@@ -52,7 +40,7 @@ namespace FluentValidation.AspNetCore {
 				throw new InvalidOperationException("Cannot use the RuleSetForClientSideMessagesAttribute unless the IHttpContextAccessor is registered with the service provider. Make sure the provider is registered by calling services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>(); in your Startup class's ConfigureServices method");
 			}
 
-			SetRulesetForClientValidation(filterContext.HttpContext, _ruleSets);
+			filterContext.HttpContext.SetRulesetForClientsideMessages(_ruleSets);
 		}
 	}
 }

--- a/src/FluentValidation.AspNetCore/RuleSetForClientSideMessagesAttribute.cs
+++ b/src/FluentValidation.AspNetCore/RuleSetForClientSideMessagesAttribute.cs
@@ -14,9 +14,15 @@ namespace FluentValidation.AspNetCore {
 
 		public RuleSetForClientSideMessagesAttribute(params string[] ruleSets) => _ruleSets = ruleSets;
 
-		public override void OnActionExecuting(ActionExecutingContext filterContext) => SetRulesetOnExecuting(filterContext);
+		public override void OnResultExecuting(ResultExecutingContext context) {
+			var contextAccessor = context.HttpContext.RequestServices.GetService(typeof(IHttpContextAccessor));
 
-		public override void OnResultExecuting(ResultExecutingContext context) => SetRulesetOnExecuting(context);
+			if (contextAccessor == null) {
+				throw new InvalidOperationException("Cannot use the RuleSetForClientSideMessagesAttribute unless the IHttpContextAccessor is registered with the service provider. Make sure the provider is registered by calling services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>(); in your Startup class's ConfigureServices method");
+			}
+
+			context.HttpContext.SetRulesetForClientsideMessages(_ruleSets);
+		}
 
 		/// <summary>
 		/// Allows the ruleset used for generating clientside metadata to be overriden.
@@ -32,15 +38,5 @@ namespace FluentValidation.AspNetCore {
 		/// <param name="context"></param>
 		/// <returns></returns>
 		public static string[] GetRuleSetsForClientValidation(HttpContext context) => context.GetRuleSetsForClientValidation();
-
-		private void SetRulesetOnExecuting(FilterContext filterContext) {
-			var contextAccessor = filterContext.HttpContext.RequestServices.GetService(typeof(IHttpContextAccessor));
-
-			if (contextAccessor == null) {
-				throw new InvalidOperationException("Cannot use the RuleSetForClientSideMessagesAttribute unless the IHttpContextAccessor is registered with the service provider. Make sure the provider is registered by calling services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>(); in your Startup class's ConfigureServices method");
-			}
-
-			filterContext.HttpContext.SetRulesetForClientsideMessages(_ruleSets);
-		}
 	}
 }

--- a/src/FluentValidation.AspNetCore/ValidationResultExtensions.cs
+++ b/src/FluentValidation.AspNetCore/ValidationResultExtensions.cs
@@ -19,11 +19,19 @@
 #endregion
 
 namespace FluentValidation.AspNetCore {
-	using Microsoft.AspNetCore.Mvc.ModelBinding;
+	using FluentValidation.Internal;
 	using FluentValidation.Results;
+	using Microsoft.AspNetCore.Http;
 	using Microsoft.AspNetCore.Mvc;
+	using Microsoft.AspNetCore.Mvc.ModelBinding;
+#if NETCOREAPP3_1 || NET5_0
+	using Microsoft.AspNetCore.Mvc.RazorPages;
+#endif
 
 	public static class ValidationResultExtension {
+
+		private const string _rulesetKey = "_FV_ClientSideRuleSet";
+
 		/// <summary>
 		/// Stores the errors in a ValidationResult object to the specified modelstate dictionary.
 		/// </summary>
@@ -48,8 +56,38 @@ namespace FluentValidation.AspNetCore {
 		/// </summary>
 		/// <param name="context">Http context</param>
 		/// <param name="ruleSets">Array of ruleset names</param>
-		public static void SetRulesetForClientsideMessages(this ControllerContext context, params string[] ruleSets) {
-			context.HttpContext.Items["_FV_ClientSideRuleSet"] = ruleSets;
+		public static void SetRulesetForClientsideMessages(this HttpContext context, params string[] ruleSets) => context.Items[_rulesetKey] = ruleSets;
+
+		/// <summary>
+		/// Gets the rulesets used to generate clientside validation metadata.
+		/// </summary>
+		/// <param name="context">Http context</param>
+		/// <returns>Array of ruleset names</returns>
+		public static string[] GetRuleSetsForClientValidation(this HttpContext context) {
+			// If the httpContext is null (for example, if IHttpContextProvider hasn't been registered) then just assume default ruleset.
+			// This is OK because if we're actually using the attribute, the OnActionExecuting will have caught the fact that the provider is not registered. 
+
+			if (context?.Items != null && context.Items.ContainsKey(_rulesetKey) && context?.Items[_rulesetKey] is string[] ruleSets) {
+				return ruleSets;
+			}
+
+			return new[] { RulesetValidatorSelector.DefaultRuleSetName };
 		}
+
+		/// <summary>
+		/// Sets the rulests used when generating clientside messages.
+		/// </summary>
+		/// <param name="context">Controller context</param>
+		/// <param name="ruleSets">Array of ruleset names</param>
+		public static void SetRulesetForClientsideMessages(this ControllerContext context, params string[] ruleSets) => context.HttpContext.SetRulesetForClientsideMessages(ruleSets);
+
+#if NETCOREAPP3_1 || NET5_0
+		/// <summary>
+		/// Sets the rulests used when generating clientside messages.
+		/// </summary>
+		/// <param name="context">Page context</param>
+		/// <param name="ruleSets">Array of ruleset names</param>
+		public static void SetRulesetForClientsideMessages(this PageContext context, params string[] ruleSets) => context.HttpContext.SetRulesetForClientsideMessages(ruleSets);
+#endif
 	}
 }

--- a/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
@@ -213,7 +213,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 	}
 
-#if NETCOREAPP3_1 || NET5_0
+
 	public class RazorPagesClientsideMessageTester : IClassFixture<WebAppFixture> {
 		private readonly HttpClient _client;
 
@@ -251,6 +251,37 @@ namespace FluentValidation.Tests.AspNetCore {
 			msgs[0].ShouldEqual("first");
 			msgs[1].ShouldEqual("third");
 		}
-	}
+
+#if NETCOREAPP3_1 || NET5_0
+		[Fact]
+		public async Task Should_only_use_rules_from_default_ruleset_extension() {
+			var msg = await _client.RunRulesetAction("/Rulesets/RuleSetForHandlers?handler=default", "Test");
+			msg.Length.ShouldEqual(1);
+			msg[0].ShouldEqual("third");
+		}
+
+		[Fact]
+		public async Task Should_use_rules_from_specified_ruleset_extension() {
+			var msg = await _client.RunRulesetAction("/Rulesets/RuleSetForHandlers?handler=specified", "Test");
+			msg.Length.ShouldEqual(1);
+			msg[0].ShouldEqual("first");
+		}
+
+		[Fact]
+		public async Task Should_use_rules_from_multiple_rulesets_extension() {
+			var msgs = await _client.RunRulesetAction("/Rulesets/RuleSetForHandlers?handler=multiple", "Test");
+			msgs.Length.ShouldEqual(2);
+			msgs[0].ShouldEqual("first");
+			msgs[1].ShouldEqual("second");
+		}
+
+		[Fact]
+		public async Task Should_use_rules_from_default_ruleset_and_specified_ruleset_extension() {
+			var msgs = await _client.RunRulesetAction("/Rulesets/RuleSetForHandlers?handler=defaultAndSpecified", "Test");
+			msgs.Length.ShouldEqual(2);
+			msgs[0].ShouldEqual("first");
+			msgs[1].ShouldEqual("third");
+		}
 #endif
+	}
 }

--- a/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
@@ -212,4 +212,45 @@ namespace FluentValidation.Tests.AspNetCore {
 			ClientsideModelValidator.TimesInstantiated.ShouldEqual(1);
 		}
 	}
+
+#if NETCOREAPP3_1 || NET5_0
+	public class RazorPagesClientsideMessageTester : IClassFixture<WebAppFixture> {
+		private readonly HttpClient _client;
+
+		public RazorPagesClientsideMessageTester(WebAppFixture webApp) {
+			_client = webApp.WithContainer(enableLocalization: true).CreateClient();
+			CultureScope.SetDefaultCulture();
+		}
+
+		[Fact]
+		public async Task Should_only_use_rules_from_default_ruleset() {
+			var msg = await _client.RunRulesetAction("/Rulesets/DefaultRuleSet", "Test");
+			msg.Length.ShouldEqual(1);
+			msg[0].ShouldEqual("third");
+		}
+
+		[Fact]
+		public async Task Should_use_rules_from_specified_ruleset() {
+			var msg = await _client.RunRulesetAction("/Rulesets/SpecifiedRuleSet", "Test");
+			msg.Length.ShouldEqual(1);
+			msg[0].ShouldEqual("first");
+		}
+
+		[Fact]
+		public async Task Should_use_rules_from_multiple_rulesets() {
+			var msgs = await _client.RunRulesetAction("/Rulesets/MultipleRuleSets", "Test");
+			msgs.Length.ShouldEqual(2);
+			msgs[0].ShouldEqual("first");
+			msgs[1].ShouldEqual("second");
+		}
+
+		[Fact]
+		public async Task Should_use_rules_from_default_ruleset_and_specified_ruleset() {
+			var msgs = await _client.RunRulesetAction("/Rulesets/DefaultAndSpecifiedRuleSet", "Test");
+			msgs.Length.ShouldEqual(2);
+			msgs[0].ShouldEqual("first");
+			msgs[1].ShouldEqual("third");
+		}
+	}
+#endif
 }

--- a/src/FluentValidation.Tests.AspNetCore/HttpClientExtensions.cs
+++ b/src/FluentValidation.Tests.AspNetCore/HttpClientExtensions.cs
@@ -73,12 +73,12 @@ namespace FluentValidation.Tests {
 			return attr.Value;
 		}
 
-		public static async Task<string[]> RunRulesetAction(this HttpClient client, string action) {
+		public static async Task<string[]> RunRulesetAction(this HttpClient client, string action, string modelPrefix = null) {
 
 			var doc = await client.GetClientsideMessages(action);
 
 			var elems = doc.Root.Elements("input")
-				.Where(x => x.Attribute("name").Value.StartsWith("CustomName"));
+				.Where(x => x.Attribute("name").Value.StartsWith($"{(modelPrefix == null ? string.Empty : $"{modelPrefix}.")}CustomName"));
 
 			var results = elems.Select(x => x.Attribute("data-val-required"))
 				.Where(x => x != null)

--- a/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/DefaultAndSpecifiedRuleSet.cshtml
+++ b/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/DefaultAndSpecifiedRuleSet.cshtml
@@ -1,0 +1,8 @@
+@page
+@model FluentValidation.Tests.TestPageModelWithDefaultAndSpecifiedRuleSet
+
+<div>
+  <input asp-for="Test.CustomName1" />
+  <input asp-for="Test.CustomName2" />
+  <input asp-for="Test.CustomName3" />
+</div>

--- a/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/DefaultRuleSet.cshtml
+++ b/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/DefaultRuleSet.cshtml
@@ -1,0 +1,8 @@
+@page
+@model FluentValidation.Tests.TestPageModelWithDefaultRuleSet
+
+<div>
+  <input asp-for="Test.CustomName1" />
+  <input asp-for="Test.CustomName2" />
+  <input asp-for="Test.CustomName3" />
+</div>

--- a/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/MultipleRuleSets.cshtml
+++ b/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/MultipleRuleSets.cshtml
@@ -1,0 +1,8 @@
+@page
+@model FluentValidation.Tests.TestPageModelWithMultipleRuleSets
+
+<div>
+  <input asp-for="Test.CustomName1" />
+  <input asp-for="Test.CustomName2" />
+  <input asp-for="Test.CustomName3" />
+</div>

--- a/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/RuleSetForHandlers.cshtml
+++ b/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/RuleSetForHandlers.cshtml
@@ -1,0 +1,8 @@
+@page
+@model FluentValidation.Tests.TestPageModelWithRuleSetForHandlers
+
+<div>
+  <input asp-for="Test.CustomName1" />
+  <input asp-for="Test.CustomName2" />
+  <input asp-for="Test.CustomName3" />
+</div>

--- a/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/SpecifiedRuleSet.cshtml
+++ b/src/FluentValidation.Tests.AspNetCore/Pages/Rulesets/SpecifiedRuleSet.cshtml
@@ -1,0 +1,8 @@
+@page
+@model FluentValidation.Tests.TestPageModelWithSpecifiedRuleSet
+
+<div>
+  <input asp-for="Test.CustomName1" />
+  <input asp-for="Test.CustomName2" />
+  <input asp-for="Test.CustomName3" />
+</div>

--- a/src/FluentValidation.Tests.AspNetCore/Pages/_ViewImports.cshtml
+++ b/src/FluentValidation.Tests.AspNetCore/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using FluentValidation.Tests
+@namespace FluentValidation.Tests.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
+++ b/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
@@ -22,7 +22,7 @@ namespace FluentValidation.Tests {
 
 			foreach (var pair in ModelState) {
 				foreach (var error in pair.Value.Errors) {
-					errors.Add(new SimpleError {Name = pair.Key, Message = error.ErrorMessage});
+					errors.Add(new SimpleError { Name = pair.Key, Message = error.ErrorMessage });
 				}
 			}
 
@@ -46,7 +46,7 @@ namespace FluentValidation.Tests {
 
 			foreach (var pair in ModelState) {
 				foreach (var error in pair.Value.Errors) {
-					errors.Add(new SimpleError {Name = pair.Key, Message = error.ErrorMessage});
+					errors.Add(new SimpleError { Name = pair.Key, Message = error.ErrorMessage });
 				}
 			}
 
@@ -57,7 +57,7 @@ namespace FluentValidation.Tests {
 	[IgnoreAntiforgeryToken(Order = 1001)]
 	public class TestPageModelWithPrefix : PageModel {
 
-		[BindProperty(Name="Test")]
+		[BindProperty(Name = "Test")]
 		public TestModel Test { get; set; }
 
 		public Task<IActionResult> OnPostAsync() {
@@ -69,7 +69,7 @@ namespace FluentValidation.Tests {
 
 			foreach (var pair in ModelState) {
 				foreach (var error in pair.Value.Errors) {
-					errors.Add(new SimpleError {Name = pair.Key, Message = error.ErrorMessage});
+					errors.Add(new SimpleError { Name = pair.Key, Message = error.ErrorMessage });
 				}
 			}
 
@@ -77,5 +77,42 @@ namespace FluentValidation.Tests {
 		}
 	}
 
+	[IgnoreAntiforgeryToken(Order = 1001)]
+	public class TestPageModelWithDefaultRuleSet : PageModel {
 
+		[BindProperty(Name = "Test")]
+		public ClientsideRulesetModel Test { get; set; }
+
+		public IActionResult OnGet() => Page();
+	}
+
+	[IgnoreAntiforgeryToken(Order = 1001)]
+	[RuleSetForClientSideMessages("Foo")]
+	public class TestPageModelWithSpecifiedRuleSet : PageModel {
+
+		[BindProperty(Name = "Test")]
+		public ClientsideRulesetModel Test { get; set; }
+
+		public IActionResult OnGet() => Page();
+	}
+
+	[IgnoreAntiforgeryToken(Order = 1001)]
+	[RuleSetForClientSideMessages("Foo", "Bar")]
+	public class TestPageModelWithMultipleRuleSets : PageModel {
+
+		[BindProperty(Name = "Test")]
+		public ClientsideRulesetModel Test { get; set; }
+
+		public IActionResult OnGet() => Page();
+	}
+
+	[IgnoreAntiforgeryToken(Order = 1001)]
+	[RuleSetForClientSideMessages("Foo", "default")]
+	public class TestPageModelWithDefaultAndSpecifiedRuleSet : PageModel {
+
+		[BindProperty(Name = "Test")]
+		public ClientsideRulesetModel Test { get; set; }
+
+		public IActionResult OnGet() => Page();
+	}
 }

--- a/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
+++ b/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
@@ -115,4 +115,30 @@ namespace FluentValidation.Tests {
 
 		public IActionResult OnGet() => Page();
 	}
+
+	[IgnoreAntiforgeryToken(Order = 1001)]
+	public class TestPageModelWithRuleSetForHandlers : PageModel {
+
+		[BindProperty(Name = "Test")]
+		public ClientsideRulesetModel Test { get; set; }
+
+		public IActionResult OnGetDefault() => Page();
+
+#if NETCOREAPP3_1 || NET5_0
+		public IActionResult OnGetSpecified() {
+			PageContext.SetRulesetForClientsideMessages("Foo");
+			return Page();
+		}
+
+		public IActionResult OnGetMultiple() {
+			PageContext.SetRulesetForClientsideMessages("Foo", "Bar");
+			return Page();
+		}
+
+		public IActionResult OnGetDefaultAndSpecified() {
+			PageContext.SetRulesetForClientsideMessages("Foo", "default");
+			return Page();
+		}
+#endif
+	}
 }

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -9,6 +9,7 @@ Changes in 9.3.0:
 * Improvements to LanguageManager's lazy loading of resources.
 * Deprecate IStringSource and its implementors. Use delegates instead.
 * CustomizeValidatorAttribute now works in Razor pages (netcore 3.1 and net 5.0 only)
+* RuleSetForClientSideMessagesAttribute now works in Razor pages (netcore 3.1 and net 5.0 only)
 
 Changes in 9.2.1:
 * Add non-generic Add method to inheritance validator.


### PR DESCRIPTION
Hi Jeremy,

This is the updated PR for #1544 

I have centralized the logic for the `SetRulesetForClientsideMessages` extension which neatly resolves the issue of using it with page handlers anyway.

So you can use the attribute to apply it for all handlers on the `PageModel` or you can specify the ruleset via the extension on a specific handler.

One thing that might be worth mentioning in the docs is that the attribute takes precedence over the extension method. Add will overwrite the ruleset specified in the handler. I suspect the same applies to a controller action (not tested).

Good job you had that one question ;p