### PR TITLE
Extend property covariance into the internal model.

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,6 @@
+11.0.0 -
+Ensure property covariance is properly handled throughout the internal model (#1713)
+
 10.2.3 - 3 Jun 2021
 Resolve issue with rulesets not cascading correctly to Inheritance Validators (#1754)
 

--- a/src/FluentValidation.Tests/CustomMessageFormatTester.cs
+++ b/src/FluentValidation.Tests/CustomMessageFormatTester.cs
@@ -37,12 +37,12 @@ namespace FluentValidation.Tests {
 			validator.RuleFor(x => x.Surname).NotNull().WithMessage("{PropertyName}");
 			string error = validator.Validate(new Person()).Errors.Single().ErrorMessage;
 			error.ShouldEqual(expected);
-        }
+		}
 
 		[Fact]
 		public void Uses_custom_delegate_for_building_message() {
 			validator.RuleFor(x => x.Surname).NotNull().Configure(cfg => {
-				cfg.MessageBuilder = context => "Test " + ((Person)context.InstanceToValidate).Id;
+				cfg.MessageBuilder = context => "Test " + context.InstanceToValidate.Id;
 			});
 
 			var error = validator.Validate(new Person()).Errors.Single().ErrorMessage;
@@ -63,7 +63,6 @@ namespace FluentValidation.Tests {
 			result.Errors[0].ErrorMessage.ShouldEqual("Foo");
 			result.Errors[1].ErrorMessage.ShouldEqual("'Surname' must not be empty.");
 		}
-
 
 		[Fact]
 		public void Uses_property_value_in_message() {

--- a/src/FluentValidation.Tests/RuleBuilderTests.cs
+++ b/src/FluentValidation.Tests/RuleBuilderTests.cs
@@ -58,7 +58,8 @@ namespace FluentValidation.Tests {
 		[Fact]
 		public void Should_set_custom_error() {
 			builder.SetValidator(new TestPropertyValidator<Person, string>()).WithMessage("Bar");
-			_rule.Current.GetErrorMessage(null, default).ShouldEqual("Bar");
+			var component = (RuleComponent<Person, string>) _rule.Current;
+			component.GetErrorMessage(null, default).ShouldEqual("Bar");
 		}
 
 		[Fact]

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -38,7 +38,7 @@ namespace FluentValidation {
 		/// <param name="configurator">Action to configure the object.</param>
 		/// <returns></returns>
 		public static IRuleBuilderInitial<T, TProperty> Configure<T, TProperty>(this IRuleBuilderInitial<T, TProperty> ruleBuilder, Action<IValidationRule<T, TProperty>> configurator) {
-			configurator((IValidationRule<T, TProperty>) Configurable(ruleBuilder));
+			configurator(Configurable(ruleBuilder));
 			return ruleBuilder;
 		}
 
@@ -49,7 +49,7 @@ namespace FluentValidation {
 		/// <param name="configurator">Action to configure the object.</param>
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> Configure<T, TProperty>(this IRuleBuilderOptions<T, TProperty> ruleBuilder, Action<IValidationRule<T, TProperty>> configurator) {
-			configurator((IValidationRule<T, TProperty>) Configurable(ruleBuilder));
+			configurator(Configurable(ruleBuilder));
 			return ruleBuilder;
 		}
 
@@ -69,8 +69,8 @@ namespace FluentValidation {
 		/// </summary>
 		/// <param name="ruleBuilder">The rule builder.</param>
 		/// <returns>A configurable IValidationRule instance.</returns>
-		public static IValidationRuleConfigurable<T, TProperty> Configurable<T, TProperty>(IRuleBuilder<T, TProperty> ruleBuilder) {
-			return ((IRuleBuilderInternal<T, TProperty>) ruleBuilder).GetConfigurableRule();
+		public static IValidationRule<T, TProperty> Configurable<T, TProperty>(IRuleBuilder<T, TProperty> ruleBuilder) {
+			return ((IRuleBuilderInternal<T, TProperty>) ruleBuilder).Rule;
 		}
 
 		/// <summary>
@@ -79,7 +79,7 @@ namespace FluentValidation {
 		/// <param name="ruleBuilder">The rule builder.</param>
 		/// <returns>A configurable IValidationRule instance.</returns>
 		public static ICollectionRule<T, TCollectionElement> Configurable<T, TCollectionElement>(IRuleBuilderInitialCollection<T, TCollectionElement> ruleBuilder) {
-			return (ICollectionRule<T, TCollectionElement>) ((IRuleBuilderInternal<T, TCollectionElement>) ruleBuilder).GetConfigurableRule();
+			return (ICollectionRule<T, TCollectionElement>) ((IRuleBuilderInternal<T, TCollectionElement>) ruleBuilder).Rule;
 		}
 
 		/// <summary>

--- a/src/FluentValidation/IValidationRule.cs
+++ b/src/FluentValidation/IValidationRule.cs
@@ -27,9 +27,7 @@ namespace FluentValidation {
 	using Results;
 	using Validators;
 
-	//TODO: For FV 11 merge IValidationRuleConfigurable	and IValidationRule<T,Tproperty>
-
-	public interface IValidationRuleConfigurable<T, out TProperty> : IValidationRule<T> {
+	public interface IValidationRule<T, out TProperty> : IValidationRule<T> {
 		/// <summary>
 		/// Cascade mode for this rule.
 		/// </summary>
@@ -73,55 +71,6 @@ namespace FluentValidation {
 		/// Allows custom creation of an error message
 		/// </summary>
 		public Func<IMessageBuilderContext<T,TProperty>, string> MessageBuilder { set; }
-	}
-
-	public interface IValidationRule<T, TProperty> : IValidationRule<T> {
-		/// <summary>
-		/// Cascade mode for this rule.
-		/// </summary>
-		public CascadeMode CascadeMode { get; set; }
-
-		/// <summary>
-		/// Function that will be invoked if any of the validators associated with this rule fail.
-		/// </summary>
-		public Action<T, IEnumerable<ValidationFailure>> OnFailure { get; set; }
-
-		/// <summary>
-		/// Sets the display name for the property.
-		/// </summary>
-		/// <param name="name">The property's display name</param>
-		void SetDisplayName(string name);
-
-		/// <summary>
-		/// Sets the display name for the property using a function.
-		/// </summary>
-		/// <param name="factory">The function for building the display name</param>
-		void SetDisplayName(Func<ValidationContext<T>, string> factory);
-
-		/// <summary>
-		/// Adds a validator to this rule.
-		/// </summary>
-		void AddValidator(IPropertyValidator<T, TProperty> validator);
-
-		/// <summary>
-		/// Adds an async validator to this rule.
-		/// </summary>
-		/// <param name="asyncValidator">The async property validator to invoke</param>
-		/// <param name="fallback">A synchronous property validator to use as a fallback if executed synchronously. This parameter is optional. If omitted, the async validator will be called synchronously if needed.</param>
-		void AddAsyncValidator(IAsyncPropertyValidator<T, TProperty> asyncValidator, IPropertyValidator<T, TProperty> fallback = null);
-
-		/// <summary>
-		/// The current rule component.
-		/// </summary>
-		RuleComponent<T,TProperty> Current { get; }
-
-		[Obsolete("The current validator is no longer directly exposed. Access the current component with rule.Current instead. This property will be removed in FluentValidation 11.")]
-		RuleComponent<T,TProperty> CurrentValidator { get; }
-
-		/// <summary>
-		/// Allows custom creation of an error message
-		/// </summary>
-		public Func<MessageBuilderContext<T,TProperty>, string> MessageBuilder { get; set; }
 	}
 
 	public interface IValidationRule<T> : IValidationRule {

--- a/src/FluentValidation/IValidationRuleInternal.cs
+++ b/src/FluentValidation/IValidationRuleInternal.cs
@@ -30,7 +30,7 @@ namespace FluentValidation {
 		void AddDependentRules(IEnumerable<IValidationRuleInternal<T>> rules);
 	}
 
-	internal interface IValidationRuleInternal<T, TProperty> : IValidationRule<T, TProperty>, IValidationRuleInternal<T>, IValidationRuleConfigurable<T,TProperty> {
+	internal interface IValidationRuleInternal<T, TProperty> : IValidationRule<T, TProperty>, IValidationRuleInternal<T> {
 		new List<RuleComponent<T,TProperty>> Components { get; }
 	}
 }

--- a/src/FluentValidation/Internal/RuleBase.cs
+++ b/src/FluentValidation/Internal/RuleBase.cs
@@ -27,7 +27,7 @@ namespace FluentValidation.Internal {
 	using Results;
 	using Validators;
 
-	internal abstract class RuleBase<T, TProperty, TValue> : IValidationRule<T, TValue>, IValidationRuleConfigurable<T,TValue> {
+	internal abstract class RuleBase<T, TProperty, TValue> : IValidationRule<T, TValue> {
 		private readonly List<RuleComponent<T, TValue>> _components = new();
 		private Func<CascadeMode> _cascadeModeThunk;
 		private string _propertyDisplayName;
@@ -97,14 +97,9 @@ namespace FluentValidation.Internal {
 		public Action<T, IEnumerable<ValidationFailure>> OnFailure { get; set; }
 
 		/// <summary>
-		/// The current validator being configured by this rule.
-		/// </summary>
-		public RuleComponent<T, TValue> CurrentValidator => _components.LastOrDefault();
-
-		/// <summary>
 		/// The current rule component.
 		/// </summary>
-		public RuleComponent<T, TValue> Current => _components.LastOrDefault();
+		public IRuleComponent<T, TValue> Current => _components.LastOrDefault();
 
 		/// <summary>
 		/// Type of the property being validated
@@ -155,8 +150,6 @@ namespace FluentValidation.Internal {
 			_components.Add(component);
 		}
 
-		IRuleComponent<T, TValue> IValidationRuleConfigurable<T, TValue>.Current => Current;
-
 		// /// <summary>
 		// /// Replaces a validator in this rule. Used to wrap validators.
 		// /// </summary>
@@ -197,12 +190,7 @@ namespace FluentValidation.Internal {
 		/// <summary>
 		/// Allows custom creation of an error message
 		/// </summary>
-		public Func<MessageBuilderContext<T, TValue>, string> MessageBuilder { get; set; }
-
-		//TODO: Make this the default version of MessageBuilder for FV 11.
-		Func<IMessageBuilderContext<T, TValue>, string> IValidationRuleConfigurable<T, TValue>.MessageBuilder {
-			set => MessageBuilder = value;
-		}
+		public Func<IMessageBuilderContext<T, TValue>, string> MessageBuilder { get; set; }
 
 		/// <summary>
 		/// Dependent rules
@@ -239,7 +227,7 @@ namespace FluentValidation.Internal {
 				}
 			}
 			else {
-				CurrentValidator.ApplyCondition(predicate);
+				Current.ApplyCondition(predicate);
 			}
 		}
 
@@ -262,7 +250,7 @@ namespace FluentValidation.Internal {
 				}
 			}
 			else {
-				CurrentValidator.ApplyAsyncCondition(predicate);
+				Current.ApplyAsyncCondition(predicate);
 			}
 		}
 

--- a/src/FluentValidation/Internal/RuleBuilder.cs
+++ b/src/FluentValidation/Internal/RuleBuilder.cs
@@ -33,8 +33,7 @@ namespace FluentValidation.Internal {
 		/// </summary>
 		public IValidationRuleInternal<T, TProperty> Rule { get; }
 
-		//TODO: Remove in FV11 once IValidationRule<T,TProperty> and IValidationRuleConfigurable<T,TProperty> have been combined.
-		private IValidationRuleConfigurable<T, TProperty> ConfigurableRule => Rule;
+		IValidationRule<T, TProperty> IRuleBuilderInternal<T,TProperty>.Rule => Rule;
 
 		/// <summary>
 		/// Parent validator
@@ -51,7 +50,7 @@ namespace FluentValidation.Internal {
 
 		public IRuleBuilderOptions<T, TProperty> SetValidator(IPropertyValidator<T, TProperty> validator) {
 			if (validator == null) throw new ArgumentNullException(nameof(validator));
-			ConfigurableRule.AddValidator(validator);
+			Rule.AddValidator(validator);
 			return this;
 		}
 
@@ -59,7 +58,7 @@ namespace FluentValidation.Internal {
 			if (validator == null) throw new ArgumentNullException(nameof(validator));
 			// See if the async validator supports synchronous execution too.
 			IPropertyValidator<T, TProperty> fallback = validator as IPropertyValidator<T, TProperty>;
-			ConfigurableRule.AddAsyncValidator(validator, fallback);
+			Rule.AddAsyncValidator(validator, fallback);
 			return this;
 		}
 
@@ -69,7 +68,7 @@ namespace FluentValidation.Internal {
 				RuleSets = ruleSets
 			};
 			// ChildValidatorAdaptor supports both sync and async execution.
-			ConfigurableRule.AddAsyncValidator(adaptor, adaptor);
+			Rule.AddAsyncValidator(adaptor, adaptor);
 			return this;
 		}
 
@@ -79,7 +78,7 @@ namespace FluentValidation.Internal {
 				RuleSets = ruleSets
 			};
 			// ChildValidatorAdaptor supports both sync and async execution.
-			ConfigurableRule.AddAsyncValidator(adaptor, adaptor);
+			Rule.AddAsyncValidator(adaptor, adaptor);
 			return this;
 		}
 
@@ -89,7 +88,7 @@ namespace FluentValidation.Internal {
 				RuleSets = ruleSets
 			};
 			// ChildValidatorAdaptor supports both sync and async execution.
-			ConfigurableRule.AddAsyncValidator(adaptor, adaptor);
+			Rule.AddAsyncValidator(adaptor, adaptor);
 			return this;
 		}
 
@@ -115,7 +114,5 @@ namespace FluentValidation.Internal {
 		public void AddComponent(RuleComponent<T,TProperty> component) {
 			Rule.Components.Add(component);
 		}
-
-		IValidationRuleConfigurable<T, TProperty> IRuleBuilderInternal<T, TProperty>.GetConfigurableRule() => Rule;
 	}
 }

--- a/src/FluentValidation/Syntax.cs
+++ b/src/FluentValidation/Syntax.cs
@@ -115,7 +115,7 @@ namespace FluentValidation {
 	}
 
 	internal interface IRuleBuilderInternal<T, out TProperty> {
-		IValidationRuleConfigurable<T, TProperty> GetConfigurableRule();
+		IValidationRule<T, TProperty> Rule { get; }
 	}
 
 }


### PR DESCRIPTION
Makes `TProperty` covariant within the internal model's `IValidationRule<T,TProperty>` interface. 

This would resolve #1711 and related scenarios where the property type may be an inheritor of the type defined in a rule extension method. 

This would introduce several breaking changes. Specifically:
- `IValidationRule.Current` would need to be `IRuleComponent<T,TProperty>` rather than `RuleComponent<T,TProperty>`
- IRuleComponent<T,TProperty>.CustomStateProvider would become write-only
- IRuleComponent<T,TProperty>.SeverityProvider would become write-only 
- `GetErrorMessage` would not be exposed on `IRuleComponent<T,TProperty>`

Making various properties write-only is potentially problematic, but in theory users should only ever be setting these, and only the library's internals need to get them. But I expect there will be someone out there who relies on this for something nonstandard.

MessageBuilders still need some work. The quick fix is to not expose `TProperty` on the `MessageBuilderContext` and instead go back to exposing this as a non-generic `object`. This isn't ideal, so see whether there's a better way around this that still allows the MessageBuilder's getter to be exposed.