### PR TITLE
Deprecate `RunDefaultMvcValidationAfterFluentValidationExecutes`

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,7 @@ Allow AddFluentValidation to be called directly on IServiceCollection (#1726)
 Throw exception on ValidateAndThrow even if PreValidate prevents further Validation (#1736)
 ValidationException now includes rule severity (#1733)
 Optionally support internal types when scanning assemblies for validators (#1742)
+Deprecate RunDefaultMvcValidationAfterFluentValidationExecutes in MVC configuration. Use DisableDataAnnotationsValidation instead.
 
 10.1.0 - 28 April 2021
 Allow default severity level to be set globally (#1715)

--- a/docs/aspnet.md
+++ b/docs/aspnet.md
@@ -136,11 +136,11 @@ Now when you post the form, MVC's model-binding infrastructure will validate the
 
 By default, after FluentValidation is executed, any other validator providers will also have a chance to execute. This means you can mix FluentValidation with [DataAnnotations attributes](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations) (or any other ASP.NET `ModelValidatorProvider` implementation).
 
-If you want to disable this behaviour so that FluentValidation is the only validation library that executes, you can set the `RunDefaultMvcValidationAfterFluentValidationExecutes` to false in your application startup routine:
+If you want to disable this behaviour so that FluentValidation is the only validation library that executes, you can set the `DisableDataAnnotationsValidation` to `true` in your application startup routine:
 
 ```csharp
 services.AddMvc().AddFluentValidation(fv => {
- fv.RunDefaultMvcValidationAfterFluentValidationExecutes = false;
+ fv.DisableDataAnnotationsValidation = true;
 });
 ```
 

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
@@ -49,7 +49,17 @@ namespace FluentValidation.AspNetCore {
 		/// <summary>
 		/// Whether to run MVC's default validation process (including DataAnnotations) after FluentValidation is executed. True by default.
 		/// </summary>
-		public bool RunDefaultMvcValidationAfterFluentValidationExecutes { get; set; } = true;
+		[Obsolete("Use the DisableAnnotations property instead. Note that this is the inverse of this property (if you were previously setting RunDefaultMvcValidationAfterFluentValidationExecutes to false, now you should set DisableDataAnnotations to true)")]
+		public bool RunDefaultMvcValidationAfterFluentValidationExecutes {
+			get => !DisableDataAnnotationsValidation;
+			set => DisableDataAnnotationsValidation = !value;
+		}
+
+		/// <summary>
+		/// By default Data Annotations validation will also run as well as FluentValidation.
+		/// Setting this to false will disable DataAnnotations and only run FluentValidation.
+		/// </summary>
+		public bool DisableDataAnnotationsValidation { get; set; }
 
 		/// <summary>
 		/// Enables or disables localization support within FluentValidation

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcExtensions.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcExtensions.cs
@@ -82,7 +82,7 @@ namespace FluentValidation.AspNetCore {
 				services.Add(ServiceDescriptor.Singleton<IObjectModelValidator, FluentValidationObjectModelValidator>(s => {
 					var options = s.GetRequiredService<IOptions<MvcOptions>>().Value;
 					var metadataProvider = s.GetRequiredService<IModelMetadataProvider>();
-					return new FluentValidationObjectModelValidator(metadataProvider, options.ModelValidatorProviders, config.RunDefaultMvcValidationAfterFluentValidationExecutes);
+					return new FluentValidationObjectModelValidator(metadataProvider, options.ModelValidatorProviders, !config.DisableDataAnnotationsValidation);
 				}));
 			}
 

--- a/src/FluentValidation.Tests.AspNetCore/DisableDataAnnotationsTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/DisableDataAnnotationsTests.cs
@@ -16,7 +16,7 @@ namespace FluentValidation.Tests {
 		public async Task Disables_data_annotations() {
 			var client = _app.CreateClientWithServices(services => {
 				services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
-					fv.RunDefaultMvcValidationAfterFluentValidationExecutes = false;
+					fv.DisableDataAnnotationsValidation = true;
 				});
 				services.AddScoped<IValidator<MultiValidationModel>, MultiValidationValidator>();
 			});


### PR DESCRIPTION
Introduces `DisableDataAnnotationsValidation` as a better-named replacement. 