### PR TITLE
Add netstandard2.0 back in FluentValidation.DependencyInjectionExtensions

### DIFF
--- a/src/FluentValidation.DependencyInjectionExtensions/FluentValidation.DependencyInjectionExtensions.csproj
+++ b/src/FluentValidation.DependencyInjectionExtensions/FluentValidation.DependencyInjectionExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <AssemblyName>FluentValidation.DependencyInjectionExtensions</AssemblyName>
         <PackageId>FluentValidation.DependencyInjectionExtensions</PackageId>
         <Product>FluentValidation.DependencyInjectionExtensions</Product>


### PR DESCRIPTION
Not sure if it was intentional or not, but this project should also support netstandard2.0 as long as the main library does.

And about this thing as a whole. In my opinion dropping support for netstandard2.0 in general is a bit premature.