### PR TITLE
Adding Serbian and Bosnian languages.

### DIFF
--- a/src/FluentValidation.Tests/LanguageManagerTests.cs
+++ b/src/FluentValidation.Tests/LanguageManagerTests.cs
@@ -15,6 +15,28 @@
 			_languages = new LanguageManager();
 		}
 
+		[Theory]
+		[InlineData("bs")]
+		[InlineData("bs-Latn")]
+		[InlineData("bs-Latn-BA")]
+		public void Gets_translation_for_bosnian_latin_culture(string cultureName) {
+			using (new CultureScope(cultureName)) {
+				var msg = _languages.GetStringForValidator<NotNullValidator>();
+				msg.ShouldEqual("'{PropertyName}' ne smije biti prazan.");
+			}
+		}
+
+		[Theory]
+		[InlineData("sr")]
+		[InlineData("sr-Latn")]
+		[InlineData("sr-Latn-RS")]
+		public void Gets_translation_for_serbian_culture(string cultureName) {
+			using (new CultureScope(cultureName)) {
+				var msg = _languages.GetStringForValidator<NotNullValidator>();
+				msg.ShouldEqual("'{PropertyName}' ne smije biti prazan.");
+			}
+		}
+
 		[Fact]
 		public void Gets_translation_for_culture() {
 			using (new CultureScope("fr")) {

--- a/src/FluentValidation/Resources/LanguageManager.cs
+++ b/src/FluentValidation/Resources/LanguageManager.cs
@@ -21,10 +21,7 @@
 namespace FluentValidation.Resources {
 	using System;
 	using System.Collections.Concurrent;
-	using System.Collections.Generic;
 	using System.Globalization;
-	using System.Linq;
-	using Languages;
 
 	/// <summary>
 	/// Allows the default error message translations to be managed.
@@ -47,7 +44,6 @@ namespace FluentValidation.Resources {
 				ArabicLanguage.Culture => ArabicLanguage.GetTranslation(key),
 				BengaliLanguage.Culture => BengaliLanguage.GetTranslation(key),
 				BosnianLanguage.Culture => BosnianLanguage.GetTranslation(key),
-				BosnianLanguage.LatinCulture => BosnianLanguage.GetTranslation(key),
 				ChineseSimplifiedLanguage.Culture => ChineseSimplifiedLanguage.GetTranslation(key),
 				ChineseTraditionalLanguage.Culture => ChineseTraditionalLanguage.GetTranslation(key),
 				CroatianLanguage.Culture => CroatianLanguage.GetTranslation(key),
@@ -79,7 +75,6 @@ namespace FluentValidation.Resources {
 				SlovenianLanguage.Culture => SlovenianLanguage.GetTranslation(key),
 				SpanishLanguage.Culture => SpanishLanguage.GetTranslation(key),
 				SerbianLanguage.Culture => SerbianLanguage.GetTranslation(key),
-				SerbianLanguage.LatinCulture => SerbianLanguage.GetTranslation(key),
 				SwedishLanguage.Culture => SwedishLanguage.GetTranslation(key),
 				TurkishLanguage.Culture => TurkishLanguage.GetTranslation(key),
 				UkrainianLanguage.Culture => UkrainianLanguage.GetTranslation(key),
@@ -122,9 +117,11 @@ namespace FluentValidation.Resources {
 				value = _languages.GetOrAdd(currentCultureKey, k => GetTranslation(culture.Name, key));
 
 				// If the value couldn't be found, try the parent culture.
-				if (value == null && !culture.IsNeutralCulture) {
-					string parentCultureKey = culture.Parent.Name + ":" + key;
-					value = _languages.GetOrAdd(parentCultureKey, k => GetTranslation(culture.Parent.Name, key));
+				var currentCulture = culture;
+				while (value == null && currentCulture.Parent != CultureInfo.InvariantCulture) {
+					currentCulture = currentCulture.Parent;
+					string parentCultureKey = currentCulture.Name + ":" + key;
+					value = _languages.GetOrAdd(parentCultureKey, k => GetTranslation(currentCulture.Name, key));
 				}
 
 				if (value == null && culture.Name != EnglishLanguage.Culture) {

--- a/src/FluentValidation/Resources/LanguageManager.cs
+++ b/src/FluentValidation/Resources/LanguageManager.cs
@@ -24,6 +24,7 @@ namespace FluentValidation.Resources {
 	using System.Collections.Generic;
 	using System.Globalization;
 	using System.Linq;
+	using Languages;
 
 	/// <summary>
 	/// Allows the default error message translations to be managed.
@@ -45,6 +46,8 @@ namespace FluentValidation.Resources {
 				AlbanianLanguage.Culture => AlbanianLanguage.GetTranslation(key),
 				ArabicLanguage.Culture => ArabicLanguage.GetTranslation(key),
 				BengaliLanguage.Culture => BengaliLanguage.GetTranslation(key),
+				BosnianLanguage.Culture => BosnianLanguage.GetTranslation(key),
+				BosnianLanguage.LatinCulture => BosnianLanguage.GetTranslation(key),
 				ChineseSimplifiedLanguage.Culture => ChineseSimplifiedLanguage.GetTranslation(key),
 				ChineseTraditionalLanguage.Culture => ChineseTraditionalLanguage.GetTranslation(key),
 				CroatianLanguage.Culture => CroatianLanguage.GetTranslation(key),
@@ -75,6 +78,8 @@ namespace FluentValidation.Resources {
 				SlovakLanguage.Culture => SlovakLanguage.GetTranslation(key),
 				SlovenianLanguage.Culture => SlovenianLanguage.GetTranslation(key),
 				SpanishLanguage.Culture => SpanishLanguage.GetTranslation(key),
+				SerbianLanguage.Culture => SerbianLanguage.GetTranslation(key),
+				SerbianLanguage.LatinCulture => SerbianLanguage.GetTranslation(key),
 				SwedishLanguage.Culture => SwedishLanguage.GetTranslation(key),
 				TurkishLanguage.Culture => TurkishLanguage.GetTranslation(key),
 				UkrainianLanguage.Culture => UkrainianLanguage.GetTranslation(key),

--- a/src/FluentValidation/Resources/Languages/BosnianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/BosnianLanguage.cs
@@ -20,12 +20,11 @@
 
 #pragma warning disable 618
 
-namespace FluentValidation.Resources.Languages {
+namespace FluentValidation.Resources {
 	using Validators;
 
 	internal class BosnianLanguage {
 		public const string Culture = "bs";
-		public const string LatinCulture = "bs-Latn";
 
 		public static string GetTranslation(string key) => key switch {
 			nameof(EmailValidator) => "'{PropertyName}' nije validna email adresa.",

--- a/src/FluentValidation/Resources/Languages/BosnianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/BosnianLanguage.cs
@@ -1,0 +1,63 @@
+﻿#region License
+
+// Copyright (c) .NET Foundation and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/FluentValidation/FluentValidation
+
+#endregion
+
+#pragma warning disable 618
+
+namespace FluentValidation.Resources.Languages {
+	using Validators;
+
+	internal class BosnianLanguage {
+		public const string Culture = "bs";
+		public const string LatinCulture = "bs-Latn";
+
+		public static string GetTranslation(string key) => key switch {
+			nameof(EmailValidator) => "'{PropertyName}' nije validna email adresa.",
+			nameof(GreaterThanOrEqualValidator) => "'{PropertyName}' mora biti veće ili jednako '{ComparisonValue}'.",
+			nameof(GreaterThanValidator) => "'{PropertyName}' mora biti veće od '{ComparisonValue}'.",
+			nameof(LengthValidator) => "'{PropertyName}' mora imati između {MinLength} i {MaxLength} karatkera. Uneseno je {TotalLength} karaktera.",
+			nameof(MinimumLengthValidator) => "'{PropertyName}' mora imati najmanje {MinLength} karaktera. Uneseno je {TotalLength} karaktera.",
+			nameof(MaximumLengthValidator) => "'{PropertyName}' ne smije imati više od {MaxLength} karaktera. Uneseno je {TotalLength} karaktera.",
+			nameof(LessThanOrEqualValidator) => "'{PropertyName}' mora biti manje ili jednako '{ComparisonValue}'.",
+			nameof(LessThanValidator) => "'{PropertyName}' mora biti manje od '{ComparisonValue}'.",
+			nameof(NotEmptyValidator) => "'{PropertyName}' ne smije biti prazan.",
+			nameof(NotEqualValidator) => "'{PropertyName}' ne smije biti jednak '{ComparisonValue}'.",
+			nameof(NotNullValidator) => "'{PropertyName}' ne smije biti prazan.",
+			nameof(PredicateValidator) => "Zadan uslov nije ispunjen za '{PropertyName}'.",
+			nameof(AsyncPredicateValidator) => "Zadan uslov nije ispunjen za '{PropertyName}'.",
+			nameof(RegularExpressionValidator) => "'{PropertyName}' nije u odgovarajućem formatu.",
+			nameof(EqualValidator) => "'{PropertyName}' mora biti jednak '{ComparisonValue}'.",
+			nameof(ExactLengthValidator) => "'{PropertyName}' mora imati tačno {MaxLength} karaktera. Uneseno je {TotalLength} karaktera.",
+			nameof(InclusiveBetweenValidator) => "'{PropertyName}' mora biti između {From} i {To}. Uneseno je {Value}.",
+			nameof(ExclusiveBetweenValidator) => "'{PropertyName}' mora biti između {From} i {To} (ekskluzivno). Uneseno je {Value}.",
+			nameof(CreditCardValidator) => "'{PropertyName}' nije validna kreditna kartica.",
+			nameof(ScalePrecisionValidator) => "'{PropertyName}' ne smije imati više od {ExpectedPrecision} cifara, sa dozvoljenih {ExpectedScale} decimalnih mjesta. Uneseno je {Digits} cifara i {ActualScale} decimalnih mjesta.",
+			nameof(EmptyValidator) => "'{PropertyName}' mora biti prazno.",
+			nameof(NullValidator) => "'{PropertyName}' mora biti prazno.",
+			nameof(EnumValidator) => "'{PropertyName}' ima raspon vrijednosti koji ne uključuje '{PropertyValue}'.",
+			// Additional fallback messages used by clientside validation integration.
+			"Length_Simple" => "'{PropertyName}' mora imati između {MinLength} i {MaxLength} karaktera.",
+			"MinimumLength_Simple" => "'{PropertyName}' mora imati najmanje {MinLength} karaktera.",
+			"MaximumLength_Simple" => "'{PropertyName}' ne smije imati više od {MaxLength} karaktera.",
+			"ExactLength_Simple" => "'{PropertyName}' mora imati tačno {MaxLength} karaktera.",
+			"InclusiveBetween_Simple" => "'{PropertyName}' mora biti između {From} i {To}.",
+			_ => null,
+		};
+	}
+}

--- a/src/FluentValidation/Resources/Languages/SerbianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/SerbianLanguage.cs
@@ -1,0 +1,63 @@
+﻿#region License
+
+// Copyright (c) .NET Foundation and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/FluentValidation/FluentValidation
+
+#endregion
+
+#pragma warning disable 618
+
+namespace FluentValidation.Resources.Languages {
+	using Validators;
+
+	internal class SerbianLanguage {
+		public const string Culture = "sr";
+		public const string LatinCulture = "sr-Latn";
+
+		public static string GetTranslation(string key) => key switch {
+			nameof(EmailValidator) => "'{PropertyName}' nije validna email adresa.",
+			nameof(GreaterThanOrEqualValidator) => "'{PropertyName}' mora biti veće ili jednako '{ComparisonValue}'.",
+			nameof(GreaterThanValidator) => "'{PropertyName}' mora biti veće od '{ComparisonValue}'.",
+			nameof(LengthValidator) => "'{PropertyName}' mora imati između {MinLength} i {MaxLength} karatkera. Uneseno je {TotalLength} karaktera.",
+			nameof(MinimumLengthValidator) => "'{PropertyName}' mora imati najmanje {MinLength} karaktera. Uneseno je {TotalLength} karaktera.",
+			nameof(MaximumLengthValidator) => "'{PropertyName}' ne smije imati više od {MaxLength} karaktera. Uneseno je {TotalLength} karaktera.",
+			nameof(LessThanOrEqualValidator) => "'{PropertyName}' mora biti manje ili jednako '{ComparisonValue}'.",
+			nameof(LessThanValidator) => "'{PropertyName}' mora biti manje od '{ComparisonValue}'.",
+			nameof(NotEmptyValidator) => "'{PropertyName}' ne smije biti prazan.",
+			nameof(NotEqualValidator) => "'{PropertyName}' ne smije biti jednak '{ComparisonValue}'.",
+			nameof(NotNullValidator) => "'{PropertyName}' ne smije biti prazan.",
+			nameof(PredicateValidator) => "Zadan uslov nije ispunjen za '{PropertyName}'.",
+			nameof(AsyncPredicateValidator) => "Zadan uslov nije ispunjen za '{PropertyName}'.",
+			nameof(RegularExpressionValidator) => "'{PropertyName}' nije u odgovarajućem formatu.",
+			nameof(EqualValidator) => "'{PropertyName}' mora biti jednak '{ComparisonValue}'.",
+			nameof(ExactLengthValidator) => "'{PropertyName}' mora imati tačno {MaxLength} karaktera. Uneseno je {TotalLength} karaktera.",
+			nameof(InclusiveBetweenValidator) => "'{PropertyName}' mora biti između {From} i {To}. Uneseno je {Value}.",
+			nameof(ExclusiveBetweenValidator) => "'{PropertyName}' mora biti između {From} i {To} (ekskluzivno). Uneseno je {Value}.",
+			nameof(CreditCardValidator) => "'{PropertyName}' nije validna kreditna kartica.",
+			nameof(ScalePrecisionValidator) => "'{PropertyName}' ne smije imati više od {ExpectedPrecision} cifara, sa dozvoljenih {ExpectedScale} decimalnih mjesta. Uneseno je {Digits} cifara i {ActualScale} decimalnih mjesta.",
+			nameof(EmptyValidator) => "'{PropertyName}' mora biti prazno.",
+			nameof(NullValidator) => "'{PropertyName}' mora biti prazno.",
+			nameof(EnumValidator) => "'{PropertyName}' ima raspon vrijednosti koji ne uključuje '{PropertyValue}'.",
+			// Additional fallback messages used by clientside validation integration.
+			"Length_Simple" => "'{PropertyName}' mora imati između {MinLength} i {MaxLength} karaktera.",
+			"MinimumLength_Simple" => "'{PropertyName}' mora imati najmanje {MinLength} karaktera.",
+			"MaximumLength_Simple" => "'{PropertyName}' ne smije imati više od {MaxLength} karaktera.",
+			"ExactLength_Simple" => "'{PropertyName}' mora imati tačno {MaxLength} karaktera.",
+			"InclusiveBetween_Simple" => "'{PropertyName}' mora biti između {From} i {To}.",
+			_ => null,
+		};
+	}
+}

--- a/src/FluentValidation/Resources/Languages/SerbianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/SerbianLanguage.cs
@@ -20,12 +20,11 @@
 
 #pragma warning disable 618
 
-namespace FluentValidation.Resources.Languages {
+namespace FluentValidation.Resources {
 	using Validators;
 
 	internal class SerbianLanguage {
 		public const string Culture = "sr";
-		public const string LatinCulture = "sr-Latn";
 
 		public static string GetTranslation(string key) => key switch {
 			nameof(EmailValidator) => "'{PropertyName}' nije validna email adresa.",


### PR DESCRIPTION
Adding Serbian and Bosnian language support. Languages registered in **LanguageManager** using multiple cultures to support finding them by parent, in case when the culture is **bs-Latn-BA** or **sr-Latn-SR**. 