### PR TITLE
Fixed collections instructions in collections.md

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -83,7 +83,7 @@ As of version 8.2, an alternative to using `RuleForEach` is to call `ForEach` as
 ```csharp
 // This rule acts on the whole collection (using RuleFor)
 RuleFor(x => x.Orders)
-  .Must(x => x.Orders.Count <= 10).WithMessage("No more than 10 orders are allowed");
+  .Must(x => x.Count <= 10).WithMessage("No more than 10 orders are allowed");
 
 // This rule acts on each individual element (using RuleForEach)
 RuleForEach(x => x.Orders)
@@ -94,7 +94,7 @@ The above 2 rules could be re-written as:
 
 ```csharp
 RuleFor(x => x.Orders)
-  .Must(x => x.Orders.Count <= 10).WithMessage("No more than 10 orders are allowed")
+  .Must(x => x.Count <= 10).WithMessage("No more than 10 orders are allowed")
   .ForEach(orderRule => {
     orderRule.Must(order => order.Total > 0).WithMessage("Orders must have a total of more than 0")
   });


### PR DESCRIPTION
Removed a extra call to the collection within the RuleFor() predicate.

x.Orders.Count => x.Count