### PR TITLE
Updating Extensions string extension method SplitPascalCase to not return a singular delimiting period.

### DIFF
--- a/src/FluentValidation.Tests/AbstractValidatorTester.cs
+++ b/src/FluentValidation.Tests/AbstractValidatorTester.cs
@@ -348,6 +348,15 @@ namespace FluentValidation.Tests {
 			Assert.Contains(testMessage, result.Errors.Select(failure => failure.ErrorMessage));
 		}
 
+		[Fact]
+		public void PropertyName_Dispays_Correctly_In_Messages_For_Properties_With_Periods() {
+			validator.RuleFor(x => x.Address.Line1).NotNull().WithMessage("{PropertyName}");
+
+			var validationResult = validator.Validate(new Person { Address = new Address() });
+
+			validationResult.Errors.First().ErrorMessage.ShouldEqual("Address Line1");
+		}
+
 		public static TheoryData<ValidationResult> PreValidationReturnValueTheoryData = new TheoryData<ValidationResult> {
 			new ValidationResult(),
 			new ValidationResult(new List<ValidationFailure> {new ValidationFailure(nameof(Person.AnotherInt), $"{nameof(Person.AnotherInt)} Test Message")})

--- a/src/FluentValidation.Tests/ExtensionTester.cs
+++ b/src/FluentValidation.Tests/ExtensionTester.cs
@@ -41,18 +41,25 @@ namespace FluentValidation.Tests {
 		[Fact]
 		public void Should_split_pascal_cased_member_name() {
 			var cases = new Dictionary<string, string> {
-				            {"DateOfBirth", "Date Of Birth"},
-				            {"DATEOFBIRTH", "DATEOFBIRTH"},
-				            {"dateOfBirth", "date Of Birth"},
-				            {"dateofbirth", "dateofbirth"},
-							{"Date_Of_Birth", "Date_ Of_ Birth"},
-							{"Name2", "Name2"},
-                           {"ProductID", "Product ID"},
-                           {"MyTVRemote", "My TV Remote"},
-                           {"TVRemote", "TV Remote"},
-                           {"XCopy", "X Copy"},
-                           {"ThisXCopy", "This X Copy"},
-						};
+				{"DateOfBirth", "Date Of Birth"},
+				{"DATEOFBIRTH", "DATEOFBIRTH"},
+				{"dateOfBirth", "date Of Birth"},
+				{"dateofbirth", "dateofbirth"},
+				{"Date_Of_Birth", "Date_ Of_ Birth"},
+				{"Name2", "Name2"},
+				{"ProductID", "Product ID"},
+				{"MyTVRemote", "My TV Remote"},
+				{"TVRemote", "TV Remote"},
+				{"XCopy", "X Copy"},
+				{"ThisXCopy", "This X Copy"},
+				{"Address.Line1", "Address Line1"},
+				{"Address..Line1", "Address. Line1"},
+				{"address.Line1", "address Line1"},
+				{"addressLine1", "address Line1"},
+				{"address.line1", "address.line1"},
+				{"address.line1.", "address.line1."},
+				{"address..line1.", "address..line1."}
+			};
 
 			foreach (var @case in cases) {
 				string name = @case.Key.SplitPascalCase();

--- a/src/FluentValidation/Internal/Extensions.cs
+++ b/src/FluentValidation/Internal/Extensions.cs
@@ -109,8 +109,12 @@ namespace FluentValidation.Internal {
 		}
 
 		/// <summary>
-		/// Splits pascal case, so "FooBar" would become "Foo Bar"
+		/// Splits pascal case, so "FooBar" would become "Foo Bar".  
 		/// </summary>
+		/// <remarks>
+		/// Pascal case strings with periods delimiting the upper case letters,
+		/// such as "Address.Line1", will have the periods removed.  
+		/// </remarks>
 		public static string SplitPascalCase(this string input) {
 			if (string.IsNullOrEmpty(input))
 				return input;
@@ -125,7 +129,11 @@ namespace FluentValidation.Internal {
 						retVal.Append(' ');
 				}
 
-				retVal.Append(currentChar);
+				if (!char.Equals('.', currentChar)
+					|| i + 1 == input.Length
+					|| !char.IsUpper(input[i + 1])) {
+					retVal.Append(currentChar);
+				}
 			}
 
 			return retVal.ToString().Trim();


### PR DESCRIPTION
This stems from [this issue](https://github.com/FluentValidation/FluentValidation/issues/1147).

Some outstanding ideas:
Separating methods. Using `Replace(". ", " ")` after return value is built. Creating a new specific unit test for periods. A test in the AbstractValidatorTests class might not be necessary. What about other special characters?