### PR TITLE
Update sample code: IRuleBuilderInitial -> IRuleBuilderOptionsConditions

### DIFF
--- a/docs/custom-validators.md
+++ b/docs/custom-validators.md
@@ -104,7 +104,7 @@ context.AddFailure(new ValidationFailure("SomeOtherProperty", "The list must con
 As before, this could be wrapped in an extension method to simplify the consuming code.
 
 ```csharp
-public static IRuleBuilderInitial<T, IList<TElement>> ListMustContainFewerThan<T, TElement>(this IRuleBuilder<T, IList<TElement>> ruleBuilder, int num) {
+public static IRuleBuilderOptionsConditions<T, IList<TElement>> ListMustContainFewerThan<T, TElement>(this IRuleBuilder<T, IList<TElement>> ruleBuilder, int num) {
 
   return ruleBuilder.Custom((list, context) => {
      if(list.Count > 10) {


### PR DESCRIPTION
After upgrading to FluentValidation 10.0 I ran into a compilation error, this change appeared to resolve it.

```
[CS0266] Cannot implicitly convert type 'FluentValidation.IRuleBuilderOptionsConditions<T, System.Collections.Generic.IList<TElement>>' to 'FluentValidation.IRuleBuilderInitial<T, System.Collections.Generic.IList<TElement>>'. An explicit conversion exists (are you missing a cast?)
```