### PR TITLE
Document ComparisonProperty placeholder

### DIFF
--- a/docs/built-in-validators.md
+++ b/docs/built-in-validators.md
@@ -44,6 +44,7 @@ Example error: *'Surname' should not be equal to 'Foo'*
 String format args:
 * `{PropertyName}` – Name of the property being validated
 * `{ComparisonValue}` – Value that the property should not equal
+* `{ComparisonProperty}` – Name of the property that the property should not equal, if any
 * `{PropertyValue}` – Current value of the property
 
 Optionally, a comparer can be provided to ensure a specific type of comparison is performed:
@@ -79,6 +80,7 @@ Example error: *'Surname' should be equal to 'Foo'*
 String format args:
 * `{PropertyName}` – Name of the property being validated
 * `{ComparisonValue}` – Value that the property should equal
+* `{ComparisonProperty}` – Name of the property that the property should equal, if any
 * `{PropertyValue}` – Current value of the property
 
 ```csharp
@@ -168,6 +170,7 @@ Notes: Only valid on types that implement `IComparable<T>`
 String format args:
 * `{PropertyName}` – Name of the property being validated
 * `{ComparisonValue}` – Value to which the property was compared
+* `{ComparisonProperty}` – Name of the property to which the property was compared, if any
 * `{PropertyValue}` – Current value of the property
 
 ## Less Than Or Equal Validator
@@ -184,6 +187,7 @@ Example error: *'Credit Limit' must be less than or equal to 100.*
 Notes: Only valid on types that implement `IComparable<T>`
 * `{PropertyName}` – Name of the property being validated
 * `{ComparisonValue}` – Value to which the property was compared
+* `{ComparisonProperty}` – Name of the property to which the property was compared, if any
 * `{PropertyValue}` – Current value of the property
 
 ## Greater Than Validator
@@ -200,6 +204,7 @@ Example error: *'Credit Limit' must be greater than 0.*
 Notes: Only valid on types that implement `IComparable<T>`
 * `{PropertyName}` – Name of the property being validated
 * `{ComparisonValue}` – Value to which the property was compared
+* `{ComparisonProperty}` – Name of the property to which the property was compared, if any
 * `{PropertyValue}` – Current value of the property
 
 ## Greater Than Or Equal Validator
@@ -216,6 +221,7 @@ Example error: *'Credit Limit' must be greater than or equal to 1.*
 Notes: Only valid on types that implement `IComparable<T>`
 * `{PropertyName}` – Name of the property being validated
 * `{ComparisonValue}` – Value to which the property was compared
+* `{ComparisonProperty}` – Name of the property to which the property was compared, if any
 * `{PropertyValue}` – Current value of the property
 
 ## Predicate Validator

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -25,6 +25,7 @@ These include the predicate validator (`Must` validator), the email and the rege
 
 Used in comparison validators: (`Equal`, `NotEqual`, `GreaterThan`, `GreaterThanOrEqual`, etc.)
 * `{ComparisonValue}` – Value that the property should be compared to
+* `{ComparisonProperty}` – Name of the property that the property should be compared to, if any
 
 Used only in the Length validator:
 * `{MinLength}` – Minimum length


### PR DESCRIPTION
I discovered this placeholder accidentally, and after quite some time, while 1) trying to reference another property from a custom message, and 2) wanting to render the property names consistently. I want to render them consistently because to do otherwise invites unnecessary confusion.

---

I might take this opportunity to note that consistently referencing properties in custom messages is exceedingly painful:

- `ComparisonProperty` works perfectly for a select few validators but obviously does not work at all in any validator without first-class support for it; and so far it has been practically undocumented.
- I can't use `nameof(<property>)` because of the default display name resolver's insistence on transforming property names into not-property-names.
- I can't access the default display name resolver either, so I also can't `ddnr(nameof(<property>))`.
- Overriding the display name resolver with a bespoke version that could be used in this way is poorly documented, and specifically overriding it safely is not documented at all.

Concretely, this is completely impossible to do in `PredicateValidator`.

My wish would be for a built-in `PropertyPathDisplayNameResolver` that, for

```csharp
class AaAa { public string BbBb { get; set; } }
```

produces `AaAa.BbBb`, not `Aa Aa Bb Bb`.

Second to that, a documented, robust implementation of this in an accessible place so others can use it manually with less effort.

Third to that, a built-in `PropertyNameDisplayNameResolver` that robustly produces _just_ the property name, which I imagine is easier to program than the property path. Here is a decent version that recovers from null properties, which is a fault in the version posted in #121:

```csharp
ValidatorOptions.Global.DisplayNameResolver = (_, member, _) => member?.Name;
```
