### PR TITLE
Update AzerbaijaneseLanguage.cs to TwoLetterISOLanguageName

### DIFF
--- a/src/FluentValidation/Resources/Languages/AzerbaijaneseLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/AzerbaijaneseLanguage.cs
@@ -24,7 +24,7 @@ namespace FluentValidation.Resources {
 	using Validators;
 
 	internal class AzerbaijaneseLanguage {
-		public const string Culture = "az-AZ";
+		public const string Culture = "az";
 
 		public static string GetTranslation(string key) => key switch {
 			"EmailValidator" => "'{PropertyName}'  keçərli bir e-poçt ünvanı deyil.",


### PR DESCRIPTION
Hi guys .
I have localization problem.  I think that, finally  I found a solution. I m trying to get your localization logic. I notice that , In other langugages you have used TwoLetterISOLanguageName, but on Azerbaijani language is not the same like others.  So if ,I am not wrong, culture name should be change to "az".

ISO Codes List: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes