### PR TITLE
Support Internal Types In AssemblyScanner

### DIFF
--- a/docs/aspnet.md
+++ b/docs/aspnet.md
@@ -47,6 +47,8 @@ services.AddMvc()
 
 Validators that are registered automatically using `RegisterValidationsFromAssemblyContaining` are registered as `Scoped` with the container rather than as `Singleton`. This is done to avoid lifecycle scoping issues where a developer may inadvertantly cause a singleton-scoped validator from depending on a Transient or Request-scoped service (for example, a DB context). If you are aware of these kind of issues and understand how to avoid them, then you may choose to register the validators as singletons instead, which will give a performance boost by passing in a second argument: `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(lifetime: ServiceLifetime.Singleton)` (note that this optional parameter is only available in FluentValidation 9.0 or later).
 
+By default, only public validators will be registered. To include internal validators you can set the `includeInternalTypes` optional parameter to `true` (e.g., `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(includeInternalTypes: true)`).
+
 You can also optionally prevent certain types from being automatically registered when using this approach by passing a filter to `RegisterValidationsFromAssemblyContaining`. For example, if there is a specific validator type that you don't want to be registered, you can use a filter callback to exclude it:
 
 ```csharp

--- a/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
+++ b/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
@@ -30,10 +30,11 @@ namespace FluentValidation {
 		/// <param name="assemblies">The assemblies to scan</param>
 		/// <param name="lifetime">The lifetime of the validators. The default is scoped (per-request in web applications)</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
+		/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
 		/// <returns></returns>
-		public static IServiceCollection AddValidatorsFromAssemblies(this IServiceCollection services, IEnumerable<Assembly> assemblies, ServiceLifetime lifetime = ServiceLifetime.Scoped, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null) {
+		public static IServiceCollection AddValidatorsFromAssemblies(this IServiceCollection services, IEnumerable<Assembly> assemblies, ServiceLifetime lifetime = ServiceLifetime.Scoped, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, bool includeInternalTypes = false) {
 			foreach (var assembly in assemblies)
-				services.AddValidatorsFromAssembly(assembly, lifetime, filter);
+				services.AddValidatorsFromAssembly(assembly, lifetime, filter, includeInternalTypes);
 
 			return services;
 		}
@@ -45,10 +46,11 @@ namespace FluentValidation {
 		/// <param name="assembly">The assembly to scan</param>
 		/// <param name="lifetime">The lifetime of the validators. The default is scoped (per-request in web application)</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
+		/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
 		/// <returns></returns>
-		public static IServiceCollection AddValidatorsFromAssembly(this IServiceCollection services, Assembly assembly, ServiceLifetime lifetime = ServiceLifetime.Scoped, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null) {
+		public static IServiceCollection AddValidatorsFromAssembly(this IServiceCollection services, Assembly assembly, ServiceLifetime lifetime = ServiceLifetime.Scoped, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, bool includeInternalTypes = false) {
 			AssemblyScanner
-				.FindValidatorsInAssembly(assembly)
+				.FindValidatorsInAssembly(assembly, includeInternalTypes)
 				.ForEach(scanResult => services.AddScanResult(scanResult, lifetime, filter));
 
 			return services;
@@ -61,9 +63,10 @@ namespace FluentValidation {
 		/// <param name="type">The type whose assembly to scan</param>
 		/// <param name="lifetime">The lifetime of the validators. The default is scoped (per-request in web applications)</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
+		/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
 		/// <returns></returns>
-		public static IServiceCollection AddValidatorsFromAssemblyContaining(this IServiceCollection services, Type type, ServiceLifetime lifetime = ServiceLifetime.Scoped, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null)
-			=> services.AddValidatorsFromAssembly(type.Assembly, lifetime, filter);
+		public static IServiceCollection AddValidatorsFromAssemblyContaining(this IServiceCollection services, Type type, ServiceLifetime lifetime = ServiceLifetime.Scoped, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, bool includeInternalTypes = false)
+			=> services.AddValidatorsFromAssembly(type.Assembly, lifetime, filter, includeInternalTypes);
 
 		/// <summary>
 		/// Adds all validators in the assembly of the type specified by the generic parameter
@@ -71,9 +74,10 @@ namespace FluentValidation {
 		/// <param name="services">The collection of services</param>
 		/// <param name="lifetime">The lifetime of the validators. The default is scoped (per-request in web applications)</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
+		/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
 		/// <returns></returns>
-		public static IServiceCollection AddValidatorsFromAssemblyContaining<T>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null)
-			=> services.AddValidatorsFromAssembly(typeof(T).Assembly, lifetime, filter);
+		public static IServiceCollection AddValidatorsFromAssemblyContaining<T>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, bool includeInternalTypes = false)
+			=> services.AddValidatorsFromAssembly(typeof(T).Assembly, lifetime, filter, includeInternalTypes);
 
 		/// <summary>
 		/// Helper method to register a validator from an AssemblyScanner result

--- a/src/FluentValidation.Tests.AspNetCore/ServiceCollectionExtensionTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ServiceCollectionExtensionTests.cs
@@ -1,4 +1,5 @@
 ﻿namespace FluentValidation.Tests {
+	using System.Linq;
 	using Microsoft.Extensions.DependencyInjection;
 	using Xunit;
 
@@ -6,6 +7,7 @@
 		public class TestClass { }
 		public class TestValidator : AbstractValidator<TestClass> { }
 		public class TestValidator2 : AbstractValidator<TestClass> { }
+		internal class TestValidatorInternal : AbstractValidator<TestClass> { }
 
 		[Fact]
 		public void Should_resolve_validator_auto_registered_from_assembly_as_self() {
@@ -23,6 +25,70 @@
 				.BuildServiceProvider();
 
 			serviceProvider.GetService<IValidator<TestClass>>().ShouldNotBeNull();
+		}
+
+		[Fact]
+		public void AddValidatorsFromAssemblyContaining_T_When_Instructed_Should_Add_Internal_Validators() {
+			var serviceCollection = new ServiceCollection()
+				.AddValidatorsFromAssemblyContaining<ServiceCollectionExtensionTests>(includeInternalTypes: true);
+
+			Assert.Contains(serviceCollection, o => o.ImplementationType == typeof(TestValidatorInternal));
+		}
+
+		[Fact]
+		public void AddValidatorsFromAssemblyContaining_T_By_Default_Should_Not_Add_Internal_Validators() {
+			var serviceCollection = new ServiceCollection()
+				.AddValidatorsFromAssemblyContaining<ServiceCollectionExtensionTests>();
+
+			Assert.DoesNotContain(serviceCollection, o => o.ImplementationType == typeof(TestValidatorInternal));
+		}
+
+		[Fact]
+		public void AddValidatorsFromAssemblyContaining_When_Instructed_Should_Add_Internal_Validators() {
+			var serviceCollection = new ServiceCollection()
+				.AddValidatorsFromAssemblyContaining(typeof(ServiceCollectionExtensionTests), includeInternalTypes: true);
+
+			Assert.Contains(serviceCollection, o => o.ImplementationType == typeof(TestValidatorInternal));
+		}
+
+		[Fact]
+		public void AddValidatorsFromAssemblyContaining_By_Default_Should_Not_Add_Internal_Validators() {
+			var serviceCollection = new ServiceCollection()
+				.AddValidatorsFromAssemblyContaining(typeof(ServiceCollectionExtensionTests));
+
+			Assert.DoesNotContain(serviceCollection, o => o.ImplementationType == typeof(TestValidatorInternal));
+		}
+
+		[Fact]
+		public void AddValidatorsFromAssembly_When_Instructed_Should_Add_Internal_Validators() {
+			var serviceCollection = new ServiceCollection()
+				.AddValidatorsFromAssembly(typeof(ServiceCollectionExtensionTests).Assembly, includeInternalTypes: true);
+
+			Assert.Contains(serviceCollection, o => o.ImplementationType == typeof(TestValidatorInternal));
+		}
+
+		[Fact]
+		public void AddValidatorsFromAssembly_By_Default_Should_Not_Add_Internal_Validators() {
+			var serviceCollection = new ServiceCollection()
+				.AddValidatorsFromAssembly(typeof(ServiceCollectionExtensionTests).Assembly);
+
+			Assert.DoesNotContain(serviceCollection, o => o.ImplementationType == typeof(TestValidatorInternal));
+		}
+
+		[Fact]
+		public void AddValidatorsFromAssemblies_When_Instructed_Should_Add_Internal_Validators() {
+			var serviceCollection = new ServiceCollection()
+				.AddValidatorsFromAssemblies(new[] { typeof(ServiceCollectionExtensionTests).Assembly }, includeInternalTypes: true);
+
+			Assert.Contains(serviceCollection, o => o.ImplementationType == typeof(TestValidatorInternal));
+		}
+
+		[Fact]
+		public void AddValidatorsFromAssemblies_By_Default_Should_Not_Add_Internal_Validators() {
+			var serviceCollection = new ServiceCollection()
+				.AddValidatorsFromAssemblies(new[] { typeof(ServiceCollectionExtensionTests).Assembly });
+
+			Assert.DoesNotContain(serviceCollection, o => o.ImplementationType == typeof(TestValidatorInternal));
 		}
 	}
 }

--- a/src/FluentValidation.Tests/AssemblyScannerTester.cs
+++ b/src/FluentValidation.Tests/AssemblyScannerTester.cs
@@ -45,12 +45,21 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void FindValidatorsInAssembly_Should_Find_Internal_Types() {
-			var scanner = AssemblyScanner.FindValidatorsInAssembly(GetType().Assembly);
+		public void FindValidatorsInAssembly_When_Instructed_Should_Find_Internal_Types() {
+			var scanner = AssemblyScanner.FindValidatorsInAssembly(GetType().Assembly, true);
 			var results = new List<AssemblyScanner.AssemblyScanResult>();
 
 			scanner.ForEach(x => results.Add(x));
 			Assert.Contains(results, o=> o.ValidatorType == typeof(Model1InternalValidator));
+		}
+
+		[Fact]
+		public void FindValidatorsInAssembly_By_Default_Should_Not_Find_Internal_Types() {
+			var scanner = AssemblyScanner.FindValidatorsInAssembly(GetType().Assembly);
+			var results = new List<AssemblyScanner.AssemblyScanResult>();
+
+			scanner.ForEach(x => results.Add(x));
+			Assert.DoesNotContain(results, o=> o.ValidatorType == typeof(Model1InternalValidator));
 		}
 
 		public class Model1 {

--- a/src/FluentValidation.Tests/AssemblyScannerTester.cs
+++ b/src/FluentValidation.Tests/AssemblyScannerTester.cs
@@ -44,6 +44,15 @@ namespace FluentValidation.Tests {
 			results.Count.ShouldEqual(2);
 		}
 
+		[Fact]
+		public void FindValidatorsInAssembly_Should_Find_Internal_Types() {
+			var scanner = AssemblyScanner.FindValidatorsInAssembly(GetType().Assembly);
+			var results = new List<AssemblyScanner.AssemblyScanResult>();
+
+			scanner.ForEach(x => results.Add(x));
+			Assert.Contains(results, o=> o.ValidatorType == typeof(Model1InternalValidator));
+		}
+
 		public class Model1 {
 
 		}
@@ -57,6 +66,10 @@ namespace FluentValidation.Tests {
 		}
 
 		public class Model2Validator:AbstractValidator<Model2> {
+
+		}
+
+		internal class Model1InternalValidator : AbstractValidator<Model1> {
 
 		}
 	}

--- a/src/FluentValidation/AssemblyScanner.cs
+++ b/src/FluentValidation/AssemblyScanner.cs
@@ -42,15 +42,15 @@ namespace FluentValidation {
 		/// <summary>
 		/// Finds all the validators in the specified assembly.
 		/// </summary>
-		public static AssemblyScanner FindValidatorsInAssembly(Assembly assembly) {
-			return new AssemblyScanner(assembly.GetTypes());
+		public static AssemblyScanner FindValidatorsInAssembly(Assembly assembly, bool includeInternalTypes = false) {
+			return new AssemblyScanner(includeInternalTypes ? assembly.GetTypes() : assembly.GetExportedTypes());
 		}
 
 		/// <summary>
 		/// Finds all the validators in the specified assemblies
 		/// </summary>
-		public static AssemblyScanner FindValidatorsInAssemblies(IEnumerable<Assembly> assemblies) {
-			var types = assemblies.SelectMany(x => x.GetTypes().Distinct());
+		public static AssemblyScanner FindValidatorsInAssemblies(IEnumerable<Assembly> assemblies, bool includeInternalTypes = false) {
+			var types = assemblies.SelectMany(x => includeInternalTypes ? x.GetTypes() : x.GetExportedTypes()).Distinct();
 			return new AssemblyScanner(types);
 		}
 
@@ -72,12 +72,12 @@ namespace FluentValidation {
 			var openGenericType = typeof(IValidator<>);
 
 			var query = from type in _types
-						where !type.IsAbstract && !type.IsGenericTypeDefinition
-						let interfaces = type.GetInterfaces()
-						let genericInterfaces = interfaces.Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == openGenericType)
-						let matchingInterface = genericInterfaces.FirstOrDefault()
-						where matchingInterface != null
-						select new AssemblyScanResult(matchingInterface, type);
+									where !type.IsAbstract && !type.IsGenericTypeDefinition
+									let interfaces = type.GetInterfaces()
+									let genericInterfaces = interfaces.Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == openGenericType)
+									let matchingInterface = genericInterfaces.FirstOrDefault()
+									where matchingInterface != null
+									select new AssemblyScanResult(matchingInterface, type);
 
 			return query;
 		}

--- a/src/FluentValidation/AssemblyScanner.cs
+++ b/src/FluentValidation/AssemblyScanner.cs
@@ -43,14 +43,14 @@ namespace FluentValidation {
 		/// Finds all the validators in the specified assembly.
 		/// </summary>
 		public static AssemblyScanner FindValidatorsInAssembly(Assembly assembly) {
-			return new AssemblyScanner(assembly.GetExportedTypes());
+			return new AssemblyScanner(assembly.GetTypes());
 		}
 
 		/// <summary>
 		/// Finds all the validators in the specified assemblies
 		/// </summary>
 		public static AssemblyScanner FindValidatorsInAssemblies(IEnumerable<Assembly> assemblies) {
-			var types = assemblies.SelectMany(x => x.GetExportedTypes().Distinct());
+			var types = assemblies.SelectMany(x => x.GetTypes().Distinct());
 			return new AssemblyScanner(types);
 		}
 


### PR DESCRIPTION
The commit solves #1741 by changing AssemblyScanner behavior to look for all types in an assembly instead of exported typed.