### PR TITLE
🧹Code Cleanup

### DIFF
--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Reflection;
 
 [assembly : AssemblyVersion("9.0.0.0")]

--- a/src/FluentValidation.AspNetCore/Adapters/ClientValidatorBase.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/ClientValidatorBase.cs
@@ -16,12 +16,9 @@
 // The latest version of this file can be found at https://github.com/FluentValidation/FluentValidation
 #endregion
 namespace FluentValidation.AspNetCore {
-	using System;
 	using System.Collections.Generic;
-	using System.ComponentModel;
 	using Internal;
 	using Validators;
-	using System.Linq;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 	public abstract class ClientValidatorBase : IClientModelValidator {

--- a/src/FluentValidation.AspNetCore/Adapters/CreditCardClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/CreditCardClientValidator.cs
@@ -18,11 +18,8 @@
 namespace FluentValidation.AspNetCore
 {
 	using System;
-	using System.Collections.Generic;
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
-	using Validators;
 
 	internal class CreditCardClientValidator : ClientValidatorBase {
 		public CreditCardClientValidator(IValidationRule rule, IRuleComponent component) : base(rule, component) {

--- a/src/FluentValidation.AspNetCore/Adapters/EmailClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/EmailClientValidator.cs
@@ -17,11 +17,8 @@
 #endregion
 namespace FluentValidation.AspNetCore {
 	using System;
-	using System.Collections.Generic;
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
-	using Validators;
 
 	internal class EmailClientValidator : ClientValidatorBase {
 

--- a/src/FluentValidation.AspNetCore/Adapters/EqualToClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/EqualToClientValidator.cs
@@ -17,11 +17,9 @@
 #endregion
 namespace FluentValidation.AspNetCore {
 	using System;
-	using System.Collections.Generic;
 	using System.Reflection;
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
 	using Validators;
 
 	internal class EqualToClientValidator : ClientValidatorBase {

--- a/src/FluentValidation.AspNetCore/Adapters/MaxLengthClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/MaxLengthClientValidator.cs
@@ -22,7 +22,6 @@ namespace FluentValidation.AspNetCore {
 	using System;
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
 	using Validators;
 
 	internal class MaxLengthClientValidator : ClientValidatorBase {

--- a/src/FluentValidation.AspNetCore/Adapters/MinLengthClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/MinLengthClientValidator.cs
@@ -22,7 +22,6 @@ namespace FluentValidation.AspNetCore {
 	using System;
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
 	using Validators;
 
 	internal class MinLengthClientValidator : ClientValidatorBase {

--- a/src/FluentValidation.AspNetCore/Adapters/RangeClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/RangeClientValidator.cs
@@ -18,7 +18,6 @@
 namespace FluentValidation.AspNetCore {
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
 	using System;
 	using System.Globalization;
 	using Validators;

--- a/src/FluentValidation.AspNetCore/Adapters/RangeMaxClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/RangeMaxClientValidator.cs
@@ -1,7 +1,6 @@
 namespace FluentValidation.AspNetCore {
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
 	using System;
 	using System.Globalization;
 	using Validators;

--- a/src/FluentValidation.AspNetCore/Adapters/RangeMinClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/RangeMinClientValidator.cs
@@ -1,7 +1,6 @@
 namespace FluentValidation.AspNetCore {
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
 	using System;
 	using System.Globalization;
 	using Validators;

--- a/src/FluentValidation.AspNetCore/Adapters/RegexClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/RegexClientValidator.cs
@@ -17,10 +17,8 @@
 #endregion
 namespace FluentValidation.AspNetCore {
 	using System;
-	using System.Collections.Generic;
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
 	using Validators;
 
 	internal class RegexClientValidator : ClientValidatorBase {

--- a/src/FluentValidation.AspNetCore/Adapters/RequiredClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/RequiredClientValidator.cs
@@ -17,11 +17,8 @@
 #endregion
 namespace FluentValidation.AspNetCore {
 	using System;
-	using System.Collections.Generic;
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
-	using Validators;
 
 	internal class RequiredClientValidator : ClientValidatorBase{
 		public RequiredClientValidator(IValidationRule rule, IRuleComponent component) : base(rule, component) {

--- a/src/FluentValidation.AspNetCore/Adapters/StringLengthClientValidator.cs
+++ b/src/FluentValidation.AspNetCore/Adapters/StringLengthClientValidator.cs
@@ -17,10 +17,8 @@
 #endregion
 namespace FluentValidation.AspNetCore {
 	using System;
-	using System.Collections.Generic;
 	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
-	using Resources;
 	using Validators;
 
 	internal class StringLengthClientValidator : ClientValidatorBase {

--- a/src/FluentValidation.AspNetCore/CustomizeValidatorAttribute.cs
+++ b/src/FluentValidation.AspNetCore/CustomizeValidatorAttribute.cs
@@ -18,8 +18,7 @@
 
 namespace FluentValidation.AspNetCore {
 	using System;
-	using FluentValidation.Internal;
-	using System.Reflection;
+	using Internal;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 	using Microsoft.Extensions.DependencyInjection;
 	using System.Linq;

--- a/src/FluentValidation.AspNetCore/FluentValidationClientModelValidatorProvider.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationClientModelValidatorProvider.cs
@@ -18,12 +18,10 @@
 namespace FluentValidation.AspNetCore {
 	using System;
 	using System.Collections.Generic;
-	using System.ComponentModel.DataAnnotations;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 	using System.Linq;
-	using System.Reflection;
-	using FluentValidation.Internal;
-	using FluentValidation.Validators;
+	using Internal;
+	using Validators;
 	using Microsoft.AspNetCore.Http;
 	using Microsoft.AspNetCore.Mvc.DataAnnotations;
 

--- a/src/FluentValidation.AspNetCore/IValidatorInterceptor.cs
+++ b/src/FluentValidation.AspNetCore/IValidatorInterceptor.cs
@@ -17,7 +17,7 @@
 #endregion
 namespace FluentValidation.AspNetCore
 {
-	using FluentValidation.Results;
+	using Results;
 	using Microsoft.AspNetCore.Mvc;
 	using FluentValidation;
 

--- a/src/FluentValidation.AspNetCore/ValidationResultExtensions.cs
+++ b/src/FluentValidation.AspNetCore/ValidationResultExtensions.cs
@@ -19,8 +19,8 @@
 #endregion
 
 namespace FluentValidation.AspNetCore {
-	using FluentValidation.Internal;
-	using FluentValidation.Results;
+	using Internal;
+	using Results;
 	using Microsoft.AspNetCore.Http;
 	using Microsoft.AspNetCore.Mvc;
 	using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/FluentValidation.AspNetCore/ValidatorDescriptorCache.cs
+++ b/src/FluentValidation.AspNetCore/ValidatorDescriptorCache.cs
@@ -19,7 +19,6 @@
 namespace FluentValidation.AspNetCore {
 	using System;
 	using System.Collections.Generic;
-	using Microsoft.AspNetCore.DataProtection.KeyManagement.Internal;
 	using Microsoft.AspNetCore.Http;
 	using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 

--- a/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
@@ -246,7 +246,7 @@ namespace FluentValidation.Tests.AspNetCore {
 				services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 				services.AddScoped<ClientsideScopedDependency>();
 				services.AddLocalization(opts => { opts.ResourcesPath = "Resources"; });
-			});;
+			});
 
 			CultureScope.SetDefaultCulture();
 		}

--- a/src/FluentValidation.Tests.AspNetCore/ExtensionTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ExtensionTests.cs
@@ -22,7 +22,7 @@ namespace FluentValidation.Tests.AspNetCore {
 	using Xunit;
 	using FluentValidation.AspNetCore;
 	using Microsoft.AspNetCore.Mvc.ModelBinding;
-	using FluentValidation.Results;
+	using Results;
 
 	public class ValidationResultExtensionTests {
 		private ValidationResult result;

--- a/src/FluentValidation.Tests.AspNetCore/TestModels.cs
+++ b/src/FluentValidation.Tests.AspNetCore/TestModels.cs
@@ -17,16 +17,16 @@ namespace FluentValidation.Tests.AspNetCore {
 	public class TestModel5Validator : AbstractValidator<TestModel5> {
 		public TestModel5Validator() {
 			//force a complex rule
-			RuleFor(x => x.SomeBool).Must(x => x == true);
+			RuleFor(x => x.SomeBool).Must(x => x);
 			RuleFor(x => x.Id).NotEmpty();
 		}
 	}
 
-	public class SimplePropertyInterceptor : FluentValidation.AspNetCore.IValidatorInterceptor {
+	public class SimplePropertyInterceptor : IValidatorInterceptor {
 		readonly string[] properties = new[] {"Surname", "Forename"};
 
 		public IValidationContext BeforeAspNetValidation(ActionContext cc, IValidationContext context) {
-			var newContext = new ValidationContext<object>(context.InstanceToValidate, context.PropertyChain, new FluentValidation.Internal.MemberNameValidatorSelector(properties));
+			var newContext = new ValidationContext<object>(context.InstanceToValidate, context.PropertyChain, new Internal.MemberNameValidatorSelector(properties));
 			return newContext;
 		}
 
@@ -35,7 +35,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 	}
 
-	public class ClearErrorsInterceptor : FluentValidation.AspNetCore.IValidatorInterceptor {
+	public class ClearErrorsInterceptor : IValidatorInterceptor {
 		public IValidationContext BeforeAspNetValidation(ActionContext cc, IValidationContext context) {
 			return null;
 		}
@@ -314,7 +314,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		public string Name { get; set; }
 		public string Name2 { get; set; }
 
-		public IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> Validate(System.ComponentModel.DataAnnotations.ValidationContext validationContext) {
+		public IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> Validate(ValidationContext validationContext) {
 			yield return new System.ComponentModel.DataAnnotations.ValidationResult("Fail", new[] {"Name2"});
 		}
 	}
@@ -335,7 +335,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		public string Name { get; set; }
 		public string Name2 { get; set; }
 
-		public IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> Validate(System.ComponentModel.DataAnnotations.ValidationContext validationContext) {
+		public IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> Validate(ValidationContext validationContext) {
 			yield return new System.ComponentModel.DataAnnotations.ValidationResult("Fail", new[] {"Name2"});
 		}
 	}

--- a/src/FluentValidation/AssemblyScanner.cs
+++ b/src/FluentValidation/AssemblyScanner.cs
@@ -24,7 +24,6 @@ namespace FluentValidation {
 	using System.Collections.Generic;
 	using System.Linq;
 	using System.Reflection;
-	using Internal;
 
 	/// <summary>
 	/// Class that can be used to find all the validators from a collection of types.

--- a/src/FluentValidation/DefaultValidatorExtensions_Validate.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions_Validate.cs
@@ -18,8 +18,6 @@
 
 namespace FluentValidation {
 	using System;
-	using System.Linq;
-	using System.Linq.Expressions;
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Internal;

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -23,9 +23,7 @@ namespace FluentValidation {
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Internal;
-	using Resources;
 	using Results;
-	using Validators;
 
 	/// <summary>
 	/// Default options that can be used to configure a validator.

--- a/src/FluentValidation/IValidator.cs
+++ b/src/FluentValidation/IValidator.cs
@@ -18,11 +18,8 @@
 
 namespace FluentValidation {
 	using System;
-	using System.Collections.Generic;
-	using System.Linq;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Internal;
 	using Results;
 
 	/// <summary>

--- a/src/FluentValidation/IValidatorDescriptor.cs
+++ b/src/FluentValidation/IValidatorDescriptor.cs
@@ -19,7 +19,6 @@
 namespace FluentValidation {
 	using System.Collections.Generic;
 	using System.Linq;
-	using System.Reflection;
 	using Internal;
 	using Validators;
 

--- a/src/FluentValidation/InlineValidator.cs
+++ b/src/FluentValidation/InlineValidator.cs
@@ -18,10 +18,6 @@
 
 namespace FluentValidation {
 	using System;
-	using System.Collections.Generic;
-	using System.Linq.Expressions;
-	using System.Threading;
-	using System.Threading.Tasks;
 
 	/// <summary>
 	/// Validator implementation that allows rules to be defined without inheriting from AbstractValidator.

--- a/src/FluentValidation/Internal/CompositeValidatorSelector.cs
+++ b/src/FluentValidation/Internal/CompositeValidatorSelector.cs
@@ -21,7 +21,7 @@ namespace FluentValidation.Internal {
 	using System.Linq;
 
 	internal class CompositeValidatorSelector : IValidatorSelector {
-		private IEnumerable<IValidatorSelector> _selectors;
+		private readonly IEnumerable<IValidatorSelector> _selectors;
 
 		public CompositeValidatorSelector(IEnumerable<IValidatorSelector> selectors) {
 			_selectors = selectors;

--- a/src/FluentValidation/Internal/ConditionBuilder.cs
+++ b/src/FluentValidation/Internal/ConditionBuilder.cs
@@ -24,7 +24,7 @@ namespace FluentValidation.Internal {
 	using Validators;
 
 	internal class ConditionBuilder<T> {
-		private TrackingCollection<IValidationRuleInternal<T>> _rules;
+		private readonly TrackingCollection<IValidationRuleInternal<T>> _rules;
 
 		public ConditionBuilder(TrackingCollection<IValidationRuleInternal<T>> rules) {
 			_rules = rules;
@@ -85,7 +85,7 @@ namespace FluentValidation.Internal {
 	}
 
 	internal class AsyncConditionBuilder<T> {
-		private TrackingCollection<IValidationRuleInternal<T>> _rules;
+		private readonly TrackingCollection<IValidationRuleInternal<T>> _rules;
 
 		public AsyncConditionBuilder(TrackingCollection<IValidationRuleInternal<T>> rules) {
 			_rules = rules;
@@ -144,7 +144,7 @@ namespace FluentValidation.Internal {
 	}
 
 	internal class ConditionOtherwiseBuilder<T> : IConditionBuilder {
-		private TrackingCollection<IValidationRuleInternal<T>> _rules;
+		private readonly TrackingCollection<IValidationRuleInternal<T>> _rules;
 		private readonly Func<IValidationContext, bool> _condition;
 
 		public ConditionOtherwiseBuilder(TrackingCollection<IValidationRuleInternal<T>> rules, Func<IValidationContext, bool> condition) {
@@ -168,7 +168,7 @@ namespace FluentValidation.Internal {
 	}
 
 	internal class AsyncConditionOtherwiseBuilder<T> : IConditionBuilder {
-		private TrackingCollection<IValidationRuleInternal<T>> _rules;
+		private readonly TrackingCollection<IValidationRuleInternal<T>> _rules;
 		private readonly Func<IValidationContext, CancellationToken, Task<bool>> _condition;
 
 		public AsyncConditionOtherwiseBuilder(TrackingCollection<IValidationRuleInternal<T>> rules, Func<IValidationContext, CancellationToken, Task<bool>> condition) {

--- a/src/FluentValidation/Internal/ConditionBuilder.cs
+++ b/src/FluentValidation/Internal/ConditionBuilder.cs
@@ -21,7 +21,6 @@ namespace FluentValidation.Internal {
 	using System.Collections.Generic;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Validators;
 
 	internal class ConditionBuilder<T> {
 		private readonly TrackingCollection<IValidationRuleInternal<T>> _rules;

--- a/src/FluentValidation/Internal/Extensions.cs
+++ b/src/FluentValidation/Internal/Extensions.cs
@@ -18,11 +18,8 @@
 
 namespace FluentValidation.Internal {
 	using System;
-	using System.Collections.Generic;
 	using System.Linq.Expressions;
 	using System.Reflection;
-	using System.Text;
-	using Resources;
 
 	/// <summary>
 	/// Useful extensions

--- a/src/FluentValidation/Internal/ExtensionsInternal.cs
+++ b/src/FluentValidation/Internal/ExtensionsInternal.cs
@@ -70,7 +70,7 @@ namespace FluentValidation.Internal {
 						retVal.Append(' ');
 				}
 
-				if(!char.Equals('.', currentChar)
+				if(!Equals('.', currentChar)
 				   || i + 1 == input.Length
 				   || !char.IsUpper(input[i + 1])) {
 					retVal.Append(currentChar);

--- a/src/FluentValidation/Internal/IncludeRule.cs
+++ b/src/FluentValidation/Internal/IncludeRule.cs
@@ -1,10 +1,7 @@
 namespace FluentValidation.Internal {
 	using System;
-	using System.Collections.Generic;
-	using System.Linq;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Results;
 	using Validators;
 
 	/// <summary>

--- a/src/FluentValidation/Internal/MessageBuilderContext.cs
+++ b/src/FluentValidation/Internal/MessageBuilderContext.cs
@@ -1,6 +1,4 @@
 ﻿namespace FluentValidation.Internal {
-	using System;
-	using Resources;
 	using Validators;
 
 	public interface IMessageBuilderContext<T, out TProperty> {

--- a/src/FluentValidation/Internal/MessageBuilderContext.cs
+++ b/src/FluentValidation/Internal/MessageBuilderContext.cs
@@ -16,8 +16,8 @@
 	}
 
 	public class MessageBuilderContext<T,TProperty> : IMessageBuilderContext<T,TProperty> {
-		private ValidationContext<T> _innerContext;
-		private TProperty _value;
+		private readonly ValidationContext<T> _innerContext;
+		private readonly TProperty _value;
 
 		public MessageBuilderContext(ValidationContext<T> innerContext, TProperty value, RuleComponent<T,TProperty> component) {
 			_innerContext = innerContext;

--- a/src/FluentValidation/Internal/MessageFormatter.cs
+++ b/src/FluentValidation/Internal/MessageFormatter.cs
@@ -16,7 +16,6 @@
 // The latest version of this file can be found at https://github.com/FluentValidation/FluentValidation
 #endregion
 namespace FluentValidation.Internal {
-	using System;
 	using System.Collections.Generic;
 	using System.Text.RegularExpressions;
 

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -24,7 +24,6 @@ namespace FluentValidation.Internal {
 	using System.Reflection;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Validators;
 
 	/// <summary>
 	/// Defines a rule associated with a property.

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -204,7 +204,7 @@ namespace FluentValidation.Internal {
 
 				if (!await validator.InvokeAsyncCondition(context, cancellation)) {
 					continue;
-				};
+				}
 
 				if (validator.ShouldValidateAsynchronously(context)) {
 					await InvokePropertyValidatorAsync(context, accessor, propertyName, validator, cancellation);

--- a/src/FluentValidation/Internal/RuleComponent.cs
+++ b/src/FluentValidation/Internal/RuleComponent.cs
@@ -22,7 +22,6 @@ namespace FluentValidation.Internal {
 	using System;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Internal;
 	using Validators;
 
 	/// <summary>

--- a/src/FluentValidation/Internal/RuleComponentForNullableStruct.cs
+++ b/src/FluentValidation/Internal/RuleComponentForNullableStruct.cs
@@ -24,8 +24,8 @@ namespace FluentValidation.Internal {
 	using Validators;
 
 	internal class RuleComponentForNullableStruct<T, TProperty> : RuleComponent<T, TProperty?> where TProperty : struct {
-		private IPropertyValidator<T, TProperty> _propertyValidator;
-		private IAsyncPropertyValidator<T, TProperty> _asyncPropertyValidator;
+		private readonly IPropertyValidator<T, TProperty> _propertyValidator;
+		private readonly IAsyncPropertyValidator<T, TProperty> _asyncPropertyValidator;
 
 		internal RuleComponentForNullableStruct(IPropertyValidator<T, TProperty> propertyValidator)
 			: base(null) {

--- a/src/FluentValidation/Internal/RulesetValidatorSelector.cs
+++ b/src/FluentValidation/Internal/RulesetValidatorSelector.cs
@@ -2,8 +2,6 @@ namespace FluentValidation.Internal {
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
-	using System.Linq.Expressions;
-	using Validators;
 
 	/// <summary>
 	/// Selects validators that belong to the specified rulesets.

--- a/src/FluentValidation/Internal/ValidationStrategy.cs
+++ b/src/FluentValidation/Internal/ValidationStrategy.cs
@@ -20,7 +20,6 @@ namespace FluentValidation.Internal {
 	using System;
 	using System.Collections.Generic;
 	using System.Linq.Expressions;
-	using Internal;
 
 	public class ValidationStrategy<T> {
 		private List<string> _properties;

--- a/src/FluentValidation/Resources/Languages/AlbanianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/AlbanianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class AlbanianLanguage {
 		public const string Culture = "sq";
 

--- a/src/FluentValidation/Resources/Languages/ArabicLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/ArabicLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class ArabicLanguage {
 		public const string Culture = "ar";
 

--- a/src/FluentValidation/Resources/Languages/BengaliLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/BengaliLanguage.cs
@@ -21,7 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
 	internal class BengaliLanguage {
 		public const string Culture = "bn";
 

--- a/src/FluentValidation/Resources/Languages/BosnianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/BosnianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class BosnianLanguage {
 		public const string Culture = "bs";
 

--- a/src/FluentValidation/Resources/Languages/ChineseSimplifiedLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/ChineseSimplifiedLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class ChineseSimplifiedLanguage {
 		public const string Culture = "zh-CN";
 

--- a/src/FluentValidation/Resources/Languages/ChineseTraditionalLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/ChineseTraditionalLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class ChineseTraditionalLanguage {
 		public const string Culture = "zh-TW";
 

--- a/src/FluentValidation/Resources/Languages/CroatianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/CroatianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class CroatianLanguage {
 		public const string Culture = "hr";
 

--- a/src/FluentValidation/Resources/Languages/CzechLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/CzechLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class CzechLanguage {
 		public const string Culture = "cs";
 

--- a/src/FluentValidation/Resources/Languages/DanishLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/DanishLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class DanishLanguage {
 		public const string Culture = "da";
 

--- a/src/FluentValidation/Resources/Languages/DutchLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/DutchLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class DutchLanguage {
 		public const string Culture = "nl";
 

--- a/src/FluentValidation/Resources/Languages/FinnishLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/FinnishLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class FinnishLanguage {
 		public const string Culture = "fi";
 

--- a/src/FluentValidation/Resources/Languages/FrenchLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/FrenchLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class FrenchLanguage {
 		public const string Culture = "fr";
 

--- a/src/FluentValidation/Resources/Languages/GeorgianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/GeorgianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class GeorgianLanguage {
 		public const string Culture = "ka";
 

--- a/src/FluentValidation/Resources/Languages/GermanLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/GermanLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class GermanLanguage {
 		public const string Culture = "de";
 

--- a/src/FluentValidation/Resources/Languages/GreekLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/GreekLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class GreekLanguage {
 		public const string Culture = "el";
 

--- a/src/FluentValidation/Resources/Languages/HebrewLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/HebrewLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class HebrewLanguage {
 		public const string Culture = "he";
 

--- a/src/FluentValidation/Resources/Languages/HindiLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/HindiLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class HindiLanguage {
 		public const string Culture = "hi";
 

--- a/src/FluentValidation/Resources/Languages/HungarianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/HungarianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class HungarianLanguage {
 		public const string Culture = "hu";
 

--- a/src/FluentValidation/Resources/Languages/IcelandicLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/IcelandicLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class IcelandicLanguage {
 		public const string Culture = "is";
 

--- a/src/FluentValidation/Resources/Languages/IndonesianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/IndonesianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class IndonesianLanguage {
 		public const string Culture = "id";
 

--- a/src/FluentValidation/Resources/Languages/ItalianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/ItalianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class ItalianLanguage {
 		public const string Culture = "it";
 

--- a/src/FluentValidation/Resources/Languages/JapaneseLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/JapaneseLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class JapaneseLanguage {
 		public const string Culture = "ja";
 

--- a/src/FluentValidation/Resources/Languages/KoreanLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/KoreanLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class KoreanLanguage {
 		public const string Culture = "ko";
 

--- a/src/FluentValidation/Resources/Languages/MacedonianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/MacedonianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class MacedonianLanguage {
 		public const string Culture = "mk";
 

--- a/src/FluentValidation/Resources/Languages/NorwegianBokmalLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/NorwegianBokmalLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class NorwegianBokmalLanguage {
 		public const string Culture = "nb";
 

--- a/src/FluentValidation/Resources/Languages/PersianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/PersianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class PersianLanguage {
 		public const string Culture = "fa";
 

--- a/src/FluentValidation/Resources/Languages/PolishLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/PolishLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class PolishLanguage {
 		public const string Culture = "pl";
 

--- a/src/FluentValidation/Resources/Languages/PortugueseBrazilLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/PortugueseBrazilLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class PortugueseBrazilLanguage {
 		public const string Culture = "pt-BR";
 

--- a/src/FluentValidation/Resources/Languages/PortugueseLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/PortugueseLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class PortugueseLanguage {
 		public const string Culture = "pt";
 

--- a/src/FluentValidation/Resources/Languages/RomanianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/RomanianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class RomanianLanguage {
 		public const string Culture = "ro";
 

--- a/src/FluentValidation/Resources/Languages/RussianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/RussianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class RussianLanguage {
 		public const string Culture = "ru";
 

--- a/src/FluentValidation/Resources/Languages/SerbianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/SerbianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class SerbianLanguage {
 		public const string Culture = "sr";
 

--- a/src/FluentValidation/Resources/Languages/SlovakLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/SlovakLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class SlovakLanguage {
 		public const string Culture = "sk";
 

--- a/src/FluentValidation/Resources/Languages/SlovenianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/SlovenianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class SlovenianLanguage {
 		public const string Culture = "sl";
 

--- a/src/FluentValidation/Resources/Languages/SpanishLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/SpanishLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class SpanishLanguage {
 		public const string Culture = "es";
 

--- a/src/FluentValidation/Resources/Languages/SwedishLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/SwedishLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class SwedishLanguage {
 		public const string Culture = "sv";
 

--- a/src/FluentValidation/Resources/Languages/TurkishLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/TurkishLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class TurkishLanguage {
 		public const string Culture = "tr";
 

--- a/src/FluentValidation/Resources/Languages/UkrainianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/UkrainianLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class UkrainianLanguage {
 		public const string Culture = "uk";
 

--- a/src/FluentValidation/Resources/Languages/WelshLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/WelshLanguage.cs
@@ -21,8 +21,6 @@
 #pragma warning disable 618
 
 namespace FluentValidation.Resources {
-	using Validators;
-
 	internal class WelshLanguage {
 		public const string Culture = "cy";
 

--- a/src/FluentValidation/Syntax.cs
+++ b/src/FluentValidation/Syntax.cs
@@ -18,7 +18,6 @@
 
 namespace FluentValidation {
 	using System;
-	using Internal;
 	using Validators;
 
 	/// <summary>

--- a/src/FluentValidation/TestHelper/ValidationTestException.cs
+++ b/src/FluentValidation/TestHelper/ValidationTestException.cs
@@ -20,7 +20,7 @@
 namespace FluentValidation.TestHelper {
 	using System;
 	using System.Collections.Generic;
-	using FluentValidation.Results;
+	using Results;
 
 	public class ValidationTestException : Exception {
 		public List<ValidationFailure> Errors { get; }

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -23,7 +23,6 @@ namespace FluentValidation.TestHelper {
 	using System.Collections.Generic;
 	using System.Linq;
 	using System.Linq.Expressions;
-	using System.Reflection;
 	using System.Text.RegularExpressions;
 	using System.Threading;
 	using System.Threading.Tasks;

--- a/src/FluentValidation/Validators/AbstractComparisonValidator.cs
+++ b/src/FluentValidation/Validators/AbstractComparisonValidator.cs
@@ -20,7 +20,6 @@ namespace FluentValidation.Validators {
 	using System;
 	using System.Reflection;
 	using Internal;
-	using Resources;
 
 	/// <summary>
 	/// Base class for all comparison validators

--- a/src/FluentValidation/Validators/AsyncPredicateValidator.cs
+++ b/src/FluentValidation/Validators/AsyncPredicateValidator.cs
@@ -20,8 +20,7 @@ namespace FluentValidation.Validators {
 	using System;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using FluentValidation.Internal;
-	using FluentValidation.Resources;
+	using Internal;
 
 	/// <summary>
 	/// Asynchronous custom validator

--- a/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
+++ b/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
@@ -1,11 +1,8 @@
 namespace FluentValidation.Validators {
 	using System;
-	using System.Collections.Generic;
-	using System.Linq;
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Internal;
-	using Results;
 
 	/// <summary>
 	/// Indicates that this validator wraps another validator.

--- a/src/FluentValidation/Validators/ComparableComparer.cs
+++ b/src/FluentValidation/Validators/ComparableComparer.cs
@@ -19,7 +19,6 @@
 namespace FluentValidation.Validators {
 	using System;
 	using System.Collections.Generic;
-	using System.Drawing;
 
 	internal class ComparableComparer<T> : IComparer<T> where T : IComparable<T> {
 		internal static ComparableComparer<T> Instance { get; }

--- a/src/FluentValidation/Validators/CreditCardValidator.cs
+++ b/src/FluentValidation/Validators/CreditCardValidator.cs
@@ -18,7 +18,6 @@
 
 namespace FluentValidation.Validators {
 	using System.Linq;
-	using Resources;
 
 
 	/// <summary>

--- a/src/FluentValidation/Validators/EmailValidator.cs
+++ b/src/FluentValidation/Validators/EmailValidator.cs
@@ -19,7 +19,6 @@
 namespace FluentValidation.Validators {
 	using System;
 	using System.Text.RegularExpressions;
-	using Resources;
 
 	/// <summary>
 	/// Defines which mode should be used for email validation.

--- a/src/FluentValidation/Validators/EmptyValidator.cs
+++ b/src/FluentValidation/Validators/EmptyValidator.cs
@@ -21,7 +21,6 @@
 namespace FluentValidation.Validators {
 	using System;
 	using System.Collections;
-	using Resources;
 	using System.Linq;
 
 	public class EmptyValidator<T,TProperty> : PropertyValidator<T,TProperty> {

--- a/src/FluentValidation/Validators/EnumValidator.cs
+++ b/src/FluentValidation/Validators/EnumValidator.cs
@@ -21,8 +21,6 @@
 namespace FluentValidation.Validators {
 	using System;
 	using System.Reflection;
-	using FluentValidation.Internal;
-	using Resources;
 
 	public class EnumValidator<T, TProperty> : PropertyValidator<T,TProperty> {
 		private readonly Type _enumType = typeof(TProperty);

--- a/src/FluentValidation/Validators/ExclusiveBetweenValidator.cs
+++ b/src/FluentValidation/Validators/ExclusiveBetweenValidator.cs
@@ -17,7 +17,6 @@
 #endregion
 
 namespace FluentValidation.Validators {
-	using System;
 	using System.Collections.Generic;
 
 	/// <summary>

--- a/src/FluentValidation/Validators/GreaterThanOrEqualValidator.cs
+++ b/src/FluentValidation/Validators/GreaterThanOrEqualValidator.cs
@@ -43,7 +43,7 @@ namespace FluentValidation.Validators {
 			return value.CompareTo(valueToCompare) >= 0;
 		}
 
-		public override Comparison Comparison => Validators.Comparison.GreaterThanOrEqual;
+		public override Comparison Comparison => Comparison.GreaterThanOrEqual;
 
 		protected override string GetDefaultMessageTemplate(string errorCode) {
 			return Localized(errorCode, Name);

--- a/src/FluentValidation/Validators/GreaterThanValidator.cs
+++ b/src/FluentValidation/Validators/GreaterThanValidator.cs
@@ -19,8 +19,6 @@
 namespace FluentValidation.Validators {
 	using System;
 	using System.Reflection;
-	using Internal;
-	using Resources;
 
 	public class GreaterThanValidator<T, TProperty> : AbstractComparisonValidator<T, TProperty> where TProperty : IComparable<TProperty>, IComparable {
 

--- a/src/FluentValidation/Validators/GreaterThanValidator.cs
+++ b/src/FluentValidation/Validators/GreaterThanValidator.cs
@@ -42,7 +42,7 @@ namespace FluentValidation.Validators {
 			return value.CompareTo(valueToCompare) > 0;
 		}
 
-		public override Comparison Comparison => Validators.Comparison.GreaterThan;
+		public override Comparison Comparison => Comparison.GreaterThan;
 
 		protected override string GetDefaultMessageTemplate(string errorCode) {
 			return Localized(errorCode, Name);

--- a/src/FluentValidation/Validators/IPropertyValidator.cs
+++ b/src/FluentValidation/Validators/IPropertyValidator.cs
@@ -17,12 +17,8 @@
 #endregion
 
 namespace FluentValidation.Validators {
-	using System;
-	using System.Collections.Generic;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Resources;
-	using Results;
 
 	public interface IAsyncPropertyValidator<T, in TProperty> : IPropertyValidator {
 		/// <summary>

--- a/src/FluentValidation/Validators/InclusiveBetweenValidator.cs
+++ b/src/FluentValidation/Validators/InclusiveBetweenValidator.cs
@@ -17,7 +17,6 @@
 #endregion
 
 namespace FluentValidation.Validators {
-	using System;
 	using System.Collections.Generic;
 
 	/// <summary>

--- a/src/FluentValidation/Validators/LegacyPropertyValidator.cs
+++ b/src/FluentValidation/Validators/LegacyPropertyValidator.cs
@@ -33,7 +33,7 @@ namespace FluentValidation.Validators {
 
 	internal class LegacyValidatorAdaptor<T, TProperty> : IPropertyValidator<T, TProperty>, IAsyncPropertyValidator<T, TProperty>, ILegacyValidatorAdaptor {
 
-		private PropertyValidator _inner;
+		private readonly PropertyValidator _inner;
 
 		public LegacyValidatorAdaptor(PropertyValidator inner) {
 			_inner = inner;

--- a/src/FluentValidation/Validators/LengthValidator.cs
+++ b/src/FluentValidation/Validators/LengthValidator.cs
@@ -18,7 +18,6 @@
 
 namespace FluentValidation.Validators {
 	using System;
-	using Resources;
 
 	public class LengthValidator<T> : PropertyValidator<T,string>, ILengthValidator {
 		public override string Name => "LengthValidator";

--- a/src/FluentValidation/Validators/LessThanOrEqualValidator.cs
+++ b/src/FluentValidation/Validators/LessThanOrEqualValidator.cs
@@ -19,7 +19,6 @@
 namespace FluentValidation.Validators {
 	using System;
 	using System.Reflection;
-	using Resources;
 
 	public class LessThanOrEqualValidator<T, TProperty> : AbstractComparisonValidator<T, TProperty>, ILessThanOrEqualValidator where TProperty : IComparable<TProperty>, IComparable {
 

--- a/src/FluentValidation/Validators/NoopPropertyValidator.cs
+++ b/src/FluentValidation/Validators/NoopPropertyValidator.cs
@@ -17,13 +17,6 @@
 #endregion
 
 namespace FluentValidation.Validators {
-	using System;
-	using System.Collections.Generic;
-	using System.Threading;
-	using System.Threading.Tasks;
-	using Resources;
-	using Results;
-
 	public abstract class NoopPropertyValidator<T,TProperty> : PropertyValidator<T,TProperty> {
 		public override bool IsValid(ValidationContext<T> context, TProperty value) {
 			return true;

--- a/src/FluentValidation/Validators/NotEmptyValidator.cs
+++ b/src/FluentValidation/Validators/NotEmptyValidator.cs
@@ -33,7 +33,7 @@ namespace FluentValidation.Validators {
 				case null:
 				case string s when string.IsNullOrWhiteSpace(s):
 				case ICollection {Count: 0}:
-				case Array {Length: 0}c:
+				case Array {Length: 0}:
 				case IEnumerable e when !e.Cast<object>().Any():
 					return false;
 			}

--- a/src/FluentValidation/Validators/NotEmptyValidator.cs
+++ b/src/FluentValidation/Validators/NotEmptyValidator.cs
@@ -22,7 +22,6 @@ namespace FluentValidation.Validators {
 	using System;
 	using System.Collections;
 	using System.Linq;
-	using Resources;
 
 	public class NotEmptyValidator<T,TProperty> : PropertyValidator<T, TProperty>, INotEmptyValidator {
 

--- a/src/FluentValidation/Validators/NotEqualValidator.cs
+++ b/src/FluentValidation/Validators/NotEqualValidator.cs
@@ -18,10 +18,8 @@
 
 namespace FluentValidation.Validators {
 	using System;
-	using System.Collections;
 	using System.Collections.Generic;
 	using System.Reflection;
-	using Resources;
 
 	public class NotEqualValidator<T,TProperty> : PropertyValidator<T,TProperty>, IComparisonValidator {
 		private readonly IEqualityComparer<TProperty> _comparer;

--- a/src/FluentValidation/Validators/NotNullValidator.cs
+++ b/src/FluentValidation/Validators/NotNullValidator.cs
@@ -17,9 +17,6 @@
 #endregion
 
 namespace FluentValidation.Validators {
-	using System;
-	using Resources;
-
 	public class NotNullValidator<T,TProperty> : PropertyValidator<T,TProperty>, INotNullValidator {
 
 		public override string Name => "NotNullValidator";

--- a/src/FluentValidation/Validators/PolymorphicValidator.cs
+++ b/src/FluentValidation/Validators/PolymorphicValidator.cs
@@ -114,7 +114,7 @@ namespace FluentValidation.Validators {
 		}
 
 		private class DerivedValidatorFactory {
-			private IValidator _innerValidator;
+			private readonly IValidator _innerValidator;
 			private readonly Func<ValidationContext<T>, TProperty, IValidator> _factory;
 			public string[] RuleSets { get; }
 

--- a/src/FluentValidation/Validators/PredicateValidator.cs
+++ b/src/FluentValidation/Validators/PredicateValidator.cs
@@ -18,7 +18,6 @@
 
 namespace FluentValidation.Validators {
 	using Internal;
-	using Resources;
 
 	public class PredicateValidator<T,TProperty> : PropertyValidator<T,TProperty>, IPredicateValidator {
 		public delegate bool Predicate(T instanceToValidate, TProperty propertyValue, ValidationContext<T> propertyValidatorContext);

--- a/src/FluentValidation/Validators/RegularExpressionValidator.cs
+++ b/src/FluentValidation/Validators/RegularExpressionValidator.cs
@@ -19,7 +19,6 @@
 namespace FluentValidation.Validators {
 	using System;
 	using System.Text.RegularExpressions;
-	using Resources;
 
 	public class RegularExpressionValidator<T> : PropertyValidator<T,string>, IRegularExpressionValidator {
 		readonly Func<T, Regex> _regexFunc;

--- a/src/FluentValidation/Validators/ScalePrecisionValidator.cs
+++ b/src/FluentValidation/Validators/ScalePrecisionValidator.cs
@@ -20,7 +20,6 @@
 
 namespace FluentValidation.Validators {
 	using System;
-	using Resources;
 
 	// Attribution: This class was contributed to FluentValidation using code posted on StackOverflow by Jon Skeet
 	// The original code can be found at https://stackoverflow.com/a/764102

--- a/src/FluentValidation/Validators/StringEnumValidator.cs
+++ b/src/FluentValidation/Validators/StringEnumValidator.cs
@@ -19,9 +19,6 @@
 namespace FluentValidation.Validators {
 	using System;
 	using System.Linq;
-	using System.Reflection;
-	using FluentValidation.Internal;
-	using Resources;
 
 	public class StringEnumValidator<T> : PropertyValidator<T, string> {
 		private readonly Type _enumType;


### PR DESCRIPTION
This PR contains the following minor changes:

- Fields that are only assigned in the constructor have been marked as 'readonly'.
Readonly fields can only be assigned in a class constructor. If a class has a field that's not marked as 'readonly' but is only set in the constructor, it could cause confusion about the field's intended use. To avoid confusion, it would be better to mark such fields 'readonly' to make their intended use explicit, and to prevent future maintainers from inadvertently changing their use.

- Redundant empty statements, unused 'using' directives, name qualifiers and boolean comparisons have been removed.
Although all that things won't change anything to the code, removing them:
	- Will help readability and maintenance;
	- Will help reduce the number of items in the IDE auto-completion list when coding;
	- May avoid some name collisions;
	- May improve compilation time (e.g. because the compiler has fewer namespaces to look-up when it resolves types).