### PR TITLE
Throw exceptions when async validator is invoked synchronously

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,6 @@
 11.0.0 -
 Ensure property covariance is properly handled throughout the internal model (#1713)
+Throw exceptions when async validator is invoked synchronously (#1705)
 
 10.2.3 - 3 Jun 2021
 Resolve issue with rulesets not cascading correctly to Inheritance Validators (#1754)

--- a/src/FluentValidation.AspNetCore/FluentValidationModelValidatorProvider.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationModelValidatorProvider.cs
@@ -28,6 +28,7 @@ namespace FluentValidation.AspNetCore {
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 	using Microsoft.Extensions.DependencyInjection;
+	using Results;
 
 	/// <summary>
 	/// ModelValidatorProvider implementation only used for child properties.
@@ -110,7 +111,15 @@ namespace FluentValidation.AspNetCore {
 					context = interceptor.BeforeAspNetValidation(mvContext.ActionContext, context) ?? context;
 				}
 
-				var result = validator.Validate(context);
+
+				ValidationResult result;
+
+				try {
+					result = validator.Validate(context);
+				}
+				catch (AsyncValidatorInvokedSynchronouslyException ex) {
+					throw new AsyncValidatorInvokedSynchronouslyException($"The validator \"{ex.ValidatorType.Name}\" can't be used with ASP.NET automatic validation as it contains asynchronous rules.");
+				}
 
 				if (interceptor != null) {
 					// allow the user to provide a custom collection of failures, which could be empty.

--- a/src/FluentValidation.Tests/ComplexValidationTester.cs
+++ b/src/FluentValidation.Tests/ComplexValidationTester.cs
@@ -134,13 +134,12 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void Async_condition_should_work_with_complex_property_when_validator_invoked_synchronously() {
+		public void Async_condition_throws_when_validator_invoked_synchronously() {
 			var validator = new TestValidator() {
 				v => v.RuleFor(x => x.Address).SetValidator(new AddressValidator()).WhenAsync(async (x, c) => x.Address.Line1 == "foo")
 			};
 
-			var result = validator.Validate(person);
-			result.IsValid.ShouldBeTrue();
+			Assert.Throws<AsyncValidatorInvokedSynchronouslyException>(() => validator.Validate(person));
 		}
 
 		[Fact]

--- a/src/FluentValidation.Tests/ConditionTests.cs
+++ b/src/FluentValidation.Tests/ConditionTests.cs
@@ -106,8 +106,8 @@ namespace FluentValidation.Tests {
 				v => v.RuleFor(x => x.Surname).NotNull().NotEqual("foo").WhenAsync(async (x,c) => x.Id > 0)
 			};
 
-			var result = validator.Validate(new Person());
-			result.Errors.Count.ShouldEqual(0);
+			Assert.Throws<AsyncValidatorInvokedSynchronouslyException>(() =>
+				validator.Validate(new Person()));
 		}
 
 		[Fact]
@@ -144,41 +144,42 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void Async_condition_executed_synchronosuly_with_synchronous_role() {
+		public void Async_condition_throws_when_executed_synchronosuly_with_synchronous_role() {
 			var validator = new TestValidator();
 			validator.RuleFor(x => x.Surname).NotNull()
 				.WhenAsync((x, token) => Task.FromResult(false));
-			var result = validator.Validate(new Person());
-			result.IsValid.ShouldBeTrue();
+
+			Assert.Throws<AsyncValidatorInvokedSynchronouslyException>(() =>
+				validator.Validate(new Person()));
 		}
 
 		[Fact]
-		public void Async_condition_executed_synchronosuly_with_asynchronous_rule() {
+		public void Async_condition_throws_when_executed_synchronosuly_with_asynchronous_rule() {
 			var validator = new TestValidator();
 			validator.RuleFor(x => x.Surname)
 				.MustAsync((surname, c) => Task.FromResult(surname != null))
 				.WhenAsync((x, token) => Task.FromResult(false));
-			var result = validator.Validate(new Person());
-			result.IsValid.ShouldBeTrue();
+
+			Assert.Throws<AsyncValidatorInvokedSynchronouslyException>(() => validator.Validate(new Person()));
 		}
 
 		[Fact]
-		public void Async_condition_executed_synchronosuly_with_synchronous_collection_role() {
+		public void Async_condition_throws_when_executed_synchronosuly_with_synchronous_collection_role() {
 			var validator = new TestValidator();
 			validator.RuleForEach(x => x.NickNames).NotNull()
 				.WhenAsync((x, token) => Task.FromResult(false));
-			var result = validator.Validate(new Person { NickNames = new string[0] });
-			result.IsValid.ShouldBeTrue();
+			Assert.Throws<AsyncValidatorInvokedSynchronouslyException>(() =>
+				validator.Validate(new Person {NickNames = new string[0]}));
 		}
 
 		[Fact]
-		public void Async_condition_executed_synchronosuly_with_asynchronous_collection_rule() {
+		public void Async_condition_throws_when_invoked_synchronosuly_with_asynchronous_collection_rule() {
 			var validator = new TestValidator();
 			validator.RuleForEach(x => x.NickNames)
 				.MustAsync((n, c) => Task.FromResult(n != null))
 				.WhenAsync((x, token) => Task.FromResult(false));
-			var result = validator.Validate(new Person { NickNames = new string[0]});
-			result.IsValid.ShouldBeTrue();
+
+			Assert.Throws<AsyncValidatorInvokedSynchronouslyException>(() => validator.Validate(new Person {NickNames = new string[0]}));
 		}
 
 		[Fact]

--- a/src/FluentValidation.Tests/CustomValidatorTester.cs
+++ b/src/FluentValidation.Tests/CustomValidatorTester.cs
@@ -144,13 +144,13 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void Runs_async_rule_synchronously_when_validator_invoked_synchronously() {
+		public void Throws_when_async_rule_invoked_synchronously() {
 			validator.RuleFor(x => x.Forename).CustomAsync((x, context, cancel) => {
 				context.AddFailure("foo");
 				return Task.CompletedTask;
 			});
-			var result = validator.Validate(new Person());
-			result.Errors.Count.ShouldEqual(1);
+			Assert.Throws<AsyncValidatorInvokedSynchronouslyException>(() =>
+				validator.Validate(new Person()));
 		}
 
 		[Fact]

--- a/src/FluentValidation.Tests/OnFailureTests.cs
+++ b/src/FluentValidation.Tests/OnFailureTests.cs
@@ -125,17 +125,15 @@
 		}
 
 		[Fact]
-		public void WhenAsyncWithOnFailure_should_invoke_condition_on_inner_validator_invoked_synchronously() {
-			bool shouldNotBeTrue = false;
+		public void WhenAsyncWithOnFailure_throws_when_async_condition_on_inner_validator_invoked_synchronously() {
 			var validator = new TestValidator();
 			validator.RuleFor(x => x.Surname)
 				.NotEqual("foo")
 				.WhenAsync((x, token) => Task.FromResult(x.Id > 0))
-				.OnFailure(x => shouldNotBeTrue = true);
+				.OnFailure(x => {});
 
-			var result = validator.Validate(new Person {Id = 0, Surname = "foo"});
-			result.Errors.Count.ShouldEqual(0);
-			shouldNotBeTrue.ShouldBeFalse();
+			Assert.Throws<AsyncValidatorInvokedSynchronouslyException>(() =>
+				validator.Validate(new Person {Id = 0, Surname = "foo"}));
 		}
 
 		[Fact]

--- a/src/FluentValidation.Tests/RuleBuilderTests.cs
+++ b/src/FluentValidation.Tests/RuleBuilderTests.cs
@@ -142,10 +142,12 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void Nullable_object_with_async_condition_should_not_throw() {
+		public async Task Nullable_object_with_async_condition_should_not_throw() {
 			_validator.RuleFor(x => x.NullableInt.Value)
-				.GreaterThanOrEqualTo(3).WhenAsync((x,c) => Task.FromResult(x.NullableInt != null));
-			_validator.Validate(new ValidationContext<Person>(new Person(), new PropertyChain(), new DefaultValidatorSelector()));
+				.GreaterThanOrEqualTo(3)
+				.WhenAsync((x,c) => Task.FromResult(x.NullableInt != null));
+
+			await _validator.ValidateAsync(new ValidationContext<Person>(new Person(), new PropertyChain(), new DefaultValidatorSelector()));
 		}
 
 		[Fact]

--- a/src/FluentValidation.Tests/SharedConditionTests.cs
+++ b/src/FluentValidation.Tests/SharedConditionTests.cs
@@ -115,6 +115,18 @@ namespace FluentValidation.Tests {
 				When(x => x != null, () => {
 					RuleFor(x => x).Must(x => x != "foo");
 				});
+			}
+
+			protected override void EnsureInstanceNotNull(object instanceToValidate) {
+				//bad.
+			}
+		}
+
+		class AsyncBadValidatorDisablesNullCheck : AbstractValidator<string> {
+			public AsyncBadValidatorDisablesNullCheck() {
+				When(x => x != null, () => {
+					RuleFor(x => x).Must(x => x != "foo");
+				});
 
 				WhenAsync(async (x, ct) => x != null, () => {
 					RuleFor(x => x).Must(x => x != "foo");
@@ -125,6 +137,7 @@ namespace FluentValidation.Tests {
 				//bad.
 			}
 		}
+
 
 		[Fact]
 		public void Shared_When_is_not_applied_to_grouped_rules_when_initial_predicate_is_false() {
@@ -416,14 +429,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void Executes_custom_rule_when_async_condition_true() {
+		public async Task Executes_custom_rule_when_async_condition_true() {
 			var validator = new TestValidator();
 			validator.WhenAsync(async (x,c) =>(true), () => {
 				validator.RuleFor(x=>x).Custom((x,ctx) => ctx.AddFailure(new ValidationFailure("foo", "bar")));
 
 			});
 
-			var result = validator.Validate(new Person());
+			var result = await validator.ValidateAsync(new Person());
 			result.IsValid.ShouldBeFalse();
 		}
 
@@ -459,14 +472,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void Nested_async_conditions_with_Custom_rule() {
+		public async Task Nested_async_conditions_with_Custom_rule() {
 			var validator = new TestValidator();
 			validator.When(x => true, () => {
 				validator.WhenAsync(async (x,c) =>(false), () => {
 					validator.RuleFor(x=>x).Custom((x,ctx) => ctx.AddFailure(new ValidationFailure("Custom", "The validation failed")));
 				});
 			});
-			var result = validator.Validate(new Person());
+			var result = await validator.ValidateAsync(new Person());
 			result.IsValid.ShouldBeTrue();
 		}
 
@@ -667,7 +680,7 @@ namespace FluentValidation.Tests {
 
 		[Fact]
 		public async Task Doesnt_throw_NullReferenceException_when_instance_not_null_async() {
-			var v = new BadValidatorDisablesNullCheck();
+			var v = new AsyncBadValidatorDisablesNullCheck();
 			var result = await v.ValidateAsync((string) null);
 			result.IsValid.ShouldBeTrue();
 		}

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -93,16 +93,21 @@ namespace FluentValidation {
 
 			EnsureInstanceNotNull(context.InstanceToValidate);
 
-			foreach (var rule in Rules) {
-				rule.Validate(context);
+			try {
+				foreach (var rule in Rules) {
+					rule.Validate(context);
 
-				if (CascadeMode == CascadeMode.Stop && result.Errors.Count > 0) {
-					// Bail out if we're "failing-fast".
-					// Check for > 0 rather than == 1 because a rule chain may have overridden the Stop behaviour to Continue
-					// meaning that although the first rule failed, it actually generated 2 failures if there were 2 validators
-					// in the chain.
-					break;
+					if (CascadeMode == CascadeMode.Stop && result.Errors.Count > 0) {
+						// Bail out if we're "failing-fast".
+						// Check for > 0 rather than == 1 because a rule chain may have overridden the Stop behaviour to Continue
+						// meaning that although the first rule failed, it actually generated 2 failures if there were 2 validators
+						// in the chain.
+						break;
+					}
 				}
+			}
+			catch (AsyncValidatorInvokedSynchronouslyException) {
+				throw new AsyncValidatorInvokedSynchronouslyException(GetType());
 			}
 
 			SetExecutedRulesets(result, context);

--- a/src/FluentValidation/AsyncValidatorInvokedSynchronouslyException.cs
+++ b/src/FluentValidation/AsyncValidatorInvokedSynchronouslyException.cs
@@ -1,0 +1,39 @@
+#region License
+// Copyright (c) .NET Foundation and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/FluentValidation/FluentValidation
+#endregion
+
+namespace FluentValidation {
+	using System;
+
+	/// <summary>
+	/// This exception is thrown when an asynchronous validator is executed synchronously.
+	/// </summary>
+	public class AsyncValidatorInvokedSynchronouslyException : InvalidOperationException {
+		public Type ValidatorType { get; }
+
+		internal AsyncValidatorInvokedSynchronouslyException() {
+		}
+
+		internal AsyncValidatorInvokedSynchronouslyException(Type validatorType)
+			: base($"Validator \"{validatorType.Name}\" contains asynchronous rules but was invoked synchronously. Please call ValidateAsync rather than Validate.") {
+			ValidatorType = validatorType;
+		}
+
+		internal AsyncValidatorInvokedSynchronouslyException(string message) : base(message) {
+		}
+	}
+}

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -115,9 +115,7 @@ namespace FluentValidation.Internal {
 			}
 
 			if (AsyncCondition != null) {
-				if (! AsyncCondition(context, default).GetAwaiter().GetResult()) {
-					return;
-				}
+				throw new AsyncValidatorInvokedSynchronouslyException();
 			}
 
 			var filteredValidators = GetValidatorsToExecute(context);
@@ -165,7 +163,7 @@ namespace FluentValidation.Internal {
 					foreach (var validator in filteredValidators) {
 						context.MessageFormatter.Reset();
 						if (validator.ShouldValidateAsynchronously(context)) {
-							InvokePropertyValidatorAsync(context, valueToValidate, propertyNameToValidate, validator, index, default).GetAwaiter().GetResult();
+							throw new AsyncValidatorInvokedSynchronouslyException();
 						}
 						else {
 							InvokePropertyValidator(context, valueToValidate, propertyNameToValidate, validator, index);
@@ -229,9 +227,7 @@ namespace FluentValidation.Internal {
 			}
 
 			if (AsyncCondition != null) {
-				if (! AsyncCondition(context, default).GetAwaiter().GetResult()) {
-					return;
-				}
+				throw new AsyncValidatorInvokedSynchronouslyException();
 			}
 
 			var filteredValidators = await GetValidatorsToExecuteAsync(context, cancellation);
@@ -335,9 +331,7 @@ namespace FluentValidation.Internal {
 				}
 
 				if (component.HasAsyncCondition) {
-					if (!component.InvokeAsyncCondition(context, default).GetAwaiter().GetResult()) {
-						validators.Remove(component);
-					}
+					throw new AsyncValidatorInvokedSynchronouslyException();
 				}
 			}
 

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -99,9 +99,7 @@ namespace FluentValidation.Internal {
 			}
 
 			if (AsyncCondition != null) {
-				if (!AsyncCondition(context, default).GetAwaiter().GetResult()) {
-					return;
-				}
+				throw new AsyncValidatorInvokedSynchronouslyException();
 			}
 
 			var cascade = CascadeMode;
@@ -117,12 +115,12 @@ namespace FluentValidation.Internal {
 					continue;
 				}
 
-				if (step.HasAsyncCondition && !step.InvokeAsyncCondition(context, CancellationToken.None).GetAwaiter().GetResult()) {
-					continue;
+				if (step.HasAsyncCondition) {
+					throw new AsyncValidatorInvokedSynchronouslyException();
 				}
 
 				if (step.ShouldValidateAsynchronously(context)) {
-					InvokePropertyValidatorAsync(context, accessor, propertyName, step, default).GetAwaiter().GetResult();
+					throw new AsyncValidatorInvokedSynchronouslyException();
 				}
 				else {
 					InvokePropertyValidator(context, accessor, propertyName, step);

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -175,7 +175,14 @@ namespace FluentValidation.TestHelper {
 		/// </summary>
 		public static TestValidationResult<T> TestValidate<T>(this IValidator<T> validator, T objectToTest, Action<ValidationStrategy<T>> options = null) where T : class {
 			options ??= _ => { };
-			var validationResult = validator.Validate(objectToTest, options);
+			ValidationResult validationResult;
+			try {
+				validationResult = validator.Validate(objectToTest, options);
+			}
+			catch (AsyncValidatorInvokedSynchronouslyException ex) {
+				throw new AsyncValidatorInvokedSynchronouslyException(ex.ValidatorType.Name + " contains asynchronous rules - please use the asynchronous test methods instead.");
+			}
+
 			return new TestValidationResult<T>(validationResult);
 		}
 


### PR DESCRIPTION
This is part of #1705.

Throws an exception if a validator with async rules or conditions is invoked synchronously