### PR TITLE
Introduce new syntax for Transform, deprecate the old version

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,6 @@
+9.5.0 - 31 January 2021
+Introduce new syntax for applying transformations and deprecate the old syntax (#1613)
+
 9.4.0 - 14 January 2021
 ChildRules now work as expected when inside a ruleset (#1597)
 Added ImplicitlyValidateRootCollectionElements option to MVC integration (#1585)

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -1,7 +1,34 @@
 # Transforming Values
 
-As of FluentValidation 9.0, you can use the `Transform` method to transform a property value prior to validation being performed against it. For example, if you have property of type `string` that atually contains numeric input, you could use `Transform` to convert the string value to a number. 
+As of FluentValidation 9.5, you can apply a transformation to a property value prior to validation being performed against it. For example, if you have property of type `string` that actually contains numeric input, you could apply a transformation to convert the string value to a number.
 
+
+```csharp
+Transform(from: x => x.SomeStringProperty, to: value => int.TryParse(value, out int val) ? (int?) val : null)
+    .GreaterThan(10);
+```
+
+This rule transforms the value from a `string` to an nullable `int` (returning `null` if the value couldn't be converted). A greater-than check is then performed on the resulting value.
+
+Syntactically this is not particularly nice to read, so the logic for the transformation can optionally be moved into a separate method:
+
+```csharp
+Transform(x => x.SomeStringProperty, StringToNullableInt)
+    .GreaterThan(10);
+
+int? StringToNullableInt(string value)
+  => int.TryParse(value, out int val) ? (int?) val : null;
+
+```
+
+This syntax is available in FluentValidation 9.5 and newer.
+
+There is also a `TransformForEach` method available, which performs the transformation against each item in a collection.
+
+
+# Transforming Values (9.0 - 9.4)
+
+Prior to FluentValidation 9.5, you can use the `Transform` method after a call to `RuleFor` to achieve the same result.
 
 ```csharp
 RuleFor(x => x.SomeStringProperty)
@@ -9,28 +36,4 @@ RuleFor(x => x.SomeStringProperty)
     .GreaterThan(10);
 ```
 
-This rule transforms the value from a `string` to an nullable `int` (returning `null` if the value couldn't be converted). A greater-than check is then performed on the resulting value. 
-
-Syntactically this is not particularly nice to read, so this can be cleaned up by using an extension method:
-
-```csharp
-public static class ValidationExtensions {
-	public static IRuleBuilder<T, int?> TransformToInt<T>(this IRuleBuilderInitial<T, string> ruleBuilder) {
-		return ruleBuilder.Transform(value => int.TryParse(value, out int val) ? (int?) val : null);
-	} 
-}
-```
-
-The rule can then be written as:
-
-```csharp
-RuleFor(x => x.SomeStringProperty)
-    .TransformToInt()
-    .GreaterThan(10);
-```
-
-
-```eval_rst
-.. note::
-  FluentValidation 8.x supported a limited version of the Transform method that could only be used to perform transformations on the same type (e.g., if the property is a string, the result of the transformation must also be a string). FluentValidation 9.0 allows transformations to be performed that change the type.
-```
+This `Transform` method is marked as obsolete as of FluentValidation 9.5 and is removed in FluentValidation 10.0. In newer versions of FluentValidation the transformation should be applied by calling `Transform` as the first method in the chain (see above).

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>9.4.0</VersionPrefix>
+    <VersionPrefix>9.5.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <!-- Use CI build number as version suffix (if defined) -->
     <!--<VersionSuffix Condition="'$(GITHUB_RUN_NUMBER)'!=''">ci-$(GITHUB_RUN_NUMBER)</VersionSuffix>-->

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -5,6 +5,9 @@
     <PackageReleaseNotes>
 FluentValidation 9 is a major release. Please read the upgrade notes at https://docs.fluentvalidation.net/en/latest/upgrading-to-9.html
 
+Changes in 9.5.0:
+* Introduce new syntax for applying transformations and deprecate the old syntax
+
 Changes in 9.4.0:
 * ChildRules now work as expected when inside a ruleset
 * Added ImplicitlyValidateRootCollectionElements option to MVC integration

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -188,6 +188,32 @@ namespace FluentValidation.Internal {
 		}
 
 		/// <summary>
+		/// Creates a new property rule from a lambda expression.
+		/// </summary>
+		internal static PropertyRule Create<T, TProperty, TTransformed>(Expression<Func<T, TProperty>> expression, Func<TProperty, TTransformed> transformer, Func<CascadeMode> cascadeModeThunk, bool bypassCache = false) {
+			var member = expression.GetMember();
+			var compiled = AccessorCache<T>.GetCachedAccessor(member, expression, bypassCache);
+
+			object PropertyFunc(object instance)
+				=> transformer(compiled((T)instance));
+
+			return new PropertyRule(member, PropertyFunc, expression, cascadeModeThunk, typeof(TProperty), typeof(T));
+		}
+
+		/// <summary>
+		/// Creates a new property rule from a lambda expression.
+		/// </summary>
+		internal static PropertyRule Create<T, TProperty, TTransformed>(Expression<Func<T, TProperty>> expression, Func<T, TProperty, TTransformed> transformer, Func<CascadeMode> cascadeModeThunk, bool bypassCache = false) {
+			var member = expression.GetMember();
+			var compiled = AccessorCache<T>.GetCachedAccessor(member, expression, bypassCache);
+
+			object PropertyFunc(object instance)
+				=> transformer((T)instance, compiled((T)instance));
+
+			return new PropertyRule(member, PropertyFunc, expression, cascadeModeThunk, typeof(TProperty), typeof(T));
+		}
+
+		/// <summary>
 		/// Adds a validator to the rule.
 		/// </summary>
 		public void AddValidator(IPropertyValidator validator) {
@@ -241,6 +267,7 @@ namespace FluentValidation.Internal {
 		/// </summary>
 		public List<IValidationRule> DependentRules { get; }
 
+		[Obsolete("This property will be removed in FluentValidation 10")]
 		public Func<object, object> Transformer { get; set; }
 
 		/// <summary>
@@ -499,7 +526,9 @@ namespace FluentValidation.Internal {
 		/// <returns>The value to be validated</returns>
 		internal virtual object GetPropertyValue(object instanceToValidate) {
 			var value = PropertyFunc(instanceToValidate);
+#pragma warning disable 618
 			if (Transformer != null) value = Transformer(value);
+#pragma warning restore 618
 			return value;
 		}
 

--- a/src/FluentValidation/Internal/RuleBuilder.cs
+++ b/src/FluentValidation/Internal/RuleBuilder.cs
@@ -122,6 +122,7 @@ namespace FluentValidation.Internal {
 			return this;
 		}
 
+		[Obsolete("Use RuleFor(x => x.Property, transformer) instead. This method will be removed in FluentValidation 10.")]
 		public IRuleBuilderInitial<T, TNew> Transform<TNew>(Func<TProperty, TNew> transformationFunc) {
 			if (transformationFunc == null) throw new ArgumentNullException(nameof(transformationFunc));
 			Rule.Transformer = transformationFunc.CoerceToNonGeneric();

--- a/src/FluentValidation/Syntax.cs
+++ b/src/FluentValidation/Syntax.cs
@@ -35,6 +35,7 @@ namespace FluentValidation {
 		/// <typeparam name="TNew"></typeparam>
 		/// <param name="transformationFunc"></param>
 		/// <returns></returns>
+		[Obsolete("Use RuleFor(x => x.Property, transformer) instead. This method will be removed in FluentValidation 10.")]
 		IRuleBuilderInitial<T, TNew> Transform<TNew>(Func<TProperty, TNew> transformationFunc);
 	}
 
@@ -96,6 +97,7 @@ namespace FluentValidation {
 		/// </summary>
 		/// <param name="transformationFunc"></param>
 		/// <returns></returns>
+		[Obsolete("Use RuleFor(x => x.Property, transformer) instead. This method will be removed in FluentValidation 10.")]
 		IRuleBuilderInitial<T, TNew> Transform<TNew>(Func<TElement, TNew> transformationFunc);
 	}
 


### PR DESCRIPTION
Marks the current `Transform` syntax as obsolete, and introduces a new transform syntax as part of the call to RuleFor. 

Old:
```csharp
RuleFor(x => x.SomeInt).Transform(i => i.ToString()).NotEqual("0");
```

New:
```csharp
Transform(from: x => x.SomeInt, to: i => i.ToString()).NotEqual("0");
```

There is also a `TransformForEach` method available (equivalent of the old `RuleForEach(expr).Transform(transformer)`)

This change is needed as we're moving to generics in the internal API for FluentValidation 10, which means transforming the type will no longer be possible after rules have been created. 

The old syntax should be deprecated in the next 9.x release, and removed in 10.0. 