### PR TITLE
add support for registering internal validator types through FluentValidationMvcConfiguration

### DIFF
--- a/docs/aspnet.md
+++ b/docs/aspnet.md
@@ -47,7 +47,7 @@ services.AddMvc()
 
 Validators that are registered automatically using `RegisterValidationsFromAssemblyContaining` are registered as `Scoped` with the container rather than as `Singleton`. This is done to avoid lifecycle scoping issues where a developer may inadvertantly cause a singleton-scoped validator from depending on a Transient or Request-scoped service (for example, a DB context). If you are aware of these kind of issues and understand how to avoid them, then you may choose to register the validators as singletons instead, which will give a performance boost by passing in a second argument: `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(lifetime: ServiceLifetime.Singleton)` (note that this optional parameter is only available in FluentValidation 9.0 or later).
 
-By default, only public validators will be registered. To include internal validators you can set the `includeInternalTypes` optional parameter to `true` (e.g., `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(includeInternalTypes: true)`).
+By default, only public validators will be registered. To include internal validators, set the `IncludeInternalValidatorTypes` parameter to `true` (e.g., `fv.IncludeInternalValidatorTypes = true`).
 
 You can also optionally prevent certain types from being automatically registered when using this approach by passing a filter to `RegisterValidationsFromAssemblyContaining`. For example, if there is a specific validator type that you don't want to be registered, you can use a filter callback to exclude it:
 

--- a/docs/aspnet.md
+++ b/docs/aspnet.md
@@ -47,7 +47,7 @@ services.AddMvc()
 
 Validators that are registered automatically using `RegisterValidationsFromAssemblyContaining` are registered as `Scoped` with the container rather than as `Singleton`. This is done to avoid lifecycle scoping issues where a developer may inadvertantly cause a singleton-scoped validator from depending on a Transient or Request-scoped service (for example, a DB context). If you are aware of these kind of issues and understand how to avoid them, then you may choose to register the validators as singletons instead, which will give a performance boost by passing in a second argument: `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(lifetime: ServiceLifetime.Singleton)` (note that this optional parameter is only available in FluentValidation 9.0 or later).
 
-By default, only public validators will be registered. To include internal validators, set the `IncludeInternalValidatorTypes` parameter to `true` (e.g., `fv.IncludeInternalValidatorTypes = true`).
+By default, only public validators will be registered. To include internal validators you can set the `includeInternalTypes` optional parameter to `true` (e.g., `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(includeInternalTypes: true)`).
 
 You can also optionally prevent certain types from being automatically registered when using this approach by passing a filter to `RegisterValidationsFromAssemblyContaining`. For example, if there is a specific validator type that you don't want to be registered, you can use a filter callback to exclude it:
 

--- a/docs/aspnet.md
+++ b/docs/aspnet.md
@@ -47,7 +47,7 @@ services.AddMvc()
 
 Validators that are registered automatically using `RegisterValidationsFromAssemblyContaining` are registered as `Scoped` with the container rather than as `Singleton`. This is done to avoid lifecycle scoping issues where a developer may inadvertantly cause a singleton-scoped validator from depending on a Transient or Request-scoped service (for example, a DB context). If you are aware of these kind of issues and understand how to avoid them, then you may choose to register the validators as singletons instead, which will give a performance boost by passing in a second argument: `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(lifetime: ServiceLifetime.Singleton)` (note that this optional parameter is only available in FluentValidation 9.0 or later).
 
