### PR TITLE
Remove support for .NET 4.x, netstandard2.0 and netcoreapp2.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,5 +3,5 @@
       "version": "5.0.100",
       "rollForward": "latestFeature"
     },
-    "others": ["3.1.201", "2.2.105"]
+    "others": ["3.1.201"]
 }

--- a/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
+++ b/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>FluentValidation.AspNetCore</AssemblyName>
     <PackageId>FluentValidation.AspNetCore</PackageId>
     <Product>FluentValidation.AspNetCore</Product>
@@ -76,10 +76,7 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1' Or '$(TargetFramework)'=='net5.0'">
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FluentValidation.AspNetCore/FluentValidationClientModelValidatorProvider.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationClientModelValidatorProvider.cs
@@ -25,12 +25,8 @@ namespace FluentValidation.AspNetCore {
 	using FluentValidation.Internal;
 	using FluentValidation.Validators;
 	using Microsoft.AspNetCore.Http;
-	using Microsoft.Extensions.DependencyInjection;
-#if NETCOREAPP2_1 || NETCOREAPP2_2
-	using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
-#else
 	using Microsoft.AspNetCore.Mvc.DataAnnotations;
-#endif
+
 	public delegate IClientModelValidator FluentValidationClientValidatorFactory(ClientValidatorProviderContext context, IValidationRule rule, IPropertyValidator validator);
 
 	/// <summary>

--- a/src/FluentValidation.AspNetCore/FluentValidationObjectModelValidator.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationObjectModelValidator.cs
@@ -22,10 +22,6 @@ namespace FluentValidation.AspNetCore {
 	using Microsoft.AspNetCore.Mvc;
 	using Microsoft.AspNetCore.Mvc.ModelBinding;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-#if NETCOREAPP2_1 || NETCOREAPP2_2
-	// For aspnetcore 2.x (targetting NS2.0), the ValidationVisitor class lives in the .Internal namespace
-	using Microsoft.AspNetCore.Mvc.Internal;
-#endif
 
 	internal class FluentValidationObjectModelValidator : ObjectModelValidator {
 		private readonly bool _runMvcValidation;

--- a/src/FluentValidation.AspNetCore/FluentValidationVisitor.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationVisitor.cs
@@ -21,11 +21,6 @@ namespace FluentValidation.AspNetCore {
 	using Microsoft.AspNetCore.Mvc;
 	using Microsoft.AspNetCore.Mvc.ModelBinding;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-#if NETCOREAPP2_1 || NETCOREAPP2_2
-	// For aspnetcore 2.x (targetting NS2.0), the ValidationVisitor class lives in the .Internal namespace
-	using Microsoft.AspNetCore.Mvc.Internal;
-#endif
-
 	using static MvcValidationHelper;
 
 	internal class FluentValidationVisitor : ValidationVisitor {

--- a/src/FluentValidation.DependencyInjectionExtensions/FluentValidation.DependencyInjectionExtensions.csproj
+++ b/src/FluentValidation.DependencyInjectionExtensions/FluentValidation.DependencyInjectionExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>FluentValidation.DependencyInjectionExtensions</AssemblyName>
         <PackageId>FluentValidation.DependencyInjectionExtensions</PackageId>
         <Product>FluentValidation.DependencyInjectionExtensions</Product>

--- a/src/FluentValidation.Tests.AspNetCore/FluentValidation.Tests.AspNetCore.csproj
+++ b/src/FluentValidation.Tests.AspNetCore/FluentValidation.Tests.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>FluentValidation.Tests</RootNamespace>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -10,23 +10,18 @@
     <AddRazorSupportForMvc>True</AddRazorSupportForMvc>
   </PropertyGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.0" />
   </ItemGroup>

--- a/src/FluentValidation.Tests.AspNetCore/Startup.cs
+++ b/src/FluentValidation.Tests.AspNetCore/Startup.cs
@@ -21,32 +21,18 @@ namespace FluentValidation.Tests.AspNetCore {
 				options.SupportedUICultures = new[] {cultureInfo};
 			});
 
-#if NETCOREAPP2_1
-			app.UseMvc(routes => {
-				routes.MapRoute(
-					name: "default",
-					template: "{controller=Home}/{action=Index}/{id?}");
-			});
-#else
 			app
 				.UseRouting()
 				.UseEndpoints(endpoints => {
 					endpoints.MapRazorPages();
 					endpoints.MapDefaultControllerRoute();
 				});
-#endif
 		}
 	}
 
 	public static class WebTestExtensions {
-
 		public static void AddFluentValidationForTesting(this IServiceCollection services, Action<FluentValidationMvcConfiguration> configurator) {
-#if NETCOREAPP2_1
-			var mvcBuilder = services.AddMvc();
-#else
-			var mvcBuilder = services.AddMvc().AddNewtonsoftJson();
-#endif
-			mvcBuilder.AddFluentValidation(configurator);
+			services.AddMvc().AddNewtonsoftJson().AddFluentValidation(configurator);
 		}
 	}
 

--- a/src/FluentValidation.Tests/FluentValidation.Tests.csproj
+++ b/src/FluentValidation.Tests/FluentValidation.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>FluentValidation.Tests</AssemblyName>
     <RootNamespace>FluentValidation.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
     <Description>A validation library for .NET that uses a fluent interface to construct strongly-typed validation rules.</Description>
     <PackageReleaseNotes>
 FluentValidation 9 is a major release. Please read the upgrade notes at https://docs.fluentvalidation.net/en/latest/upgrading-to-9.html


### PR DESCRIPTION
Going forward we'll only support the latest LTS release (currently netcoreapp3.1) plus any still-supported non-LTS release (net5) 