### PR TITLE
Clientside messages shouldn't be generated for func version of LessThanOrEqual/GreaterThanOrEqual

### DIFF
--- a/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
@@ -232,6 +232,21 @@ namespace FluentValidation.Tests.AspNetCore {
 			lessThan.Attribute("data-val-range").ShouldBeNull();
 			greaterThan.Attribute("data-val-range").ShouldBeNull();
 		}
+
+		[Fact]
+		public async Task Shouldnt_generate_clientside_message_for_LessThanOrEqual_GreaterThanOrEqual_func() {
+			// A call to LessThanOrEqual(x => DateTime.Now) shouldn't generate clientside metadata.
+			var document = await _client.GetClientsideMessages();
+
+			var lessThan = document.Root.Elements("input")
+				.SingleOrDefault(x => x.Attribute("name").Value == "LessThanOrEqualFunc");
+
+			var greaterThan = document.Root.Elements("input")
+				.SingleOrDefault(x => x.Attribute("name").Value == "GreaterThanOrEqualFunc");
+
+			lessThan.Attribute("data-val-range").ShouldBeNull();
+			greaterThan.Attribute("data-val-range").ShouldBeNull();
+		}
 	}
 
 

--- a/src/FluentValidation.Tests.AspNetCore/TestModels_ClientSIde.cs
+++ b/src/FluentValidation.Tests.AspNetCore/TestModels_ClientSIde.cs
@@ -19,9 +19,11 @@
 		public int GreaterThan { get; set; }
 		public int GreaterThanOrEqual { get; set; }
 		public DateTime GreaterThanOrEqualProperty { get; set; }
+		public DateTime GreaterThanOrEqualFunc { get; set; }
 		public int LessThan { get; set; }
 		public int LessThanOrEqual { get; set; }
 		public DateTime LessThanOrEqualProperty { get; set; }
+		public DateTime LessThanOrEqualFunc { get; set; }
 		public DateTime DateTimeComparison { get; set; }
 		public string LengthWithMessage { get; set; }
 		public string CustomPlaceholder { get; set; }
@@ -81,6 +83,8 @@
 			RuleFor(x => x.GreaterThanOrEqual).GreaterThanOrEqualTo(1);
 			RuleFor(x => x.LessThanOrEqualProperty).LessThanOrEqualTo(x => x.DateTimeComparison);
 			RuleFor(x => x.GreaterThanOrEqualProperty).GreaterThanOrEqualTo(x => x.DateTimeComparison);
+			RuleFor(x => x.LessThanOrEqualFunc).LessThanOrEqualTo(x => DateTime.Now);
+			RuleFor(x => x.GreaterThanOrEqualFunc).GreaterThanOrEqualTo(x => DateTime.Now);
 
 			RuleFor(x => x.LengthWithMessage).Length(1, 10).WithMessage("Foo");
 			RuleFor(x => x.CustomPlaceholder).NotNull().WithMessage("{PropertyName} is null.");

--- a/src/FluentValidation.Tests.AspNetCore/Views/Clientside/Inputs.cshtml
+++ b/src/FluentValidation.Tests.AspNetCore/Views/Clientside/Inputs.cshtml
@@ -15,8 +15,10 @@
     <input asp-for="GreaterThan" />
     <input asp-for="GreaterThanOrEqual" />
     <input asp-for="GreaterThanOrEqualProperty"/>
+    <input asp-for="GreaterThanOrEqualFunc" />
     <input asp-for="LessThanOrEqual" />
     <input asp-for="LessThanOrEqualProperty" />
+    <input asp-for="LessThanOrEqualFunc" />
     <input asp-for="LengthWithMessage"/>
     <input asp-for="CustomPlaceholder" />
     <input asp-for="LengthCustomPlaceholders"/>

--- a/src/FluentValidation/Validators/AbstractComparisonValidator.cs
+++ b/src/FluentValidation/Validators/AbstractComparisonValidator.cs
@@ -122,11 +122,11 @@ namespace FluentValidation.Validators {
 		/// Comparison value as non-generic for metadata.
 		/// </summary>
 		object IComparisonValidator.ValueToCompare =>
-			// For clientside validation to work, we must return null if MemberToCompare is set.
+			// For clientside validation to work, we must return null if MemberToCompare or valueToCompareFunc is set.
 			// We can't rely on ValueToCompare being null itself as it's generic, and will be initialized
 			// as default(TProperty) which for non-nullable value types will emit the
 			// default value for the type rather than null. See https://github.com/FluentValidation/FluentValidation/issues/1721
-			MemberToCompare != null ? null : ValueToCompare;
+			MemberToCompare != null || _valueToCompareFunc != null ? null : ValueToCompare;
 	}
 
 	/// <summary>


### PR DESCRIPTION
This similar to the issue resolved in #1721 but occurs if using a func.  