-By default, only public validators will be registered. To include internal validators you can set the `includeInternalTypes` optional parameter to `true` (e.g., `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(includeInternalTypes: true)`).
+By default, only public validators will be registered. To include internal validators you can set the `includeInternalValidatorTypes` optional parameter to `true` (e.g., `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(includeInternalValidatorTypes: true)`).
 
 You can also optionally prevent certain types from being automatically registered when using this approach by passing a filter to `RegisterValidationsFromAssemblyContaining`. For example, if there is a specific validator type that you don't want to be registered, you can use a filter callback to exclude it:
 

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
@@ -22,11 +22,6 @@ namespace FluentValidation.AspNetCore {
 	using System.Reflection;
 	using Microsoft.Extensions.DependencyInjection;
 
-	internal class AssemblyRegistration {
-		public Assembly Assembly { get; }
-		public bool Include
-	}
-
 	/// <summary>
 	/// FluentValidation asp.net core configuration
 	/// </summary>

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
@@ -62,6 +62,12 @@ namespace FluentValidation.AspNetCore {
 		public bool DisableDataAnnotationsValidation { get; set; }
 
 		/// <summary>
+		/// By default, only public validators will be registered.
+		/// Setting this to true will register internal validators in addition to public validators.
+		/// </summary>
+		public bool IncludeInternalValidatorTypes { get; set; }
+
+		/// <summary>
 		/// Enables or disables localization support within FluentValidation
 		/// </summary>
 		public bool LocalizationEnabled {

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
@@ -22,6 +22,11 @@ namespace FluentValidation.AspNetCore {
 	using System.Reflection;
 	using Microsoft.Extensions.DependencyInjection;
 
+	internal class AssemblyRegistration {
+		public Assembly Assembly { get; }
+		public bool Include
+	}
+
 	/// <summary>
 	/// FluentValidation asp.net core configuration
 	/// </summary>
@@ -62,12 +67,6 @@ namespace FluentValidation.AspNetCore {
 		public bool DisableDataAnnotationsValidation { get; set; }
 
 		/// <summary>
-		/// By default, only public validators will be registered.
-		/// Setting this to true will register internal validators in addition to public validators.
-		/// </summary>
-		public bool IncludeInternalValidatorTypes { get; set; }
-
-		/// <summary>
 		/// Enables or disables localization support within FluentValidation
 		/// </summary>
 		public bool LocalizationEnabled {
@@ -93,6 +92,7 @@ namespace FluentValidation.AspNetCore {
 		internal List<Assembly> AssembliesToRegister { get; } = new List<Assembly>();
 		internal Func<AssemblyScanner.AssemblyScanResult, bool> TypeFilter { get; set; }
 		internal ServiceLifetime ServiceLifetime { get; set; } = ServiceLifetime.Scoped;
+		internal bool IncludeInternalValidatorTypes { get; set; }
 
 		/// <summary>
 		/// Whether automatic server-side validation should be enabled (default true).
@@ -104,8 +104,9 @@ namespace FluentValidation.AspNetCore {
 		/// </summary>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
 		/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining<T>(Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
-			return RegisterValidatorsFromAssemblyContaining(typeof(T), filter, lifetime);
+		/// <param name="includeInternalValidatorTypes">Include internal validators. The default is false.</param>
+		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining<T>(Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalValidatorTypes = false) {
+			return RegisterValidatorsFromAssemblyContaining(typeof(T), filter, lifetime, includeInternalValidatorTypes);
 		}
 
 		/// <summary>
@@ -114,8 +115,9 @@ namespace FluentValidation.AspNetCore {
 		/// <param name="type">The type that indicates which assembly that should be scanned</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
 		/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining(Type type, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
-			return RegisterValidatorsFromAssembly(type.Assembly, filter, lifetime);
+		/// <param name="includeInternalValidatorTypes">Include internal validators. The default is false.</param>
+		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining(Type type, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalValidatorTypes = false) {
+			return RegisterValidatorsFromAssembly(type.Assembly, filter, lifetime, includeInternalValidatorTypes);
 		}
 
 		/// <summary>
@@ -124,11 +126,13 @@ namespace FluentValidation.AspNetCore {
 		/// <param name="assembly">The assembly to scan</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
 		/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-		public FluentValidationMvcConfiguration RegisterValidatorsFromAssembly(Assembly assembly, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
+		/// <param name="includeInternalValidatorTypes">Include internal validators. The default is false.</param>
+		public FluentValidationMvcConfiguration RegisterValidatorsFromAssembly(Assembly assembly, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalValidatorTypes = false) {
 			ValidatorFactoryType = typeof(ServiceProviderValidatorFactory);
 			AssembliesToRegister.Add(assembly);
 			TypeFilter = filter;
 			ServiceLifetime = lifetime;
+			IncludeInternalValidatorTypes = includeInternalValidatorTypes;
 			return this;
 		}
 
@@ -138,11 +142,13 @@ namespace FluentValidation.AspNetCore {
 		/// <param name="assemblies">The assemblies to scan</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
 		/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblies(IEnumerable<Assembly> assemblies, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
+		/// <param name="includeInternalValidatorTypes">Include internal validators. The default is false.</param>
+		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblies(IEnumerable<Assembly> assemblies, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalValidatorTypes = false) {
 			ValidatorFactoryType = typeof(ServiceProviderValidatorFactory);
 			AssembliesToRegister.AddRange(assemblies);
 			TypeFilter = filter;
 			ServiceLifetime = lifetime;
+			IncludeInternalValidatorTypes = includeInternalValidatorTypes;
 			return this;
 		}
 

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
@@ -99,9 +99,9 @@ namespace FluentValidation.AspNetCore {
 		/// </summary>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
 		/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-		/// <param name="includeInternalValidatorTypes">Include internal validators. The default is false.</param>
-		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining<T>(Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalValidatorTypes = false) {
-			return RegisterValidatorsFromAssemblyContaining(typeof(T), filter, lifetime, includeInternalValidatorTypes);
+		/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
+		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining<T>(Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalTypes = false) {
+			return RegisterValidatorsFromAssemblyContaining(typeof(T), filter, lifetime, includeInternalTypes);
 		}
 
 		/// <summary>
@@ -110,9 +110,9 @@ namespace FluentValidation.AspNetCore {
 		/// <param name="type">The type that indicates which assembly that should be scanned</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
 		/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-		/// <param name="includeInternalValidatorTypes">Include internal validators. The default is false.</param>
-		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining(Type type, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalValidatorTypes = false) {
-			return RegisterValidatorsFromAssembly(type.Assembly, filter, lifetime, includeInternalValidatorTypes);
+		/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
+		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblyContaining(Type type, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalTypes = false) {
+			return RegisterValidatorsFromAssembly(type.Assembly, filter, lifetime, includeInternalTypes);
 		}
 
 		/// <summary>
@@ -121,13 +121,13 @@ namespace FluentValidation.AspNetCore {
 		/// <param name="assembly">The assembly to scan</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
 		/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-		/// <param name="includeInternalValidatorTypes">Include internal validators. The default is false.</param>
-		public FluentValidationMvcConfiguration RegisterValidatorsFromAssembly(Assembly assembly, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalValidatorTypes = false) {
+		/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
+		public FluentValidationMvcConfiguration RegisterValidatorsFromAssembly(Assembly assembly, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalTypes = false) {
 			ValidatorFactoryType = typeof(ServiceProviderValidatorFactory);
 			AssembliesToRegister.Add(assembly);
 			TypeFilter = filter;
 			ServiceLifetime = lifetime;
-			IncludeInternalValidatorTypes = includeInternalValidatorTypes;
+			IncludeInternalValidatorTypes = includeInternalTypes;
 			return this;
 		}
 
@@ -137,13 +137,13 @@ namespace FluentValidation.AspNetCore {
 		/// <param name="assemblies">The assemblies to scan</param>
 		/// <param name="filter">Optional filter that allows certain types to be skipped from registration.</param>
 		/// <param name="lifetime">The service lifetime that should be used for the validator registration. Defaults to Scoped</param>
-		/// <param name="includeInternalValidatorTypes">Include internal validators. The default is false.</param>
-		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblies(IEnumerable<Assembly> assemblies, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalValidatorTypes = false) {
+		/// <param name="includeInternalTypes">Include internal validators. The default is false.</param>
+		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblies(IEnumerable<Assembly> assemblies, Func<AssemblyScanner.AssemblyScanResult, bool> filter = null, ServiceLifetime lifetime = ServiceLifetime.Scoped, bool includeInternalTypes = false) {
 			ValidatorFactoryType = typeof(ServiceProviderValidatorFactory);
 			AssembliesToRegister.AddRange(assemblies);
 			TypeFilter = filter;
 			ServiceLifetime = lifetime;
-			IncludeInternalValidatorTypes = includeInternalValidatorTypes;
+			IncludeInternalValidatorTypes = includeInternalTypes;
 			return this;
 		}
 

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcExtensions.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcExtensions.cs
@@ -66,7 +66,7 @@ namespace FluentValidation.AspNetCore {
 			var config = new FluentValidationMvcConfiguration(ValidatorOptions.Global);
 			configurationExpression?.Invoke(config);
 
-			services.AddValidatorsFromAssemblies(config.AssembliesToRegister, config.ServiceLifetime, config.TypeFilter);
+			services.AddValidatorsFromAssemblies(config.AssembliesToRegister, config.ServiceLifetime, config.TypeFilter, config.IncludeInternalValidatorTypes);
 			services.AddSingleton(config.ValidatorOptions);
 
 			if (config.ValidatorFactory != null) {

--- a/src/FluentValidation/Internal/PropertyChain.cs
+++ b/src/FluentValidation/Internal/PropertyChain.cs
@@ -149,16 +149,9 @@ namespace FluentValidation.Internal {
 				return propertyName;
 			}
 
-			return WithPropertyName(propertyName).ToString();
-		}
-
-		/// <summary>
-		/// Creates a new property chain with the specified property name appended to the end of the chain.
-		/// </summary>
-		public PropertyChain WithPropertyName(string propertyName) {
 			var chain = new PropertyChain(this);
 			chain.Add(propertyName);
-			return chain;
+			return chain.ToString();
 		}
 
 		/// <summary>

--- a/src/FluentValidation/Internal/PropertyChain.cs
+++ b/src/FluentValidation/Internal/PropertyChain.cs
@@ -149,9 +149,16 @@ namespace FluentValidation.Internal {
 				return propertyName;
 			}
 
+			return WithPropertyName(propertyName).ToString();
+		}
+
+		/// <summary>
+		/// Creates a new property chain with the specified property name appended to the end of the chain.
+		/// </summary>
+		public PropertyChain WithPropertyName(string propertyName) {
 			var chain = new PropertyChain(this);
 			chain.Add(propertyName);
-			return chain.ToString();
+			return chain;
 		}
 
 		/// <summary>


### PR DESCRIPTION
The [documentation](https://docs.fluentvalidation.net/en/latest/aspnet.html#automatic-registration) mentions being able to register `internal` validator types using the following syntax:

``` csharp
services
    .AddMvc()
    .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(includeInternalTypes: true))
```

... but this is incorrect.  The [pull request introducing the opt-in behavior](https://github.com/FluentValidation/FluentValidation/pull/1742) modified the `IServiceCollection` extension methods and not any of the `RegisterValidators...` methods defined by `FluentValidationMvcConfiguration`.  This PR adds a new `IncludeInternalValidatorTypes` flag to `FluentValidationMvcConfiguration` and that value will be passed to the `IServiceCollection` extension method call made later (since `FluentValidationMvcConfiguration` caches a collection of assemblies and all validators from all assemblies are registered at once).

I also added a useful `WithPropertyName` method to `PropertyChain` to allow for fluent declaration of property chains: `validationContext.PropertyChain.WithPropertyName(validationContext.PropertyName).WithPropertyName("OtherProperty")`