### PR TITLE
Add test-reporter CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,12 @@ jobs:
       shell: pwsh
       env:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+
+    - name: Create test report
+      if: success() || failure()
+      uses: dorny/test-reporter@v1
+      with:
+        name: Test results (${{ matrix.os }})
+        path: src/**/TestResults/*.trx
+        reporter: dotnet-trx
+        list-tests: failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
 
     - name: Create test report
-      if: success() || failure()
+      if: failure()
       uses: dorny/test-reporter@v1
       with:
         name: Test results (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,8 @@ jobs:
       env:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
 
-    - name: Create test report
-      if: failure()
-      uses: dorny/test-reporter@v1
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
       with:
-        name: Test results (${{ matrix.os }})
+        name: test-results-${{ matrix.os }}
         path: src/**/TestResults/*.trx
-        reporter: dotnet-trx
-        list-tests: failed

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -1,0 +1,19 @@
+name: Test Report
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  report:
+    runs-on: 'ubuntu-20.04'
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: /test-results-(.*)/
+        name: Test Report $1
+        path: '**/*.trx'
+        reporter: dotnet-trx
+        list-tests: failed

--- a/build.ps1
+++ b/build.ps1
@@ -27,7 +27,7 @@ target compile {
 }
 
 target test {
-  Invoke-Dotnet test $solution_file -c $configuration --no-build --logger trx
+  Invoke-Dotnet test $solution_file -c $configuration --no-build
 }
 
 target deploy {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,6 +17,7 @@
     <NeutralLanguage>en</NeutralLanguage>
     <AssemblyOriginatorKeyFile>$(MSBuildProjectDirectory)/../FluentValidation-Release.snk</AssemblyOriginatorKeyFile>
     <PackageOutputPath>$(MSBuildProjectDirectory)/../../.build/packages</PackageOutputPath>
+    <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName)-$(TargetFramework).trx</VSTestLogger>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\logo\fluent-validation-icon.png" Pack="true" PackagePath="" />


### PR DESCRIPTION
This PR:
1. Configures test results filename to `$(MSBuildProjectName)-$(TargetFramework).trx`
1. Adds CI step [test-reporter](https://github.com/dorny/test-reporter) to display report from test results 

Here you can see how it looks for:
 - [Failed build](https://github.com/dorny/FluentValidation/runs/1802163806?check_suite_focus=true)
 - [Successful build](https://github.com/dorny/FluentValidation/runs/1809435942?check_suite_focus=true)

Edit:
It's configured to run only when previous step (e.g. tests) already failed so it wouldn't affect successful builds at all.

Compared to scrolling through build step logs this action makes it somewhat easier to see which tests failed and why. It's useful mostly when test fails only in CI environment.

I created [test-reporter](https://github.com/dorny/test-reporter) mostly for my own needs but I would be glad if others found it useful too. During development I test it against few randomly picked popular OSS projects. FluentValidation was one of them so basically that's why I'm creating this PR now when the action hit 1.0 version.