### PR TITLE
New method for test assertions: Only() (#1819)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,7 @@ Remove deprecated RunDefaultMvcValidationAfterFluentValidationExecutes option fr
 Remove deprecated Options property from RuleComponent.
 Remove deprecated TestHelper methods.
 Remove PropertyValidator backwards compatibility layer.
+Add method Only() asserting that no other validation errors were raised.
 
 10.3.1 - 
 Fix scale precision error message when digits is calculated as negative (#1790)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,7 +79,21 @@ result.ShouldHaveValidationErrorFor(person => person.Name)
   .WithErrorCode("NotNullValidator");
 ```
 
-There are also inverse methods available (`WithoutMessage`, `WithoutErrorCode`, `WithoutSeverity`, `WithoutCustomState`)
+If you want to make sure no other validation failures occured, except specified by conditions, use method `Only` after the conditions:
+
+```csharp
+var result = validator.TestValidate(person);
+
+// Assert that failures only happened for Name property.
+result.ShouldHaveValidationErrorFor(person => person.Name).Only();
+
+// Assert that failures only happened for Name property and all have the specified message
+result.ShouldHaveValidationErrorFor(person => person.Name)
+  .WithErrorMessage("'Name' must not be empty.")
+  .Only();
+```
+
+There are also inverse methods available (`WithoutMessage`, `WithoutErrorCode`, `WithoutSeverity`, `WithoutCustomState`).
 
 ## Asynchronous TestValidate
 

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -835,6 +835,138 @@ namespace FluentValidation.Tests {
 			});
 		}
 
+		[Fact]
+		public void ShouldHaveValidationErrorFor_Only() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname).Must((x, ct) => false);
+			validator.TestValidate(new Person())
+				.ShouldHaveValidationErrorFor(x => x.Surname)
+				.Only();
+		}
+
+		[Fact]
+		public void ShouldHaveValidationErrorFor_Only_throws() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname).Must((x, ct) => false);
+			validator.RuleFor(x => x.Age).Must((x, ct) => false);
+			Assert.Throws<ValidationTestException>(() =>
+				validator.TestValidate(new Person())
+					.ShouldHaveValidationErrorFor(x => x.Surname)
+					.Only()
+			).Message.ShouldEqual("Expected to have errors only matching specified conditions\n----\nUnexpected Errors:\n[0]: The specified condition was not met for 'Age'.\n");
+		}
+
+		[Fact]
+		public async Task ShouldHaveValidationErrorFor_Only_async() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(false));
+			(await validator.TestValidateAsync(new Person()))
+				.ShouldHaveValidationErrorFor(x => x.Surname)
+				.Only();
+		}
+
+		[Fact]
+		public async Task ShouldHaveValidationErrorFor_Only_async_throws() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(false));
+			validator.RuleFor(x => x.Age).MustAsync((x, ct) => Task.FromResult(false));
+			(await Assert.ThrowsAsync<ValidationTestException>(async () => {
+				(await validator.TestValidateAsync(new Person()))
+					.ShouldHaveValidationErrorFor(x => x.Surname)
+					.Only();
+			})).Message.ShouldEqual("Expected to have errors only matching specified conditions\n----\nUnexpected Errors:\n[0]: The specified condition was not met for 'Age'.\n");
+		}
+
+		[Fact]
+		public void ShouldHaveValidationErrorFor_WithMultipleRules_Only() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname)
+				.Must((x, ct) => false)
+				.NotEmpty();
+			validator.TestValidate(new Person())
+				.ShouldHaveValidationErrorFor(x => x.Surname)
+				.Only();
+		}
+
+		[Fact]
+		public void ShouldHaveValidationErrorFor_WithMessage_Only_throws() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname)
+				.Must((x, ct) => false)
+				.NotEmpty();
+			Assert.Throws<ValidationTestException>(() =>
+				validator.TestValidate(new Person())
+					.ShouldHaveValidationErrorFor(x => x.Surname)
+					.WithErrorMessage("The specified condition was not met for 'Surname'.")
+					.Only()
+			).Message.ShouldEqual("Expected to have errors only matching specified conditions\n----\nUnexpected Errors:\n[0]: 'Surname' must not be empty.\n");
+		}
+
+		[Fact]
+		public void ShouldHaveValidationErrorFor_WithMessage_Only() {
+			var validator = new InlineValidator<Person>();
+			var message = "Something's wrong but I won't tell you what";
+			validator.RuleFor(x => x.Surname)
+				.Must((x, ct) => false).WithMessage(message)
+				.NotEmpty().WithMessage(message);
+			validator.TestValidate(new Person())
+				.ShouldHaveValidationErrorFor(x => x.Surname)
+				.WithErrorMessage(message)
+				.Only();
+		}
+
+		[Fact]
+		public void ShouldHaveValidationErrorFor_WithSeverity_Only() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname)
+				.Must((x, ct) => false).WithSeverity(Severity.Warning)
+				.NotEmpty().WithSeverity(Severity.Warning);
+			validator.TestValidate(new Person())
+				.ShouldHaveValidationErrorFor(x => x.Surname)
+				.WithSeverity(Severity.Warning)
+				.Only();
+		}
+
+		[Fact]
+		public void ShouldHaveValidationErrorFor_WithSeverity_Only_throws() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname)
+				.Must((x, ct) => false).WithSeverity(Severity.Warning)
+				.NotEmpty();
+			Assert.Throws<ValidationTestException>(() =>
+				validator.TestValidate(new Person())
+					.ShouldHaveValidationErrorFor(x => x.Surname)
+					.WithSeverity(Severity.Warning)
+					.Only()
+			).Message.ShouldEqual("Expected to have errors only matching specified conditions\n----\nUnexpected Errors:\n[0]: 'Surname' must not be empty.\n");
+		}
+
+		[Fact]
+		public void ShouldHaveValidationErrorFor_WithErrorCode_Only() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname)
+				.Must((x, ct) => false).WithErrorCode("100")
+				.NotEmpty().WithErrorCode("100");
+			validator.TestValidate(new Person())
+				.ShouldHaveValidationErrorFor(x => x.Surname)
+				.WithErrorCode("100")
+				.Only();
+		}
+
+		[Fact]
+		public void ShouldHaveValidationErrorFor_WithErrorCode_Only_throws() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => x.Surname)
+				.Must((x, ct) => false).WithErrorCode("100")
+				.NotEmpty().WithErrorCode("200");
+			Assert.Throws<ValidationTestException>(() =>
+				validator.TestValidate(new Person())
+					.ShouldHaveValidationErrorFor(x => x.Surname)
+					.WithErrorCode("100")
+					.Only()
+			).Message.ShouldEqual("Expected to have errors only matching specified conditions\n----\nUnexpected Errors:\n[0]: 'Surname' must not be empty.\n");
+		}
+
 		private class AddressValidator : AbstractValidator<Address> {
 		}
 

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -353,15 +353,7 @@ namespace FluentValidation.Tests {
 			ex.Message.ShouldEqual("Expected an error message of 'foo'. Actual message was 'bar'");
 		}
 
-		/// <summary>
-		/// Full test (for WhenAll)
-		/// </summary>
-		/// <param name="withoutErrMsg"></param>
-		/// <param name="errMessages"></param>
-		/// <param name="shouldBe"></param>
 		[Theory]
-		[InlineData("bar", new string[] { })]
-		[InlineData("bar", new string[] { "foo", })]
 		[InlineData("bar", new string[] { "foo", "bar" })]
 		[InlineData("bar", new string[] { "bar", })]
 		public void Unexpected_message_check(string withoutErrMsg, string[] errMessages) {
@@ -371,7 +363,7 @@ namespace FluentValidation.Tests {
 			}
 
 			var ex = Assert.Throws<ValidationTestException>(() =>
-				validator.TestValidate(new Person { }).Errors.WithoutErrorMessage(withoutErrMsg));
+				validator.TestValidate(new Person { }).ShouldHaveAnyValidationError().WithoutErrorMessage(withoutErrMsg));
 			ex.Message.ShouldEqual($"Found an unexpected error message of '{withoutErrMsg}'");
 		}
 

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -342,23 +342,15 @@ namespace FluentValidation.Tests {
 
 		[Fact]
 		public void Expected_message_check() {
-			bool exceptionCaught = false;
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Surname).NotNull().WithMessage("bar")
+			};
 
-			try {
-				var validator = new InlineValidator<Person> {
-					v => v.RuleFor(x => x.Surname).NotNull().WithMessage("bar")
-				};
+			var ex = Assert.Throws<ValidationTestException>(() =>
 				validator.TestValidate(new Person())
 					.ShouldHaveValidationErrorFor(x => x.Surname)
-					.WithErrorMessage("foo");
-			}
-			catch (ValidationTestException e) {
-				exceptionCaught = true;
-
-				e.Message.ShouldEqual("Expected an error message of 'foo'. Actual message was 'bar'");
-			}
-
-			exceptionCaught.ShouldBeTrue();
+					.WithErrorMessage("foo"));
+			ex.Message.ShouldEqual("Expected an error message of 'foo'. Actual message was 'bar'");
 		}
 
 		/// <summary>
@@ -373,91 +365,57 @@ namespace FluentValidation.Tests {
 		[InlineData("bar", new string[] { "foo", "bar" })]
 		[InlineData("bar", new string[] { "bar", })]
 		public void Unexpected_message_check(string withoutErrMsg, string[] errMessages) {
-			bool exceptionCaught = false;
-
-			try {
-				var validator = new InlineValidator<Person>();
-				foreach (var msg in errMessages) {
-					validator.Add(v => v.RuleFor(x => x.Surname).NotNull().WithMessage(msg));
-				}
-
-				validator.TestValidate(new Person { }).Errors.WithoutErrorMessage(withoutErrMsg);
-			}
-			catch (ValidationTestException e) {
-				exceptionCaught = true;
-
-				e.Message.ShouldEqual($"Found an unexpected error message of '{withoutErrMsg}'");
+			var validator = new InlineValidator<Person>();
+			foreach (var msg in errMessages) {
+				validator.Add(v => v.RuleFor(x => x.Surname).NotNull().WithMessage(msg));
 			}
 
-			exceptionCaught.ShouldEqual(errMessages.Contains(withoutErrMsg));
+			var ex = Assert.Throws<ValidationTestException>(() =>
+				validator.TestValidate(new Person { }).Errors.WithoutErrorMessage(withoutErrMsg));
+			ex.Message.ShouldEqual($"Found an unexpected error message of '{withoutErrMsg}'");
 		}
 
 		[Fact]
 		public void Expected_message_argument_check() {
-			bool exceptionCaught = false;
-
-			try {
-				var validator = new InlineValidator<Person> {
-					v => v.RuleFor(x => x.Surname)
-						.Must((x, y, context) => {
-							context.MessageFormatter.AppendArgument("Foo", "bar");
-							return false;
-						})
-						.WithMessage("{Foo}")
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Surname)
+					.Must((x, y, context) => {
+						context.MessageFormatter.AppendArgument("Foo", "bar");
+						return false;
+					})
+					.WithMessage("{Foo}")
 				};
+			var ex = Assert.Throws<ValidationTestException>(() =>
 				validator.TestValidate(new Person())
 					.ShouldHaveValidationErrorFor(x => x.Surname)
-					.WithMessageArgument("Foo", "foo");
-			}
-			catch (ValidationTestException e) {
-				exceptionCaught = true;
-				e.Message.ShouldEqual("Expected message argument 'Foo' with value 'foo'. Actual value was 'bar'");
-			}
-
-			exceptionCaught.ShouldBeTrue();
+					.WithMessageArgument("Foo", "foo")
+			);
+			ex.Message.ShouldEqual("Expected message argument 'Foo' with value 'foo'. Actual value was 'bar'");
 		}
 
 		[Fact]
 		public void Expected_state_check() {
-			bool exceptionCaught = false;
-
-			try {
-				var validator = new InlineValidator<Person> {
-					v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "bar")
-				};
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "bar")
+			};
+			var ex = Assert.Throws<ValidationTestException>(() =>
 				validator.TestValidate(new Person())
 					.ShouldHaveValidationErrorFor(x => x.Surname)
-					.WithCustomState("foo");
-			}
-			catch (ValidationTestException e) {
-				exceptionCaught = true;
-
-				e.Message.ShouldEqual("Expected custom state of 'foo'. Actual state was 'bar'");
-			}
-
-			exceptionCaught.ShouldBeTrue();
+					.WithCustomState("foo"));
+			ex.Message.ShouldEqual("Expected custom state of 'foo'. Actual state was 'bar'");
 		}
 
 		[Fact]
 		public void Unexpected_state_check() {
-			bool exceptionCaught = false;
-
-			try {
-				var validator = new InlineValidator<Person> {
-					v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "bar"),
-					v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "foo"),
-				};
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "bar"),
+				v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "foo"),
+			};
+			var ex = Assert.Throws<ValidationTestException>(() =>
 				validator.TestValidate(new Person())
 					.ShouldHaveValidationErrorFor(x => x.Surname)
-					.WithoutCustomState("bar");
-			}
-			catch (ValidationTestException e) {
-				exceptionCaught = true;
-
-				e.Message.ShouldEqual("Found an unexpected custom state of 'bar'");
-			}
-
-			exceptionCaught.ShouldBeTrue();
+					.WithoutCustomState("bar"));
+			ex.Message.ShouldEqual("Found an unexpected custom state of 'bar'");
 		}
 
 		[Fact]
@@ -496,88 +454,55 @@ namespace FluentValidation.Tests {
 
 		[Fact]
 		public void Expected_error_code_check() {
-			bool exceptionCaught = false;
-
-			try {
-				var validator = new InlineValidator<Person> {
-					v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("bar")
-				};
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("bar")
+			};
+			var ex = Assert.Throws<ValidationTestException>(() =>
 				validator.TestValidate(new Person())
 					.ShouldHaveValidationErrorFor(x => x.Surname)
-					.WithErrorCode("foo");
-			}
-			catch (ValidationTestException e) {
-				exceptionCaught = true;
-
-				e.Message.ShouldEqual("Expected an error code of 'foo'. Actual error code was 'bar'");
-			}
-
-			exceptionCaught.ShouldBeTrue();
+					.WithErrorCode("foo"));
+			ex.Message.ShouldEqual("Expected an error code of 'foo'. Actual error code was 'bar'");
 		}
 
 		[Fact]
 		public void Unexpected_error_code_check() {
-			bool exceptionCaught = false;
-
-			try {
-				var validator = new InlineValidator<Person> {
-					v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("bar"),
-					v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("foo")
-				};
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("bar"),
+				v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("foo")
+			};
+			var ex = Assert.Throws<ValidationTestException>(() =>
 				validator.TestValidate(new Person())
 					.ShouldHaveValidationErrorFor(x => x.Surname)
-					.WithoutErrorCode("bar");
-			}
-			catch (ValidationTestException e) {
-				exceptionCaught = true;
-
-				e.Message.ShouldEqual("Found an unexpected error code of 'bar'");
-			}
-
-			exceptionCaught.ShouldBeTrue();
+					.WithoutErrorCode("bar"));
+				ex.Message.ShouldEqual("Found an unexpected error code of 'bar'");
 		}
 
 		[Fact]
 		public void Expected_severity_check() {
-			bool exceptionCaught = false;
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Warning)
+			};
 
-			try {
-				var validator = new InlineValidator<Person> {
-					v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Warning)
-				};
+			var ex = Assert.Throws<ValidationTestException>(() =>
 				validator.TestValidate(new Person())
 					.ShouldHaveValidationErrorFor(x => x.Surname)
-					.WithSeverity(Severity.Error);
-			}
-			catch (ValidationTestException e) {
-				exceptionCaught = true;
+					.WithSeverity(Severity.Error));
 
-				e.Message.ShouldEqual($"Expected a severity of '{nameof(Severity.Error)}'. Actual severity was '{nameof(Severity.Warning)}'");
-			}
-
-			exceptionCaught.ShouldBeTrue();
+			ex.Message.ShouldEqual($"Expected a severity of '{nameof(Severity.Error)}'. Actual severity was '{nameof(Severity.Warning)}'");
 		}
 
 		[Fact]
 		public void Unexpected_severity_check() {
-			bool exceptionCaught = false;
-
-			try {
-				var validator = new InlineValidator<Person> {
-					v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Warning),
-					v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Error),
-				};
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Warning),
+				v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Error),
+			};
+			var ex = Assert.Throws<ValidationTestException>(() =>
 				validator.TestValidate(new Person())
 					.ShouldHaveValidationErrorFor(x => x.Surname)
-					.WithoutSeverity(Severity.Warning);
-			}
-			catch (ValidationTestException e) {
-				exceptionCaught = true;
+					.WithoutSeverity(Severity.Warning));
 
-				e.Message.ShouldEqual($"Found an unexpected severity of '{nameof(Severity.Warning)}'");
-			}
-
-			exceptionCaught.ShouldBeTrue();
+			ex.Message.ShouldEqual($"Found an unexpected severity of '{nameof(Severity.Warning)}'");
 		}
 
 		[Theory]
@@ -716,17 +641,8 @@ namespace FluentValidation.Tests {
 			validator.RuleFor(x => x.Surname).Must(x => false);
 
 			var result = validator.TestValidate(new Person());
-
-			bool thrown = false;
-			try {
-				result.ShouldHaveValidationErrorFor(x => x);
-				result.ShouldHaveValidationErrorFor("");
-			}
-			catch (ValidationTestException) {
-				thrown = true;
-			}
-
-			thrown.ShouldBeFalse();
+			result.ShouldHaveValidationErrorFor(x => x);
+			result.ShouldHaveValidationErrorFor("");
 		}
 
 		[Fact]

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -875,6 +875,31 @@ namespace FluentValidation.Tests {
 			).Message.ShouldEqual("Expected to have errors only matching specified conditions\n----\nUnexpected Errors:\n[0]: 'Surname' must not be empty.\n");
 		}
 
+		[Fact]
+		public void ShouldHaveValidationErrorFor_WithPropertyName_Only() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => DateTime.Now)
+				.Must((x, ct) => false);
+			validator.TestValidate(new Person())
+				.ShouldHaveValidationErrorFor("Now")
+				.WithErrorMessage("The specified condition was not met for 'Now'.")
+				.Only();
+		}
+
+		[Fact]
+		public void ShouldHaveValidationErrorFor_WithPropertyName_Only_throws() {
+			var validator = new InlineValidator<Person>();
+			validator.RuleFor(x => DateTime.Now)
+				.Must((x, ct) => false)
+				.LessThan(new DateTime(1900, 1, 1));
+			Assert.Throws<ValidationTestException>(() =>
+				validator.TestValidate(new Person())
+					.ShouldHaveValidationErrorFor("Now")
+					.WithErrorMessage("The specified condition was not met for 'Now'.")
+					.Only()
+			).Message.ShouldEqual("Expected to have errors only matching specified conditions\n----\nUnexpected Errors:\n[0]: 'Now' must be less than '1/1/1900 12:00:00 AM'.\n");
+		}
+
 		private class AddressValidator : AbstractValidator<Address> {
 		}
 

--- a/src/FluentValidation/TestHelper/ITestValidationContinuation.cs
+++ b/src/FluentValidation/TestHelper/ITestValidationContinuation.cs
@@ -1,0 +1,69 @@
+namespace FluentValidation.TestHelper {
+	using System;
+	using System.Collections;
+	using System.Collections.Generic;
+	using System.Linq;
+	using Results;
+
+	public interface ITestValidationContinuation : IEnumerable<ValidationFailure> {
+		IEnumerable<ValidationFailure> UnmatchedFailures { get; }
+	}
+
+	internal class TestValidationContinuation : ITestValidationContinuation {
+		private readonly IEnumerable<ValidationFailure> _allFailures;
+		private readonly List<Func<ValidationFailure,bool>> _predicates;
+
+		public static TestValidationContinuation Create(IEnumerable<ValidationFailure> failures) =>
+			new TestValidationContinuation(failures);
+
+		public static TestValidationContinuation Create(ITestValidationContinuation continuation) {
+			if (continuation is TestValidationContinuation instance)
+				return instance;
+			var allFailures = continuation.Union(continuation.UnmatchedFailures);
+			instance = new TestValidationContinuation(allFailures);
+			instance.ApplyPredicate(failure => !continuation.UnmatchedFailures.Contains(failure));
+			return instance;
+		}
+
+		private TestValidationContinuation(IEnumerable<ValidationFailure> failures) {
+			_allFailures = failures;
+			_predicates = new List<Func<ValidationFailure, bool>>();
+		}
+
+		public void ApplyPredicate(Func<ValidationFailure, bool> failurePredicate) {
+			_predicates.Add(failurePredicate);
+		}
+
+		public IEnumerator<ValidationFailure> GetEnumerator() {
+			return MatchedFailures.GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() {
+			return ((IEnumerable) MatchedFailures).GetEnumerator();
+		}
+
+		public IEnumerable<ValidationFailure> MatchedFailures {
+			get {
+				var matchedFailures = _allFailures;
+				foreach (var predicate in _predicates) {
+					matchedFailures = matchedFailures.Where(predicate);
+				}
+
+				return matchedFailures;
+			}
+		}
+
+		public IEnumerable<ValidationFailure> UnmatchedFailures {
+			get {
+				foreach (var failure in _allFailures) {
+					foreach (var predicate in _predicates) {
+						if (!predicate(failure)) {
+							yield return failure;
+							break;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/FluentValidation/TestHelper/ITestValidationContinuation.cs
+++ b/src/FluentValidation/TestHelper/ITestValidationContinuation.cs
@@ -5,11 +5,14 @@ namespace FluentValidation.TestHelper {
 	using System.Linq;
 	using Results;
 
+	public interface ITestValidationWith : ITestValidationContinuation {
+	}
+
 	public interface ITestValidationContinuation : IEnumerable<ValidationFailure> {
 		IEnumerable<ValidationFailure> UnmatchedFailures { get; }
 	}
 
-	internal class TestValidationContinuation : ITestValidationContinuation {
+	internal class TestValidationContinuation : ITestValidationContinuation, ITestValidationWith {
 		private readonly IEnumerable<ValidationFailure> _allFailures;
 		private readonly List<Func<ValidationFailure,bool>> _predicates;
 

--- a/src/FluentValidation/TestHelper/TestValidationResult.cs
+++ b/src/FluentValidation/TestHelper/TestValidationResult.cs
@@ -20,7 +20,6 @@
 
 namespace FluentValidation.TestHelper {
 	using System;
-	using System.Collections.Generic;
 	using System.Linq.Expressions;
 	using Internal;
 	using Results;
@@ -31,7 +30,7 @@ namespace FluentValidation.TestHelper {
 			RuleSetsExecuted = validationResult.RuleSetsExecuted;
 		}
 
-		public IEnumerable<ValidationFailure> ShouldHaveValidationErrorFor<TProperty>(Expression<Func<T, TProperty>> memberAccessor) {
+		public ITestValidationContinuation ShouldHaveValidationErrorFor<TProperty>(Expression<Func<T, TProperty>> memberAccessor) {
 			string propertyName = ValidatorOptions.Global.PropertyNameResolver(typeof(T), memberAccessor.GetMember(), memberAccessor);
 			return ValidationTestExtension.ShouldHaveValidationError(Errors, propertyName, true);
 		}
@@ -41,7 +40,7 @@ namespace FluentValidation.TestHelper {
 			ValidationTestExtension.ShouldNotHaveValidationError(Errors, propertyName, true);
 		}
 
-		public IEnumerable<ValidationFailure> ShouldHaveValidationErrorFor(string propertyName) {
+		public ITestValidationContinuation ShouldHaveValidationErrorFor(string propertyName) {
 			return ValidationTestExtension.ShouldHaveValidationError(Errors, propertyName, false);
 		}
 

--- a/src/FluentValidation/TestHelper/TestValidationResult.cs
+++ b/src/FluentValidation/TestHelper/TestValidationResult.cs
@@ -30,7 +30,7 @@ namespace FluentValidation.TestHelper {
 			RuleSetsExecuted = validationResult.RuleSetsExecuted;
 		}
 
-		public ITestValidationContinuation ShouldHaveValidationErrorFor<TProperty>(Expression<Func<T, TProperty>> memberAccessor) {
+		public ITestValidationWith ShouldHaveValidationErrorFor<TProperty>(Expression<Func<T, TProperty>> memberAccessor) {
 			string propertyName = ValidatorOptions.Global.PropertyNameResolver(typeof(T), memberAccessor.GetMember(), memberAccessor);
 			return ValidationTestExtension.ShouldHaveValidationError(Errors, propertyName, true);
 		}
@@ -40,7 +40,7 @@ namespace FluentValidation.TestHelper {
 			ValidationTestExtension.ShouldNotHaveValidationError(Errors, propertyName, true);
 		}
 
-		public ITestValidationContinuation ShouldHaveValidationErrorFor(string propertyName) {
+		public ITestValidationWith ShouldHaveValidationErrorFor(string propertyName) {
 			return ValidationTestExtension.ShouldHaveValidationError(Errors, propertyName, false);
 		}
 

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -105,11 +105,11 @@ namespace FluentValidation.TestHelper {
 			return new TestValidationResult<T>(validationResult);
 		}
 
-		public static IEnumerable<ValidationFailure> ShouldHaveAnyValidationError<T>(this TestValidationResult<T> testValidationResult) where T : class {
+		public static ITestValidationContinuation ShouldHaveAnyValidationError<T>(this TestValidationResult<T> testValidationResult) where T : class {
 			if (!testValidationResult.Errors.Any())
 				throw new ValidationTestException($"Expected at least one validation error, but none were found.");
 
-			return testValidationResult.Errors;
+			return TestValidationContinuation.Create(testValidationResult.Errors);
 		}
 
 		public static void ShouldNotHaveAnyValidationErrors<T>(this TestValidationResult<T> testValidationResult) where T : class {
@@ -134,15 +134,14 @@ namespace FluentValidation.TestHelper {
 			return defaultMessage;
 		}
 
-    internal static IEnumerable<ValidationFailure> ShouldHaveValidationError(IList<ValidationFailure> errors, string propertyName, bool shouldNormalizePropertyName) {
+    internal static ITestValidationContinuation ShouldHaveValidationError(IList<ValidationFailure> errors, string propertyName, bool shouldNormalizePropertyName) {
+	    var result = TestValidationContinuation.Create(errors);
+	    result.ApplyPredicate(x => (shouldNormalizePropertyName ?  NormalizePropertyName(x.PropertyName) == propertyName : x.PropertyName == propertyName)
+	                               || (string.IsNullOrEmpty(x.PropertyName) && string.IsNullOrEmpty(propertyName))
+	                               || propertyName == MatchAnyFailure);
 
-      var failures = errors.Where(x => (shouldNormalizePropertyName ?  NormalizePropertyName(x.PropertyName) == propertyName : x.PropertyName == propertyName)
-                                       || (string.IsNullOrEmpty(x.PropertyName) && string.IsNullOrEmpty(propertyName))
-                                       || propertyName == MatchAnyFailure
-                                       ).ToArray();
-
-      if (failures.Any()) {
-        return failures;
+      if (result.Any()) {
+        return result;
       }
 
       // We expected an error but failed to match it.
@@ -184,65 +183,86 @@ namespace FluentValidation.TestHelper {
 			}
 		}
 
-		public static IEnumerable<ValidationFailure> When(this IEnumerable<ValidationFailure> failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null){
-			bool anyMatched = failures.Any(failurePredicate);
+		public static ITestValidationContinuation When(this ITestValidationContinuation failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null) {
+			var result = TestValidationContinuation.Create(failures);
+			result.ApplyPredicate(failurePredicate);
 
+			var anyMatched = result.Any();
 			if (!anyMatched) {
-				var failure = failures.FirstOrDefault();
+				var failure = result.UnmatchedFailures.FirstOrDefault();
 				string message = BuildErrorMessage(failure, exceptionMessage, "Expected validation error was not found");
 				throw new ValidationTestException(message);
 			}
 
-			return failures;
+			return result;
 		}
 
-		public static IEnumerable<ValidationFailure> WhenAll(this IEnumerable<ValidationFailure> failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null) {
-			bool allMatched = failures.All(failurePredicate);
+		public static ITestValidationContinuation WhenAll(this ITestValidationContinuation failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null) {
+			var result = TestValidationContinuation.Create(failures);
+			result.ApplyPredicate(failurePredicate);
+
+			bool allMatched = !result.UnmatchedFailures.Any();
 
 			if (!allMatched) {
-				var failure = failures.First(fail => !(failurePredicate(fail)));
+				var failure = result.UnmatchedFailures.First();
 				string message = BuildErrorMessage(failure, exceptionMessage, "Found an unexpected validation error");
 				throw new ValidationTestException(message);
 			}
 
-			return failures;
+			return result;
 		}
 
-		public static IEnumerable<ValidationFailure> WithSeverity(this IEnumerable<ValidationFailure> failures, Severity expectedSeverity) {
+		public static ITestValidationContinuation WithSeverity(this ITestValidationContinuation failures, Severity expectedSeverity) {
 			return failures.When(failure => failure.Severity == expectedSeverity, string.Format("Expected a severity of '{0}'. Actual severity was '{{Severity}}'", expectedSeverity));
 		}
 
-		public static IEnumerable<ValidationFailure> WithCustomState(this IEnumerable<ValidationFailure> failures, object expectedCustomState, IEqualityComparer comparer = null) {
+		public static ITestValidationContinuation WithCustomState(this ITestValidationContinuation failures, object expectedCustomState, IEqualityComparer comparer = null) {
 			return failures.When(failure => comparer?.Equals(failure.CustomState, expectedCustomState) ?? Equals(failure.CustomState, expectedCustomState), string.Format("Expected custom state of '{0}'. Actual state was '{{State}}'", expectedCustomState));
 		}
 
-    public static IEnumerable<ValidationFailure> WithMessageArgument<T>(this IEnumerable<ValidationFailure> failures, string argumentKey, T argumentValue) {
+    public static ITestValidationContinuation WithMessageArgument<T>(this ITestValidationContinuation failures, string argumentKey, T argumentValue) {
       return failures.When(failure => failure.FormattedMessagePlaceholderValues.ContainsKey(argumentKey) && ((T)failure.FormattedMessagePlaceholderValues[argumentKey]).Equals(argumentValue),
         string.Format("Expected message argument '{0}' with value '{1}'. Actual value was '{{MessageArgument:{0}}}'", argumentKey, argumentValue.ToString()));
     }
 
-		public static IEnumerable<ValidationFailure> WithErrorMessage(this IEnumerable<ValidationFailure> failures, string expectedErrorMessage) {
+		public static ITestValidationContinuation WithErrorMessage(this ITestValidationContinuation failures, string expectedErrorMessage) {
 			return failures.When(failure => failure.ErrorMessage == expectedErrorMessage, string.Format("Expected an error message of '{0}'. Actual message was '{{Message}}'", expectedErrorMessage));
 		}
 
-		public static IEnumerable<ValidationFailure> WithErrorCode(this IEnumerable<ValidationFailure> failures, string expectedErrorCode) {
+		public static ITestValidationContinuation WithErrorCode(this ITestValidationContinuation failures, string expectedErrorCode) {
 			return failures.When(failure => failure.ErrorCode == expectedErrorCode, string.Format("Expected an error code of '{0}'. Actual error code was '{{Code}}'", expectedErrorCode));
 		}
 
-		public static IEnumerable<ValidationFailure> WithoutSeverity(this IEnumerable<ValidationFailure> failures, Severity unexpectedSeverity) {
+		public static ITestValidationContinuation WithoutSeverity(this ITestValidationContinuation failures, Severity unexpectedSeverity) {
 			return failures.WhenAll(failure => failure.Severity != unexpectedSeverity, string.Format("Found an unexpected severity of '{0}'", unexpectedSeverity));
 		}
 
-		public static IEnumerable<ValidationFailure> WithoutCustomState(this IEnumerable<ValidationFailure> failures, object unexpectedCustomState) {
+		public static ITestValidationContinuation WithoutCustomState(this ITestValidationContinuation failures, object unexpectedCustomState) {
 			return failures.WhenAll(failure => failure.CustomState != unexpectedCustomState, string.Format("Found an unexpected custom state of '{0}'", unexpectedCustomState));
 		}
 
-		public static IEnumerable<ValidationFailure> WithoutErrorMessage(this IEnumerable<ValidationFailure> failures, string unexpectedErrorMessage) {
+		public static ITestValidationContinuation WithoutErrorMessage(this ITestValidationContinuation failures, string unexpectedErrorMessage) {
 			return failures.WhenAll(failure => failure.ErrorMessage != unexpectedErrorMessage, string.Format("Found an unexpected error message of '{0}'", unexpectedErrorMessage));
 		}
 
-		public static IEnumerable<ValidationFailure> WithoutErrorCode(this IEnumerable<ValidationFailure> failures, string unexpectedErrorCode) {
+		public static ITestValidationContinuation WithoutErrorCode(this ITestValidationContinuation failures, string unexpectedErrorCode) {
 			return failures.WhenAll(failure => failure.ErrorCode != unexpectedErrorCode, string.Format("Found an unexpected error code of '{0}'", unexpectedErrorCode));
+		}
+
+		public static ITestValidationContinuation Only(this ITestValidationContinuation failures) {
+			if (failures.UnmatchedFailures.Any()) {
+
+				var errorMessageBanner = "Expected to have errors only matching specified conditions";
+				string errorMessageDetails = "";
+				var unmatchedFailures = failures.UnmatchedFailures.ToList();
+				for (int i = 0; i < unmatchedFailures.Count; i++) {
+					errorMessageDetails += $"[{i}]: {unmatchedFailures[i].ErrorMessage}\n";
+				}
+				var errorMessage = $"{errorMessageBanner}\n----\nUnexpected Errors:\n{errorMessageDetails}";
+
+				throw new ValidationTestException(errorMessage);
+			}
+			return failures;
 		}
 
 		private static string NormalizePropertyName(string propertyName) {

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -134,7 +134,7 @@ namespace FluentValidation.TestHelper {
 			return defaultMessage;
 		}
 
-    internal static ITestValidationContinuation ShouldHaveValidationError(IList<ValidationFailure> errors, string propertyName, bool shouldNormalizePropertyName) {
+    internal static ITestValidationWith ShouldHaveValidationError(IList<ValidationFailure> errors, string propertyName, bool shouldNormalizePropertyName) {
 	    var result = TestValidationContinuation.Create(errors);
 	    result.ApplyPredicate(x => (shouldNormalizePropertyName ?  NormalizePropertyName(x.PropertyName) == propertyName : x.PropertyName == propertyName)
 	                               || (string.IsNullOrEmpty(x.PropertyName) && string.IsNullOrEmpty(propertyName))
@@ -183,7 +183,7 @@ namespace FluentValidation.TestHelper {
 			}
 		}
 
-		public static ITestValidationContinuation When(this ITestValidationContinuation failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null) {
+		public static ITestValidationWith When(this ITestValidationContinuation failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null) {
 			var result = TestValidationContinuation.Create(failures);
 			result.ApplyPredicate(failurePredicate);
 
@@ -212,24 +212,24 @@ namespace FluentValidation.TestHelper {
 			return result;
 		}
 
-		public static ITestValidationContinuation WithSeverity(this ITestValidationContinuation failures, Severity expectedSeverity) {
+		public static ITestValidationWith WithSeverity(this ITestValidationContinuation failures, Severity expectedSeverity) {
 			return failures.When(failure => failure.Severity == expectedSeverity, string.Format("Expected a severity of '{0}'. Actual severity was '{{Severity}}'", expectedSeverity));
 		}
 
-		public static ITestValidationContinuation WithCustomState(this ITestValidationContinuation failures, object expectedCustomState, IEqualityComparer comparer = null) {
+		public static ITestValidationWith WithCustomState(this ITestValidationContinuation failures, object expectedCustomState, IEqualityComparer comparer = null) {
 			return failures.When(failure => comparer?.Equals(failure.CustomState, expectedCustomState) ?? Equals(failure.CustomState, expectedCustomState), string.Format("Expected custom state of '{0}'. Actual state was '{{State}}'", expectedCustomState));
 		}
 
-    public static ITestValidationContinuation WithMessageArgument<T>(this ITestValidationContinuation failures, string argumentKey, T argumentValue) {
+    public static ITestValidationWith WithMessageArgument<T>(this ITestValidationContinuation failures, string argumentKey, T argumentValue) {
       return failures.When(failure => failure.FormattedMessagePlaceholderValues.ContainsKey(argumentKey) && ((T)failure.FormattedMessagePlaceholderValues[argumentKey]).Equals(argumentValue),
         string.Format("Expected message argument '{0}' with value '{1}'. Actual value was '{{MessageArgument:{0}}}'", argumentKey, argumentValue.ToString()));
     }
 
-		public static ITestValidationContinuation WithErrorMessage(this ITestValidationContinuation failures, string expectedErrorMessage) {
+		public static ITestValidationWith WithErrorMessage(this ITestValidationContinuation failures, string expectedErrorMessage) {
 			return failures.When(failure => failure.ErrorMessage == expectedErrorMessage, string.Format("Expected an error message of '{0}'. Actual message was '{{Message}}'", expectedErrorMessage));
 		}
 
-		public static ITestValidationContinuation WithErrorCode(this ITestValidationContinuation failures, string expectedErrorCode) {
+		public static ITestValidationWith WithErrorCode(this ITestValidationContinuation failures, string expectedErrorCode) {
 			return failures.When(failure => failure.ErrorCode == expectedErrorCode, string.Format("Expected an error code of '{0}'. Actual error code was '{{Code}}'", expectedErrorCode));
 		}
 
@@ -249,7 +249,7 @@ namespace FluentValidation.TestHelper {
 			return failures.WhenAll(failure => failure.ErrorCode != unexpectedErrorCode, string.Format("Found an unexpected error code of '{0}'", unexpectedErrorCode));
 		}
 
-		public static ITestValidationContinuation Only(this ITestValidationContinuation failures) {
+		public static ITestValidationWith Only(this ITestValidationWith failures) {
 			if (failures.UnmatchedFailures.Any()) {
 
 				var errorMessageBanner = "Expected to have errors only matching specified conditions";


### PR DESCRIPTION
This PR adds an ability to assert that no other validation errors, except the ones that match specified conditions, were raised.

For this, we are adding a new method `.Only()` that can be used in various contexts:

```
    validator.TestValidate(x).ShouldHaveValidationErrorFor(x => x.Surname).Only();
    validator.TestValidate(x).ShouldHaveValidationErrorFor(x => x.Surname)
        .WithErrorMessage(message)
        .Only();
    validator.TestValidate(x).ShouldHaveValidationErrorFor(x => x.Surname)
        .WithErrorMessage(message)
        .WithSeverity(Severity.Warning)
        .Only();
    // and so forth
```

It cannot be used directly after `.Without*()` family of methods, because such record would be confusing and would have little sense:
```
    validator.TestValidate(x).ShouldHaveValidationErrorFor(x => x.Surname)
        .WithoutErrorMessage(message)
        .Only();
```

The changes required modifications of input and output types of `ValidationTestExtension` extension methods from `IEnumerable<ValidationFailure>` to `ITestValidationContinuation` or `ITestValidationWith`. These new interfaces do implement `IEnumerable<ValidationFailure>` so most of the existing code will not be affected but this is still a breaking change because some tests will be broken. For example, this does not work:
```
validator.TestValidate(new Person { }).Errors.WithoutErrorMessage(withoutErrMsg);
```

At the same time, it also has benefits of not polluting the shared namespace, because `IEnumerable<ValidationFailure>` is quite generic, and can be used in many places aside from unit tests.

In addition, I have refactored a few tests verifying failures by using try-catch block and asserting the exception was catched to use `Assert.Throws` instead.

----

Closes #1819