### PR TITLE
Fix typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ## General support, feedback, and discussions
-FluentValidation is maintained on a voluntary basis, and unfortunately this means we are unable to provide general support or answer questions on usage due to the time and effort required to moderate these. The issue tracker should only be used for bug reports in the core FluentValidation library, or feature requests where appropriate. Requests for general support or questions on usage will be closed. We appreciate that this may appear strict, but is necessary to protect the free time and mental health of the project's maintainers. Thank you for understanding. 
+FluentValidation is maintained on a voluntary basis, and unfortunately this means we are unable to provide general support or answer questions on usage due to the time and effort required to moderate these. The issue tracker should only be used for bug reports in the core FluentValidation library, or feature requests where appropriate. Requests for general support or questions on usage will be closed. We appreciate that this may appear strict, but is necessary to protect the free time and mental health of the project's maintainers. Thank you for understanding.
 
 ## Filing bug reports and feature requests
 The best way to get your bug fixed is to be as detailed as you can be about the problem.
@@ -13,10 +13,10 @@ Please ensure all sample code is properly formatted and readable (GitHub support
 We do our best to respond to all bug reports and feature requests, but FluentValidation is maintained on a voluntary basis and we cannot guarantee how quickly these will be looked at.
 
 ## Contributing Code
-Please open an issue to discuss new feature requests before submitting a Pull Request. This allows the maintainers to discuss whether your feature is a suitible fit for the project before any code is written. Please don't open a pull request without first discussing whether the feature fits with the project roadmap.
+Please open an issue to discuss new feature requests before submitting a Pull Request. This allows the maintainers to discuss whether your feature is a suitable fit for the project before any code is written. Please don't open a pull request without first discussing whether the feature fits with the project roadmap.
 
 ## Building the code
-Run `Build.cmd` (windows) or build.sh (Linux/mac) from the command line. This builds the project and and runs tests. Building requires the following software to be installed:
+Run `Build.cmd` (windows) or build.sh (Linux/mac) from the command line. This builds the project and runs tests. Building requires the following software to be installed:
 
 * Windows Powershell or Powershell Core
 * .NET Core 3.1 SDK
@@ -35,7 +35,7 @@ Tests must be provided for all pull requests that add or change functionality.
 Please ensure that you follow the existing code-style when adding new code to the project. This may seem pedantic, but it makes it much easier to review pull requests when contributed code matches the existing project style. Specifically:
 - Please ensure that your editor is configured to use tabs for indentation, not spaces
 - Please ensure that the project copyright notice is included in the header for all files.
-- Please ensure `using` statements are inside the namespace delcaration
+- Please ensure `using` statements are inside the namespace declaration
 - Please ensure that all opening braces are on the end of line:
 
 ```csharp

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,4 +37,4 @@ body:
     value: |
       Please ensure that any code samples are readable and [properly formatted as code blocks](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks).
       
-      **Please realise that it is up to you to debug your code thorougly. Be as certain as possible that the bug is with FluentValidation, and not with your own code, prior to opening an issue.**
+      **Please realise that it is up to you to debug your code thoroughly. Be as certain as possible that the bug is with FluentValidation, and not with your own code, prior to opening an issue.**

--- a/docs/aspnet.md
+++ b/docs/aspnet.md
@@ -45,11 +45,11 @@ services.AddMvc()
   .AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>());
 ```
 
-Validators that are registered automatically using `RegisterValidationsFromAssemblyContaining` are registered as `Scoped` with the container rather than as `Singleton`. This is done to avoid lifecycle scoping issues where a developer may inadvertantly cause a singleton-scoped validator from depending on a Transient or Request-scoped service (for example, a DB context). If you are aware of these kind of issues and understand how to avoid them, then you may choose to register the validators as singletons instead, which will give a performance boost by passing in a second argument: `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(lifetime: ServiceLifetime.Singleton)` (note that this optional parameter is only available in FluentValidation 9.0 or later).
+Validators that are registered automatically using `RegisterValidatorsFromAssemblyContaining` are registered as `Scoped` with the container rather than as `Singleton`. This is done to avoid lifecycle scoping issues where a developer may inadvertently cause a singleton-scoped validator from depending on a Transient or Request-scoped service (for example, a DB context). If you are aware of these kind of issues and understand how to avoid them, then you may choose to register the validators as singletons instead, which will give a performance boost by passing in a second argument: `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(lifetime: ServiceLifetime.Singleton)` (note that this optional parameter is only available in FluentValidation 9.0 or later).
 
 By default, only public validators will be registered. To include internal validators you can set the `includeInternalTypes` optional parameter to `true` (e.g., `fv.RegisterValidatorsFromAssemblyContaining<PersonValidator>(includeInternalTypes: true)`).
 
-You can also optionally prevent certain types from being automatically registered when using this approach by passing a filter to `RegisterValidationsFromAssemblyContaining`. For example, if there is a specific validator type that you don't want to be registered, you can use a filter callback to exclude it:
+You can also optionally prevent certain types from being automatically registered when using this approach by passing a filter to `RegisterValidatorsFromAssemblyContaining`. For example, if there is a specific validator type that you don't want to be registered, you can use a filter callback to exclude it:
 
 ```csharp
 services.AddMvc()

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -103,7 +103,7 @@ public class PersonValidator : AbstractValidator<Person> {
 
 ## Stop vs StopOnFirstFailure
 
-In FluentValidation 9.0 and older, the `CascadeMode.StopOnFirstFailure` option provided control over the cascade at the rule-level, but did not behave in an intutive way when set at the validator-level. To illustrate the difference, examine the following example:
+In FluentValidation 9.0 and older, the `CascadeMode.StopOnFirstFailure` option provided control over the cascade at the rule-level, but did not behave in an intuitive way when set at the validator-level. To illustrate the difference, examine the following example:
 
 ```csharp
 public PersonValidator() {
@@ -121,7 +121,7 @@ RuleFor(x => x.Surname).Cascade(CascadeMode.StopOnFirstFailure).NotNull().NotEqu
 RuleFor(x => x.Forename).Cascade(CascadeMode.StopOnFirstFailure).NotNull().NotEqual("foo");
 ```
 
-That is, *both* of these rules will execute. If the `NotNull` fails on the first rule for `Surname`, the `NotEqual` will not be run. However, as the second rule for `Forename` is independent, it will also run with the same behaviour (if its `NotNull` fails, then its `NotEqual` will not run either), so so by setting the validator's cascade to `StopOnFirstFailure`, you will still receive 2 validation failures (one from each rule).
+That is, *both* of these rules will execute. If the `NotNull` fails on the first rule for `Surname`, the `NotEqual` will not be run. However, as the second rule for `Forename` is independent, it will also run with the same behaviour (if its `NotNull` fails, then its `NotEqual` will not run either), so by setting the validator's cascade to `StopOnFirstFailure`, you will still receive 2 validation failures (one from each rule).
 
 This behaviour has caused a lot of confusion over the years, so the `Stop` option was introduced in FluentValidation 9.1. With `Stop`, only the first failure for *any rule* will be returned. This is a true "fail-fast" behaviour.
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -31,7 +31,7 @@ Used only in the Length validator:
 * `{MaxLength}` – Maximum length
 * `{TotalLength}` – Number of characters entered
 
-For a complete list of error message placeholders see the the [Built in Validators page](built-in-validators). Each built in validator has its own supported placeholders.
+For a complete list of error message placeholders see the [Built in Validators page](built-in-validators). Each built in validator has its own supported placeholders.
 
 It is also possible to use your own custom arguments in the validation message. These can either be static values or references to other properties on the object being validated. This can be done by using the overload of `WithMessage` that takes a lambda expression, and then passing the values to `string.Format` or by using string interpolation.
 

--- a/docs/custom-validators.md
+++ b/docs/custom-validators.md
@@ -151,7 +151,7 @@ public class ListCountValidator<T, TCollectionElement> : PropertyValidator<T, IL
 		=> "{PropertyName} must contain fewer than {MaxElements} items.";
 }
 ```
-When you inherit from `PropertyValidator` you must override the `IsValid` method. This method receives two vaues - the `ValidationContext<T>` representing the current validation run, and the value of the property. The method should return a boolean indicating whether validation was successful. The generic type parameters on the base class represent the root instance being validated, and the type of the property that our custom validator can act upon. In this case we're constraining the custom validator to types that implement `IList<TCollectionElement>` although this can be left open if desired.
+When you inherit from `PropertyValidator` you must override the `IsValid` method. This method receives two values - the `ValidationContext<T>` representing the current validation run, and the value of the property. The method should return a boolean indicating whether validation was successful. The generic type parameters on the base class represent the root instance being validated, and the type of the property that our custom validator can act upon. In this case we're constraining the custom validator to types that implement `IList<TCollectionElement>` although this can be left open if desired.
 
 Note that the error message to use is specified by overriding `GetDefaultMessageTemplate`.
 

--- a/docs/di.md
+++ b/docs/di.md
@@ -1,13 +1,13 @@
 # Dependency Injection
 
-Validators can be used with any dependency injection library, such `Microsoft.Extensions.DependencyInjection`. To inject a validator for a specific model, you should register the validator with the service provider as `IValidator<T>`, where `T` is the type of object being validated. 
+Validators can be used with any dependency injection library, such as `Microsoft.Extensions.DependencyInjection`. To inject a validator for a specific model, you should register the validator with the service provider as `IValidator<T>`, where `T` is the type of object being validated.
 
 For example, imagine you have the following validator defined in your project:
 
 ```csharp
 public class UserValidator : AbstractValidator<User>
 {
-  public UserValidator() 
+  public UserValidator()
   {
     RuleFor(x => x.Name).NotNull();
   }
@@ -65,14 +65,14 @@ You can also make use of the `FluentValidation.DependencyInjectionExtensions` pa
 ```csharp
 using FluentValidation.DependencyInjectionExtensions;
 
-public class Startup 
+public class Startup
 {
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddValidatorsFromAssemblyContaining<UserValidator>();
         // ...
     }
-    
+
     // ...
 }
 ```

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -14,7 +14,7 @@ You could also use the same approach if you need to obtain the localized message
 
 ### IStringLocalizer
 
-The above 2 examples assume you're using a strongly-typed wrapper around a resource file, where each static property on the class corresponds to a key within the resourece file. This is the "old" way of working with resources prior to ASP.NET Core, but is not relevant if you're using ASP.NET Core's `IStringLocalizer`.
+The above 2 examples assume you're using a strongly-typed wrapper around a resource file, where each static property on the class corresponds to a key within the resource file. This is the "old" way of working with resources prior to ASP.NET Core, but is not relevant if you're using ASP.NET Core's `IStringLocalizer`.
 
 If you are using `IStringLocalizer` to handle localization then all you need to do is inject your localizer into your validator, and use it within a `WithMessage` callback, for example:
 
@@ -43,13 +43,13 @@ public class CustomLanguageManager : FluentValidation.Resources.LanguageManager 
 
 Here we have a custom class that inherits from the base `LanguageManager`. In its constructor we call the `AddTranslation` method passing in the language we're using, the name of the validator we want to override, and the new message.
 
-Once this is done, we can replace the default LanguageManager by setting the LanaguageManager property in the static `ValidatorOptions` class during your application's startup routine:
+Once this is done, we can replace the default LanguageManager by setting the LanguageManager property in the static `ValidatorOptions` class during your application's startup routine:
 
 ```csharp
 ValidatorOptions.Global.LanguageManager = new CustomLanguageManager();
 ```
 
-Note that if you replace messages in the `en` culture, you should consider also replacing the messages for `en-US` and `en-GB` too, as these will take precedence for users from these locales.    
+Note that if you replace messages in the `en` culture, you should consider also replacing the messages for `en-US` and `en-GB` too, as these will take precedence for users from these locales.
 
 This is a simple example that only replaces one validator's message in English only, but could be extended to replace the messages for all languages. Instead of inheriting from the default LanguageManager, you could also implement the `ILanguageManager` interface directly if you want to load the messages from a completely different location other than the FluentValidation default (for example, if you wanted to store FluentValidation's default messages in a database).
 
@@ -66,7 +66,7 @@ You can completely disable FluentValidation's support for localization, which wi
 ```csharp
 ValidatorOptions.Global.LanguageManager.Enabled = false;
 ```
-You can could also force the default messages to always be displayed in a specific language:
+You can also force the default messages to always be displayed in a specific language:
 
 ```csharp
 ValidatorOptions.Global.LanguageManager.Culture = new CultureInfo("fr");

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -27,7 +27,7 @@ var result = validator.Validate(person, options => options.IncludeRuleSets("Name
 
 ```eval_rst
 .. note::
-  Many of the methods in FluentValidation are extension methods such as "Validate" above and require the FluentValidation namespace to be imported via an using statement, e.g. "using FluentValidation;". 
+  Many of the methods in FluentValidation are extension methods such as "Validate" above and require the FluentValidation namespace to be imported via a using statement, e.g. "using FluentValidation;".
 ```
 
 This allows you to break down a complex validator definition into smaller segments that can be executed in isolation. If you call `Validate` without passing a ruleset then only rules not in a RuleSet will be executed.

--- a/docs/start.md
+++ b/docs/start.md
@@ -50,7 +50,7 @@ ValidationResult result = validator.Validate(customer);
 
 The `Validate` method returns a ValidationResult object. This contains two properties:
 
-- `IsValid` - a boolean that says whether the validation suceeded.
+- `IsValid` - a boolean that says whether the validation succeeded.
 - `Errors` - a collection of ValidationFailure objects containing details about any validation failures.
 
 The following code would write any validation failures to the console:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,7 +79,7 @@ result.ShouldHaveValidationErrorFor(person => person.Name)
   .WithErrorCode("NotNullValidator");
 ```
 
-There are also inverse methods avaialble (`WithoutMessage`, `WithoutErrorCode`, `WithoutSeverity`, `WithoutCustomState`)
+There are also inverse methods available (`WithoutMessage`, `WithoutErrorCode`, `WithoutSeverity`, `WithoutCustomState`)
 
 ## Asynchronous TestValidate
 

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -8,7 +8,7 @@ Transform(from: x => x.SomeStringProperty, to: value => int.TryParse(value, out 
     .GreaterThan(10);
 ```
 
-This rule transforms the value from a `string` to an nullable `int` (returning `null` if the value couldn't be converted). A greater-than check is then performed on the resulting value.
+This rule transforms the value from a `string` to a nullable `int` (returning `null` if the value couldn't be converted). A greater-than check is then performed on the resulting value.
 
 Syntactically this is not particularly nice to read, so the logic for the transformation can optionally be moved into a separate method:
 

--- a/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
@@ -151,7 +151,7 @@ namespace FluentValidation.AspNetCore {
 		/// Configures clientside validation support
 		/// </summary>
 		/// <param name="clientsideConfig"></param>
-		/// <param name="enabled">Whether clientisde validation integration is enabled</param>
+		/// <param name="enabled">Whether clientside validation integration is enabled</param>
 		/// <returns></returns>
 		public FluentValidationMvcConfiguration ConfigureClientsideValidation(Action<FluentValidationClientModelValidatorProvider> clientsideConfig=null, bool enabled=true) {
 			if (clientsideConfig != null) {

--- a/src/FluentValidation.AspNetCore/ValidationResultExtensions.cs
+++ b/src/FluentValidation.AspNetCore/ValidationResultExtensions.cs
@@ -37,7 +37,7 @@ namespace FluentValidation.AspNetCore {
 		/// </summary>
 		/// <param name="result">The validation result to store</param>
 		/// <param name="modelState">The ModelStateDictionary to store the errors in.</param>
-		/// <param name="prefix">An optional prefix. If ommitted, the property names will be the keys. If specified, the prefix will be concatenatd to the property name with a period. Eg "user.Name"</param>
+		/// <param name="prefix">An optional prefix. If omitted, the property names will be the keys. If specified, the prefix will be concatenated to the property name with a period. Eg "user.Name"</param>
 		public static void AddToModelState(this ValidationResult result, ModelStateDictionary modelState, string prefix) {
 			if (!result.IsValid) {
 				foreach (var error in result.Errors) {
@@ -52,7 +52,7 @@ namespace FluentValidation.AspNetCore {
 		}
 
 		/// <summary>
-		/// Sets the rulests used when generating clientside messages.
+		/// Sets the rulesets used when generating clientside messages.
 		/// </summary>
 		/// <param name="context">Http context</param>
 		/// <param name="ruleSets">Array of ruleset names</param>
@@ -65,7 +65,7 @@ namespace FluentValidation.AspNetCore {
 		/// <returns>Array of ruleset names</returns>
 		public static string[] GetRuleSetsForClientValidation(this HttpContext context) {
 			// If the httpContext is null (for example, if IHttpContextProvider hasn't been registered) then just assume default ruleset.
-			// This is OK because if we're actually using the attribute, the OnActionExecuting will have caught the fact that the provider is not registered. 
+			// This is OK because if we're actually using the attribute, the OnActionExecuting will have caught the fact that the provider is not registered.
 
 			if (context?.Items != null && context.Items.ContainsKey(_rulesetKey) && context?.Items[_rulesetKey] is string[] ruleSets) {
 				return ruleSets;


### PR DESCRIPTION
Fix misspelling, grammar, wording.
A few trailing whitespaces were removed due to `trim_trailing_whitespace=true` in `.editorconfig`.