### PR TITLE
Update documentation of NotEmpty/Empty validators

### DIFF
--- a/docs/built-in-validators.md
+++ b/docs/built-in-validators.md
@@ -16,7 +16,8 @@ String format args:
 * `{PropertyValue}` – Current value of the property
 
 ## NotEmpty Validator
-Ensures that the specified property is not null, an empty string or whitespace (or the default value for value types, e.g., 0 for `int`)
+Ensures that the specified property is not null, an empty string or whitespace (or the default value for value types, e.g., 0 for `int`).
+When used on an IEnumerable (such as arrays, collections, lists, etc.), the validator ensures that the IEnumerable is not empty.
 
 Example:
 ```csharp
@@ -338,6 +339,8 @@ String format args:
 
 ## Empty Validator
 Opposite of the `NotEmpty` validator. Checks if a property value is null, or is the default value for the type.
+When used on an IEnumerable (such as arrays, collections, lists, etc.), the validator ensures that the IEnumerable is empty.
+
 ```csharp
 RuleFor(x => x.Surname).Empty();
 ```


### PR DESCRIPTION
NotEmpty/Empty validators are working on IEnumerables:
https://github.com/FluentValidation/FluentValidation/blob/155cffc0d60113639865baafde757019b827415e/src/FluentValidation/Validators/NotEmptyValidator.cs#L36
https://github.com/FluentValidation/FluentValidation/blob/155cffc0d60113639865baafde757019b827415e/src/FluentValidation/Validators/EmptyValidator.cs#L36

This behaviour is currently not mentioned in the docs and caused a bit of confusion for us today :).