### PR TITLE
Update blazor docs

### DIFF
--- a/docs/blazor.md
+++ b/docs/blazor.md
@@ -3,5 +3,4 @@
 FluentValidation does not provide integration with Blazor out of the box, but there are several third party libraries you can use to do this:
 
 - [Blazored.FluentValidation](https://github.com/Blazored/FluentValidation)
-- [Blazor-Validation](https://github.com/mrpmorris/blazor-validation)
 - [Accelist.FluentValidation.Blazor](https://github.com/ryanelian/FluentValidation.Blazor)


### PR DESCRIPTION
Remove Blazor-Validation package, since this library is now obsolete. It's recommended to use Blazored FluentValidation instead.