### PR TITLE
FluentValidation namespace explanation in RuleSet doc page

### DIFF
--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -25,6 +25,11 @@ var person = new Person();
 var result = validator.Validate(person, options => options.IncludeRuleSets("Names"));
 ```
 
+```eval_rst
+.. note::
+  Many of the methods in FluentValidation are extension methods such as "Validate" above and require the FluentValidation namespace to be imported via an using statement, e.g. "using FluentValidation;". 
+```
+
 This allows you to break down a complex validator definition into smaller segments that can be executed in isolation. If you call `Validate` without passing a ruleset then only rules not in a RuleSet will be executed.
 
 You can execute multiple rulesets by passing multiple ruleset names to `IncludeRuleSets`:


### PR DESCRIPTION
The issue for more details: https://github.com/FluentValidation/FluentValidation/issues/1617#issuecomment-763958776

I put a note tag below of the first example so anyone can realize they have to declare the namespace to the method with ```options``` overload to work.