### PR TITLE
Switch from Task to ValueTask

### DIFF
--- a/src/FluentValidation.DependencyInjectionExtensions/FluentValidation.DependencyInjectionExtensions.csproj
+++ b/src/FluentValidation.DependencyInjectionExtensions/FluentValidation.DependencyInjectionExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1</TargetFrameworks>
         <AssemblyName>FluentValidation.DependencyInjectionExtensions</AssemblyName>
         <PackageId>FluentValidation.DependencyInjectionExtensions</PackageId>
         <Product>FluentValidation.DependencyInjectionExtensions</Product>

--- a/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ClientsideMessageTester.cs
@@ -44,151 +44,151 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task NotEmpty_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask NotEmpty_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("Required", "data-val-required");
 			msg.ShouldEqual("'Required' must not be empty.");
 		}
 
 		[Fact]
-		public async Task NotNull_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask NotNull_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("Required2", "data-val-required");
 			msg.ShouldEqual("'Required2' must not be empty.");
 		}
 
 		[Fact]
-		public async Task RegexValidator_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask RegexValidator_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("RegEx", "data-val-regex");
 			msg.ShouldEqual("'Reg Ex' is not in the correct format.");
 		}
 
 		[Fact]
-		public async Task EmailValidator_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask EmailValidator_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("Email", "data-val-email");
 			msg.ShouldEqual("'Email' is not a valid email address.");
 		}
 
 		[Fact]
-		public async Task LengthValidator_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask LengthValidator_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("Length", "data-val-length");
 			msg.ShouldEqual("'Length' must be between 1 and 4 characters.");
 		}
 
 		[Fact]
-		public async Task MinLengthValidator_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask MinLengthValidator_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("MinLength", "data-val-minlength");
 			msg.ShouldEqual("The length of 'Min Length' must be at least 1 characters.");
 		}
 
 		[Fact]
-		public async Task MaxLengthValidator_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask MaxLengthValidator_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("MaxLength", "data-val-maxlength");
 			msg.ShouldEqual("The length of 'Max Length' must be 2 characters or fewer.");
 		}
 
 		[Fact]
-		public async Task ExactLengthValidator_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask ExactLengthValidator_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("ExactLength", "data-val-length");
 			msg.ShouldEqual("'Exact Length' must be 4 characters in length.");
 		}
 
 
 		[Fact]
-		public async Task InclusiveBetween_validator_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask InclusiveBetween_validator_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("Range", "data-val-range");
 			msg.ShouldEqual("'Range' must be between 1 and 5.");
 		}
 
 		[Fact]
-		public async Task GreaterThanOrEqualTo_validator_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask GreaterThanOrEqualTo_validator_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("GreaterThanOrEqual", "data-val-range");
 			msg.ShouldEqual("'Greater Than Or Equal' must be greater than or equal to '1'.");
 		}
 
 		[Fact]
-		public async Task LessThanOrEqualTo_validator_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask LessThanOrEqualTo_validator_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("LessThanOrEqual", "data-val-range");
 			msg.ShouldEqual("'Less Than Or Equal' must be less than or equal to '10'.");
 		}
 
 		[Fact]
-		public async Task EqualValidator_with_property_uses_simplified_message_for_clientside_validation() {
+		public async ValueTask EqualValidator_with_property_uses_simplified_message_for_clientside_validation() {
 			var msg = await _client.GetClientsideMessage("EqualTo", "data-val-equalto");
 			msg.ShouldEqual("'Equal To' must be equal to 'Required'.");
 		}
 
 		[Fact]
-		public async Task Should_not_munge_custom_message() {
+		public async ValueTask Should_not_munge_custom_message() {
 			var msg = await _client.GetClientsideMessage("LengthWithMessage", "data-val-length");
 			msg.ShouldEqual("Foo");
 		}
 
 		[Fact]
-		public async Task Custom_validation_message_with_placeholders() {
+		public async ValueTask Custom_validation_message_with_placeholders() {
 			var msg = await _client.GetClientsideMessage("CustomPlaceholder", "data-val-required");
 			msg.ShouldEqual("Custom Placeholder is null.");
 		}
 
 		[Fact]
-		public async Task Custom_validation_message_for_length() {
+		public async ValueTask Custom_validation_message_for_length() {
 			var msg = await _client.GetClientsideMessage("LengthCustomPlaceholders", "data-val-length");
 			msg.ShouldEqual("Must be between 1 and 5.");
 		}
 
 		[Fact]
-		public async Task CreditCard_creates_clientside_message() {
+		public async ValueTask CreditCard_creates_clientside_message() {
 			var msg = await _client.GetClientsideMessage("CreditCard", "data-val-creditcard");
 			msg.ShouldEqual("'Credit Card' is not a valid credit card number.");
 		}
 
 		[Fact]
-		public async Task Overrides_property_name_for_clientside_rule() {
+		public async ValueTask Overrides_property_name_for_clientside_rule() {
 			var msg = await _client.GetClientsideMessage("CustomName", "data-val-required");
 
 			msg.ShouldEqual("'Foo' must not be empty.");
 		}
 
 		[Fact]
-		public async Task Overrides_property_name_for_clientside_rule_using_localized_name() {
+		public async ValueTask Overrides_property_name_for_clientside_rule_using_localized_name() {
 			var msg = await _client.GetClientsideMessage("LocalizedName", "data-val-required");
 
 			msg.ShouldEqual("'Localised Error' must not be empty.");
 		}
 
 		[Fact]
-		public async Task Overrides_property_name_for_non_nullable_value_type() {
+		public async ValueTask Overrides_property_name_for_non_nullable_value_type() {
 			var msg = await _client.GetClientsideMessage("CustomNameValueType", "data-val-required");
 
 			msg.ShouldEqual("'Foo' must not be empty.");
 		}
 
 		[Fact]
-		public async Task Falls_back_to_default_message_when_no_context_available_to_custom_message_format() {
+		public async ValueTask Falls_back_to_default_message_when_no_context_available_to_custom_message_format() {
 			var msg = await _client.GetClientsideMessage("MessageWithContext", "data-val-required");
 			msg.ShouldEqual("'Message With Context' must not be empty.");
 		}
 
 		[Fact]
-		public async Task Can_use_localizer() {
+		public async ValueTask Can_use_localizer() {
 			var msg = await _client.GetClientsideMessage("LocalizedMessage", "data-val-required");
 			msg.ShouldEqual("from localizer");
 		}
 
 		[Fact]
-		public async Task Should_only_use_rules_from_Default_ruleset() {
+		public async ValueTask Should_only_use_rules_from_Default_ruleset() {
 			var msg = await _client.RunRulesetAction("/ClientSide/DefaultRuleset");
 			msg.Length.ShouldEqual(1);
 			msg[0].ShouldEqual("third");
 		}
 
 		[Fact]
-		public async Task Should_use_rules_from_specified_ruleset() {
+		public async ValueTask Should_use_rules_from_specified_ruleset() {
 			var msg = await _client.RunRulesetAction("/ClientSide/SpecifiedRuleset");
 			msg.Length.ShouldEqual(1);
 			msg[0].ShouldEqual("first");
 		}
 
 		[Fact]
-		public async Task Should_use_rules_from_multiple_rulesets() {
+		public async ValueTask Should_use_rules_from_multiple_rulesets() {
 			var msgs = await _client.RunRulesetAction("/ClientSide/MultipleRulesets");
 			msgs.Length.ShouldEqual(2);
 			msgs[0].ShouldEqual("first");
@@ -196,7 +196,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_use_rules_from_default_ruleset_and_specified_ruleset() {
+		public async ValueTask Should_use_rules_from_default_ruleset_and_specified_ruleset() {
 			var msgs = await _client.RunRulesetAction("/ClientSide/DefaultAndSpecified");
 			msgs.Length.ShouldEqual(2);
 			msgs[0].ShouldEqual("first");
@@ -204,13 +204,13 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Renders_attributes_inside_partial() {
+		public async ValueTask Renders_attributes_inside_partial() {
 			var msg = await _client.GetClientsideMessage("RequiredInsidePartial", "data-val-required");
 			msg.ShouldEqual("'Required Inside Partial' must not be empty.");
 		}
 
 		[Fact]
-		public async Task Instantiates_validator_for_clientside_usage_only_once() {
+		public async ValueTask Instantiates_validator_for_clientside_usage_only_once() {
 			//static property - make sure it's reinitialized at the start of this test as other tests affect it too
 			ClientsideModelValidator.TimesInstantiated = 0;
 			var results = await _client.GetClientsideMessages();
@@ -218,7 +218,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Shouldnt_generate_clientside_message_for_LessThanOrEqual_GreaterThanOrEqual_cross_property() {
+		public async ValueTask Shouldnt_generate_clientside_message_for_LessThanOrEqual_GreaterThanOrEqual_cross_property() {
 			// https://github.com/FluentValidation/FluentValidation/issues/1721
 			// A call to LessThanOrEqual(x => x.SomeOtherProperty) shouldn't generate clientside metadata.
 			var document = await _client.GetClientsideMessages();
@@ -234,7 +234,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Shouldnt_generate_clientside_message_for_LessThanOrEqual_GreaterThanOrEqual_func() {
+		public async ValueTask Shouldnt_generate_clientside_message_for_LessThanOrEqual_GreaterThanOrEqual_func() {
 			// A call to LessThanOrEqual(x => DateTime.Now) shouldn't generate clientside metadata.
 			var document = await _client.GetClientsideMessages();
 
@@ -267,21 +267,21 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_only_use_rules_from_default_ruleset() {
+		public async ValueTask Should_only_use_rules_from_default_ruleset() {
 			var msg = await _client.RunRulesetAction("/Rulesets/DefaultRuleSet", "Test");
 			msg.Length.ShouldEqual(1);
 			msg[0].ShouldEqual("third");
 		}
 
 		[Fact]
-		public async Task Should_use_rules_from_specified_ruleset() {
+		public async ValueTask Should_use_rules_from_specified_ruleset() {
 			var msg = await _client.RunRulesetAction("/Rulesets/SpecifiedRuleSet", "Test");
 			msg.Length.ShouldEqual(1);
 			msg[0].ShouldEqual("first");
 		}
 
 		[Fact]
-		public async Task Should_use_rules_from_multiple_rulesets() {
+		public async ValueTask Should_use_rules_from_multiple_rulesets() {
 			var msgs = await _client.RunRulesetAction("/Rulesets/MultipleRuleSets", "Test");
 			msgs.Length.ShouldEqual(2);
 			msgs[0].ShouldEqual("first");
@@ -289,7 +289,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_use_rules_from_default_ruleset_and_specified_ruleset() {
+		public async ValueTask Should_use_rules_from_default_ruleset_and_specified_ruleset() {
 			var msgs = await _client.RunRulesetAction("/Rulesets/DefaultAndSpecifiedRuleSet", "Test");
 			msgs.Length.ShouldEqual(2);
 			msgs[0].ShouldEqual("first");
@@ -298,21 +298,21 @@ namespace FluentValidation.Tests.AspNetCore {
 
 #if NETCOREAPP3_1 || NET5_0
 		[Fact]
-		public async Task Should_only_use_rules_from_default_ruleset_extension() {
+		public async ValueTask Should_only_use_rules_from_default_ruleset_extension() {
 			var msg = await _client.RunRulesetAction("/Rulesets/RuleSetForHandlers?handler=default", "Test");
 			msg.Length.ShouldEqual(1);
 			msg[0].ShouldEqual("third");
 		}
 
 		[Fact]
-		public async Task Should_use_rules_from_specified_ruleset_extension() {
+		public async ValueTask Should_use_rules_from_specified_ruleset_extension() {
 			var msg = await _client.RunRulesetAction("/Rulesets/RuleSetForHandlers?handler=specified", "Test");
 			msg.Length.ShouldEqual(1);
 			msg[0].ShouldEqual("first");
 		}
 
 		[Fact]
-		public async Task Should_use_rules_from_multiple_rulesets_extension() {
+		public async ValueTask Should_use_rules_from_multiple_rulesets_extension() {
 			var msgs = await _client.RunRulesetAction("/Rulesets/RuleSetForHandlers?handler=multiple", "Test");
 			msgs.Length.ShouldEqual(2);
 			msgs[0].ShouldEqual("first");
@@ -320,7 +320,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_use_rules_from_default_ruleset_and_specified_ruleset_extension() {
+		public async ValueTask Should_use_rules_from_default_ruleset_and_specified_ruleset_extension() {
 			var msgs = await _client.RunRulesetAction("/Rulesets/RuleSetForHandlers?handler=defaultAndSpecified", "Test");
 			msgs.Length.ShouldEqual(2);
 			msgs[0].ShouldEqual("first");

--- a/src/FluentValidation.Tests.AspNetCore/Controllers/TestController.cs
+++ b/src/FluentValidation.Tests.AspNetCore/Controllers/TestController.cs
@@ -191,7 +191,7 @@ namespace FluentValidation.Tests.AspNetCore.Controllers {
 			return TestResult();
 		}
 
-		public async Task<ActionResult> UpdateModel() {
+		public async ValueTask<ActionResult> UpdateModel() {
 			var model = new TestModel();
 			await TryUpdateModelAsync(model);
 			return TestResult();

--- a/src/FluentValidation.Tests.AspNetCore/DependencyInjectionTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/DependencyInjectionTests.cs
@@ -32,14 +32,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Resolves_explicit_child_validator() {
+		public async ValueTask Resolves_explicit_child_validator() {
 			var result = await _client.GetErrors("InjectsExplicitChildValidator", new FormData());
 			result.IsValidField("Child.Name").ShouldBeFalse();
 			result.GetError("Child.Name").ShouldEqual("NotNullInjected");
 		}
 
 		[Fact]
-		public async Task Resolves_explicit_child_validator_for_collection() {
+		public async ValueTask Resolves_explicit_child_validator_for_collection() {
 			var formData = new FormData();
 			formData.Add("Children[0].Name", null);
 			var result = await _client.GetErrors("InjectsExplicitChildValidatorCollection", formData);

--- a/src/FluentValidation.Tests.AspNetCore/DisableAutoValidationTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/DisableAutoValidationTests.cs
@@ -32,7 +32,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Disables_automatic_validation() {
+		public async ValueTask Disables_automatic_validation() {
 			var client = _webApp.CreateClientWithServices(services => {
 				services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
 					fv.RegisterValidatorsFromAssemblyContaining<TestController>();
@@ -47,7 +47,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Disables_automatic_validation_for_implicit_validation() {
+		public async ValueTask Disables_automatic_validation_for_implicit_validation() {
 			var client = _webApp.CreateClientWithServices(services => {
 				services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
 					fv.RegisterValidatorsFromAssemblyContaining<TestController>();

--- a/src/FluentValidation.Tests.AspNetCore/DisableDataAnnotationsTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/DisableDataAnnotationsTests.cs
@@ -13,7 +13,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Disables_data_annotations() {
+		public async ValueTask Disables_data_annotations() {
 			var client = _app.CreateClientWithServices(services => {
 				services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
 					fv.DisableDataAnnotationsValidation = true;

--- a/src/FluentValidation.Tests.AspNetCore/GlobalInterceptorTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/GlobalInterceptorTests.cs
@@ -16,7 +16,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task When_global_action_context_interceptor_specified_Intercepts_validation_for_razor_pages() {
+		public async ValueTask When_global_action_context_interceptor_specified_Intercepts_validation_for_razor_pages() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},

--- a/src/FluentValidation.Tests.AspNetCore/HttpClientExtensions.cs
+++ b/src/FluentValidation.Tests.AspNetCore/HttpClientExtensions.cs
@@ -11,7 +11,7 @@ namespace FluentValidation.Tests {
 
 	public static class HttpClientExtensions {
 
-		public static async Task<string> GetResponse(this HttpClient client, string url,
+		public static async ValueTask<string> GetResponse(this HttpClient client, string url,
 			string querystring = "") {
 			if (!String.IsNullOrEmpty(querystring)) {
 				url += "?" + querystring;
@@ -22,7 +22,7 @@ namespace FluentValidation.Tests {
 			return await response.Content.ReadAsStringAsync();
 		}
 
-		public static async Task<string> PostResponse(this HttpClient client, string url,
+		public static async ValueTask<string> PostResponse(this HttpClient client, string url,
 			Dictionary<string, string> form) {
 			var c = new FormUrlEncodedContent(form);
 
@@ -32,16 +32,16 @@ namespace FluentValidation.Tests {
 			return await response.Content.ReadAsStringAsync();
 		}
 
-		public static async Task<List<SimpleError>> GetErrors(this HttpClient client, string action, Dictionary<string, string> form) {
+		public static async ValueTask<List<SimpleError>> GetErrors(this HttpClient client, string action, Dictionary<string, string> form) {
 			var response = await client.PostResponse($"/Test/{action}", form);
 			return JsonConvert.DeserializeObject<List<SimpleError>>(response);
 		}
 
-		public static Task<List<SimpleError>> GetErrorsViaJSON<T>(this HttpClient client, string action, T model) {
+		public static ValueTask<List<SimpleError>> GetErrorsViaJSON<T>(this HttpClient client, string action, T model) {
 			return client.GetErrorsViaJSONRaw(action, JsonConvert.SerializeObject(model));
 		}
 
-		public static async Task<List<SimpleError>> GetErrorsViaJSONRaw(this HttpClient client, string action, string json) {
+		public static async ValueTask<List<SimpleError>> GetErrorsViaJSONRaw(this HttpClient client, string action, string json) {
 			var request = new HttpRequestMessage(HttpMethod.Post, $"/Test/{action}");
 			request.Content = new StringContent(json, Encoding.UTF8, "application/json");
 			var responseMessage = await client.SendAsync(request);
@@ -50,12 +50,12 @@ namespace FluentValidation.Tests {
 			return JsonConvert.DeserializeObject<List<SimpleError>>(response);
 		}
 
-		public static async Task<XDocument> GetClientsideMessages(this HttpClient client, string action = "/Clientside/Inputs") {
+		public static async ValueTask<XDocument> GetClientsideMessages(this HttpClient client, string action = "/Clientside/Inputs") {
 			var output = await client.GetResponse(action);
 			return XDocument.Parse(output);
 		}
 
-		public static async Task<string> GetClientsideMessage(this HttpClient client, string name, string attribute) {
+		public static async ValueTask<string> GetClientsideMessage(this HttpClient client, string name, string attribute) {
 			var doc = await client.GetClientsideMessages();
 			var elem = doc.Root.Elements("input")
 				.Where(x => x.Attribute("name").Value == name).SingleOrDefault();
@@ -73,7 +73,7 @@ namespace FluentValidation.Tests {
 			return attr.Value;
 		}
 
-		public static async Task<string[]> RunRulesetAction(this HttpClient client, string action, string modelPrefix = null) {
+		public static async ValueTask<string[]> RunRulesetAction(this HttpClient client, string action, string modelPrefix = null) {
 
 			var doc = await client.GetClientsideMessages(action);
 

--- a/src/FluentValidation.Tests.AspNetCore/ImplicitRootCollectionTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ImplicitRootCollectionTests.cs
@@ -1,5 +1,6 @@
 namespace FluentValidation.Tests {
 	using System.Net.Http;
+	using System.Threading.Tasks;
 	using AspNetCore;
 	using AspNetCore.Controllers;
 	using FluentValidation.AspNetCore;
@@ -24,7 +25,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Does_not_implicitly_run_root_collection_element_validator_when_disabled() {
+		public async ValueTask Does_not_implicitly_run_root_collection_element_validator_when_disabled() {
 			var client = CreateClient(false);
 			var result = await client.GetErrorsViaJSON(
 				nameof(TestController.ImplicitRootCollectionElementValidator),
@@ -34,7 +35,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Does_not_implicitly_run_child_validator_when_root_collection_element_validation_enabled() {
+		public async ValueTask Does_not_implicitly_run_child_validator_when_root_collection_element_validation_enabled() {
 			var client = CreateClient(true);
 			var result = await client.GetErrorsViaJSON(
 				nameof(TestController.ImplicitRootCollectionElementValidationEnabled),
@@ -44,7 +45,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Executes_implicit_root_collection_element_validator_when_enabled() {
+		public async ValueTask Executes_implicit_root_collection_element_validator_when_enabled() {
 			var client = CreateClient(true);
 			var result = await client.GetErrorsViaJSON(
 				nameof(TestController.ImplicitRootCollectionElementValidator),

--- a/src/FluentValidation.Tests.AspNetCore/ImplicitValidationTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ImplicitValidationTests.cs
@@ -40,14 +40,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Does_not_implicitly_run_child_validator() {
+		public async ValueTask Does_not_implicitly_run_child_validator() {
 			var client = CreateClient(false);
 			var result = await client.GetErrors("ImplicitChildValidator", new FormData());
 			result.Count.ShouldEqual(0);
 		}
 
 		[Fact]
-		public async void Implicitly_run_child_validator() {
+		public async ValueTask Implicitly_run_child_validator() {
 			var client = CreateClient(true);
 			var result = await client.GetErrors("ImplicitChildValidator", new FormData());
 			result.Count.ShouldEqual(1);
@@ -55,21 +55,21 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Ignores_null_child() {
+		public async ValueTask Ignores_null_child() {
 			var client = CreateClient(true);
 			var result = await client.GetErrors("ImplicitChildValidatorWithNullChild", new FormData());
 			result.Count.ShouldEqual(0);
 		}
 
 		[Fact]
-		public async void Executes_implicit_child_validator_and_mixes_with_IValidatableObject() {
+		public async ValueTask Executes_implicit_child_validator_and_mixes_with_IValidatableObject() {
 			var client = CreateClient(true);
 			var result = await client.GetErrors("ImplicitChildImplementsIValidatableObject", new FormData());
 			result.Count.ShouldEqual(3);
 		}
 
 		[Fact]
-		public async void Executes_implicit_child_validator_when_enabled_does_not_execute_multiple_times() {
+		public async ValueTask Executes_implicit_child_validator_when_enabled_does_not_execute_multiple_times() {
 			var client = CreateClient(true);
 			var result = await client.GetErrors("ImplicitChildValidator", new FormData());
 			result.Count.ShouldEqual(1);
@@ -79,14 +79,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void ImplicitValidation_enabled_but_validator_explicitly_only_includes_error_message_once() {
+		public async ValueTask ImplicitValidation_enabled_but_validator_explicitly_only_includes_error_message_once() {
 			var client = CreateClient(true);
 			var result = await client.GetErrors("ImplicitAndExplicitChildValidator", new FormData());
 			result.Count.ShouldEqual(1);
 		}
 
 		[Fact]
-		public async void Executes_implicit_child_validator_and_mixes_with_DataAnnotations() {
+		public async ValueTask Executes_implicit_child_validator_and_mixes_with_DataAnnotations() {
 			var client = CreateClient(true);
 			var result = await client.GetErrors("ImplicitChildWithDataAnnotations", new FormData());
 			_output.WriteLine(JsonConvert.SerializeObject(result));
@@ -94,7 +94,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Can_validate_dictionary() {
+		public async ValueTask Can_validate_dictionary() {
 			var client = CreateClient(true);
 			var dictionary = new Dictionary<int, TestModel5>() {
 				{123, new TestModel5() {SomeBool = true, Id = 1}},
@@ -107,7 +107,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Validates_dictionary_with_prefix() {
+		public async ValueTask Validates_dictionary_with_prefix() {
 			var form = new FormData {
 				{"model[0].Key", "0"},
 				{"model[0].Value.Name", null},
@@ -126,7 +126,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Validates_dictionary_without_prefix() {
+		public async ValueTask Validates_dictionary_without_prefix() {
 			var form = new FormData {
 				{"[0].Name", null},
 				{"[1].Name", null},
@@ -140,7 +140,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Can_validate_enumerable() {
+		public async ValueTask Can_validate_enumerable() {
 			var list = new List<TestModel5>() {
 				new TestModel5() {SomeBool = true, Id = 1},
 				new TestModel5(),
@@ -157,7 +157,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validates_collection() {
+		public async ValueTask Validates_collection() {
 			var form = new FormData {
 				{"model[0].Name", "foo"},
 				{"model[1].Name", "foo"},
@@ -171,7 +171,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validates_collection_without_prefix() {
+		public async ValueTask Validates_collection_without_prefix() {
 			var form = new FormData {
 				{"[0].Name", "foo"},
 				{"[1].Name", "foo"},
@@ -185,7 +185,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async void Skips_implicit_child_validation() {
+		public async ValueTask Skips_implicit_child_validation() {
 			var result = await CreateClient(true).GetErrors("SkipsImplicitChildValidator", new FormData());
 			result.Count.ShouldEqual(0);
 		}

--- a/src/FluentValidation.Tests.AspNetCore/MvcIntegrationTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/MvcIntegrationTests.cs
@@ -44,7 +44,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_add_all_errors_in_one_go() {
+		public async ValueTask Should_add_all_errors_in_one_go() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},
@@ -62,7 +62,7 @@ namespace FluentValidation.Tests.AspNetCore {
 
 
 		[Fact]
-		public async Task Should_add_all_errors_in_one_go_when_NotEmpty_rule_specified_for_non_nullable_value_type() {
+		public async ValueTask Should_add_all_errors_in_one_go_when_NotEmpty_rule_specified_for_non_nullable_value_type() {
 			var form = new FormData {
 				{"SomeBool", "False"},
 				{"Id", "0"}
@@ -74,7 +74,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task When_a_validation_error_occurs_the_error_should_be_added_to_modelstate() {
+		public async ValueTask When_a_validation_error_occurs_the_error_should_be_added_to_modelstate() {
 			var form = new FormData {
 				{"test.Name", null}
 			};
@@ -86,7 +86,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task When_a_validation_error_occurs_the_error_should_be_added_to_modelstate_using_TryUpdateModel() {
+		public async ValueTask When_a_validation_error_occurs_the_error_should_be_added_to_modelstate_using_TryUpdateModel() {
 			var form = new FormData {
 				{"test.Name", null}
 			};
@@ -98,7 +98,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task When_a_validation_error_occurs_the_error_should_be_added_to_Modelstate_without_prefix() {
+		public async ValueTask When_a_validation_error_occurs_the_error_should_be_added_to_Modelstate_without_prefix() {
 			var form = new FormData {
 				{"Name", null}
 			};
@@ -108,13 +108,13 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_not_fail_when_no_validator_can_be_found() {
+		public async ValueTask Should_not_fail_when_no_validator_can_be_found() {
 			var result = await _client.PostResponse("/Test/Test2", new FormData());
 			result.ShouldEqual("not null");
 		}
 
 		[Fact]
-		public async Task Should_not_add_default_message_to_modelstate() {
+		public async ValueTask Should_not_add_default_message_to_modelstate() {
 			var form = new FormData {
 				{"Id", ""}
 			};
@@ -125,7 +125,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_not_add_default_message_to_modelstate_prefix() {
+		public async ValueTask Should_not_add_default_message_to_modelstate_prefix() {
 			var form = new FormData {
 				{"test.Id", ""}
 			};
@@ -137,7 +137,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_not_add_default_message_to_modelstate_not_specified() {
+		public async ValueTask Should_not_add_default_message_to_modelstate_not_specified() {
 			var form = new FormData {
 			};
 
@@ -147,7 +147,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_add_default_message_to_modelstate_when_there_is_no_required_validator_explicitly_specified() {
+		public async ValueTask Should_add_default_message_to_modelstate_when_there_is_no_required_validator_explicitly_specified() {
 			var form = new FormData {
 				{"Id", ""}
 			};
@@ -157,7 +157,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_add_Default_message_to_modelstate_when_no_validator_specified() {
+		public async ValueTask Should_add_Default_message_to_modelstate_when_no_validator_specified() {
 			var form = new FormData {
 				{"Id", ""}
 			};
@@ -167,7 +167,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Allows_override_of_required_message_for_non_nullable_value_types() {
+		public async ValueTask Allows_override_of_required_message_for_non_nullable_value_types() {
 			var form = new FormData {
 				{"Id", ""}
 			};
@@ -177,7 +177,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Allows_override_of_required_property_name_for_non_nullable_value_types() {
+		public async ValueTask Allows_override_of_required_property_name_for_non_nullable_value_types() {
 			var form = new FormData {
 				{"Id", ""}
 			};
@@ -186,7 +186,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_only_validate_specified_ruleset() {
+		public async ValueTask Should_only_validate_specified_ruleset() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},
@@ -200,7 +200,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Should_only_validate_specified_properties() {
+		public async ValueTask Should_only_validate_specified_properties() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},
@@ -215,7 +215,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task When_interceptor_specified_Intercepts_validation() {
+		public async ValueTask When_interceptor_specified_Intercepts_validation() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},
@@ -229,7 +229,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task When_interceptor_specified_Intercepts_validation_provides_custom_errors() {
+		public async ValueTask When_interceptor_specified_Intercepts_validation_provides_custom_errors() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},
@@ -242,7 +242,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task When_validator_implements_IValidatorInterceptor_directly_interceptor_invoked() {
+		public async ValueTask When_validator_implements_IValidatorInterceptor_directly_interceptor_invoked() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},
@@ -255,7 +255,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Validator_customizations_should_only_apply_to_single_parameter() {
+		public async ValueTask Validator_customizations_should_only_apply_to_single_parameter() {
 			var form = new FormData {
 				{"first.Email", "foo"},
 				{"first.Surname", "foo"},
@@ -275,7 +275,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Returns_multiple_errors_for_same_property() {
+		public async ValueTask Returns_multiple_errors_for_same_property() {
 			var form = new FormData() {
 				{"model.Name", "baz"}
 			};
@@ -286,66 +286,66 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Uses_both_dataannotations_and_fv_in_same_model() {
+		public async ValueTask Uses_both_dataannotations_and_fv_in_same_model() {
 			var result = await _client.GetErrors("MultipleValidationStrategies", new FormData());
 			_output.WriteLine(JsonConvert.SerializeObject(result));
 			result.Count.ShouldEqual(2);
 		}
 
 		[Fact]
-		public async Task Uses_both_dataannotations_and_fv_on_same_property() {
+		public async ValueTask Uses_both_dataannotations_and_fv_on_same_property() {
 			var result = await _client.GetErrors("MultipleValidationStrategies2", new FormData());
 			result.Count.ShouldEqual(2);
 		}
 
 		[Fact]
-		public async void Mixes_DataAnnotations_with_FV_on_explicitly_set_child_validator() {
+		public async ValueTask Mixes_DataAnnotations_with_FV_on_explicitly_set_child_validator() {
 			var result = await _client.GetErrors("MultipleValidationStrategies3", new FormData());
 			_output.WriteLine(JsonConvert.SerializeObject(result));
 			result.Count.ShouldEqual(3);
 		}
 
 		[Fact]
-		public async Task Uses_DataAnnotations_when_no_FV_validatior_defined() {
+		public async ValueTask Uses_DataAnnotations_when_no_FV_validatior_defined() {
 			var result = await _client.GetErrors("DataAnnotations", new FormData());
 			result.Count.ShouldEqual(1);
 			result[0].Message.ShouldEqual("The Name field is required.");
 		}
 
 		[Fact]
-		public async void Can_mix_FV_with_IValidatableObject() {
+		public async ValueTask Can_mix_FV_with_IValidatableObject() {
 			var result = await _client.GetErrors("ImplementsIValidatableObject", new FormData());
 			_output.WriteLine(JsonConvert.SerializeObject(result, Formatting.Indented));
 			result.Count.ShouldEqual(2);
 		}
 
 		[Fact]
-		public async void Can_validate_using_JSON() {
+		public async ValueTask Can_validate_using_JSON() {
 			var result = await _client.GetErrorsViaJSON("Test5", new TestModel5());
 			result.IsValidField("SomeBool").ShouldBeFalse();
 			result.Count.ShouldEqual(2);
 		}
 
 		[Fact]
-		public async Task Skips_validation() {
+		public async ValueTask Skips_validation() {
 			var results = await _client.GetErrors("SkipsValidation", new FormData());
 			results.Count.ShouldEqual(0);
 		}
 
 		[Fact]
-		public async void Does_not_implicitly_validate_child_collections_by_default() {
+		public async ValueTask Does_not_implicitly_validate_child_collections_by_default() {
 			var result = await _client.GetErrorsViaJSONRaw("ImplicitChildCollection", @"{ Children: [ { Name: null } ] }");
 			result.Count.ShouldEqual(0);
 		}
 
 		[Fact]
-		public async void Does_implicitly_validate_child_collections_by_default_with_DataAnnotations() {
+		public async ValueTask Does_implicitly_validate_child_collections_by_default_with_DataAnnotations() {
 			var result = await _client.GetErrorsViaJSONRaw("ImplicitChildCollectionDataAnnotations", @"{ Children: [ { Name: null } ] }");
 			result.Count.ShouldEqual(1);
 		}
 
 		[Fact]
-		public async void When_skipping_children_does_not_leave_validation_state_unvalidated() {
+		public async ValueTask When_skipping_children_does_not_leave_validation_state_unvalidated() {
 			string json = @"{ Children: [ { Name: null } ] }";
 
 			var request = new HttpRequestMessage(HttpMethod.Post, $"/Test/CheckUnvalidated");
@@ -357,7 +357,7 @@ namespace FluentValidation.Tests.AspNetCore {
 		}
 
 		[Fact]
-		public async Task Validation_invoked_with_ApiController() {
+		public async ValueTask Validation_invoked_with_ApiController() {
 			string json = @"{ Name: null }";
 			var response = await _client.PostAsync("/ApiTest", new StringContent(json, Encoding.UTF8, "application/json"));
 			var responseJson = await response.Content.ReadAsStringAsync();
@@ -369,7 +369,7 @@ namespace FluentValidation.Tests.AspNetCore {
 
 
 		[Fact]
-		public async Task When_calling_AddFluentValidation_prior_to_AddMvc_doesnot_break() {
+		public async ValueTask When_calling_AddFluentValidation_prior_to_AddMvc_doesnot_break() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},

--- a/src/FluentValidation.Tests.AspNetCore/RazorPagesTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/RazorPagesTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace FluentValidation.Tests {
 	using System.Collections.Generic;
 	using System.Net.Http;
+	using System.Threading.Tasks;
 	using AspNetCore;
 	using AspNetCore.Controllers;
 	using FluentValidation.AspNetCore;
@@ -26,7 +27,7 @@
 		}
 
 		[Fact]
-		public async void Validates_with_BindProperty_attribute_when_implicit_validation_disabled() {
+		public async ValueTask Validates_with_BindProperty_attribute_when_implicit_validation_disabled() {
 			var form = new FormData {
 				{"Name", null},
 			};
@@ -38,7 +39,7 @@
 		}
 
 		[Fact]
-		public async void Validates_with_BindProperty_attribute_when_implicit_validation_disabled_using_prefix() {
+		public async ValueTask Validates_with_BindProperty_attribute_when_implicit_validation_disabled_using_prefix() {
 			var form = new FormData {
 				{"Test.Name", null},
 			};
@@ -51,7 +52,7 @@
 
 #if NETCOREAPP3_1 || NET5_0
 		[Fact]
-		public async void Should_only_validate_specified_ruleset() {
+		public async ValueTask Should_only_validate_specified_ruleset() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},
@@ -87,7 +88,7 @@
 		}
 
 		[Fact]
-		public async void Validates_with_BindProperty_attribute_when_implicit_validation_enabled() {
+		public async ValueTask Validates_with_BindProperty_attribute_when_implicit_validation_enabled() {
 			var form = new FormData {
 				{"Name", null},
 			};
@@ -99,7 +100,7 @@
 		}
 
 		[Fact]
-		public async void Validates_with_BindProperty_attribute_when_implicit_validation_disabled_using_prefix() {
+		public async ValueTask Validates_with_BindProperty_attribute_when_implicit_validation_disabled_using_prefix() {
 			var form = new FormData {
 				{"Test.Name", null},
 			};
@@ -112,7 +113,7 @@
 
 #if NETCOREAPP3_1 || NET5_0
 		[Fact]
-		public async void Should_only_validate_specified_ruleset() {
+		public async ValueTask Should_only_validate_specified_ruleset() {
 			var form = new FormData {
 				{"Email", "foo"},
 				{"Surname", "foo"},

--- a/src/FluentValidation.Tests.AspNetCore/ServiceProviderTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/ServiceProviderTests.cs
@@ -23,7 +23,7 @@
 		}
 
 		[Fact]
-		public async Task Gets_validators_from_service_provider() {
+		public async ValueTask Gets_validators_from_service_provider() {
 			var form = new FormData {
 				{ "test.Name", null }
 			};
@@ -35,7 +35,7 @@
 		}
 
 		[Fact]
-		public async Task Validators_should_be_scoped() {
+		public async ValueTask Validators_should_be_scoped() {
 			var result = await _client.GetErrors("Lifecycle", new FormData());
 			var hashCode1 = result.GetError("Foo");
 
@@ -51,7 +51,7 @@
 		}
 
 		[Fact]
-		public async Task Gets_validator_for_model_not_underlying_collection_type() {
+		public async ValueTask Gets_validator_for_model_not_underlying_collection_type() {
 			var result = await _client.GetErrors("ModelThatimplementsIEnumerable", new FormData());
 			result.GetError("Name").ShouldEqual("Foo");
 		}

--- a/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
+++ b/src/FluentValidation.Tests.AspNetCore/TestPageModel.cs
@@ -13,8 +13,8 @@ namespace FluentValidation.Tests {
 		[BindProperty]
 		public TestModel Test { get; set; }
 
-		public Task<IActionResult> OnPostAsync() {
-			return Task.FromResult(TestResult());
+		public ValueTask<IActionResult> OnPostAsync() {
+			return new ValueTask<IActionResult>(Task.FromResult(TestResult()));
 		}
 
 		private IActionResult TestResult() {
@@ -37,8 +37,8 @@ namespace FluentValidation.Tests {
 		[CustomizeValidator(RuleSet = "Names")]
 		public RulesetTestModel Test { get; set; }
 
-		public Task<IActionResult> OnPostAsync() {
-			return Task.FromResult(TestResult());
+		public ValueTask<IActionResult> OnPostAsync() {
+			return new ValueTask<IActionResult>(Task.FromResult(TestResult()));
 		}
 
 		private IActionResult TestResult() {
@@ -60,8 +60,8 @@ namespace FluentValidation.Tests {
 		[BindProperty(Name = "Test")]
 		public TestModel Test { get; set; }
 
-		public Task<IActionResult> OnPostAsync() {
-			return Task.FromResult(TestResult());
+		public ValueTask<IActionResult> OnPostAsync() {
+			return new ValueTask<IActionResult>(Task.FromResult(TestResult()));
 		}
 
 		private IActionResult TestResult() {

--- a/src/FluentValidation.Tests.AspNetCore/TypeFilterTests.cs
+++ b/src/FluentValidation.Tests.AspNetCore/TypeFilterTests.cs
@@ -34,7 +34,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Finds_and_executes_validator() {
+		public async ValueTask Finds_and_executes_validator() {
 			var client = _webApp.CreateClientWithServices(services => {
 				services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
 					fv.RegisterValidatorsFromAssemblyContaining<TestController>();
@@ -48,7 +48,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Filters_types() {
+		public async ValueTask Filters_types() {
 			var client = _webApp.CreateClientWithServices(services => {
 				services.AddMvc().AddNewtonsoftJson().AddFluentValidation(fv => {
 					fv.RegisterValidatorsFromAssemblyContaining<TestController>(scanResult => {

--- a/src/FluentValidation.Tests/AbstractValidatorTester.cs
+++ b/src/FluentValidation.Tests/AbstractValidatorTester.cs
@@ -272,7 +272,7 @@ namespace FluentValidation.Tests {
 
 		[Theory]
 		[MemberData(nameof(PreValidationReturnValueTheoryData))]
-		public async Task WhenPreValidationReturnsFalse_ResultReturnToUserImmediatly_ValidateAsync(ValidationResult preValidationResult) {
+		public async ValueTask WhenPreValidationReturnsFalse_ResultReturnToUserImmediatly_ValidateAsync(ValidationResult preValidationResult) {
 			testValidatorWithPreValidate.PreValidateMethod = (context, validationResult) => {
 				foreach (ValidationFailure validationFailure in preValidationResult.Errors) {
 					validationResult.Errors.Add(validationFailure);
@@ -280,7 +280,7 @@ namespace FluentValidation.Tests {
 
 				return false;
 			};
-			testValidatorWithPreValidate.RuleFor(person => person.Age).MustAsync((age, token) => Task.FromResult(age >= 0));
+			testValidatorWithPreValidate.RuleFor(person => person.Age).MustAsync((age, token) => new ValueTask<bool>(Task.FromResult(age >= 0)));
 
 			var result = await testValidatorWithPreValidate.ValidateAsync(new Person() { Age = -1 });
 
@@ -316,14 +316,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task WhenPreValidationReturnsTrue_ValidatorsGetHit_ValidateAsync() {
+		public async ValueTask WhenPreValidationReturnsTrue_ValidatorsGetHit_ValidateAsync() {
 			const string testProperty = "TestProperty";
 			const string testMessage = "Test Message";
 			testValidatorWithPreValidate.PreValidateMethod = (context, validationResult) => {
 				validationResult.Errors.Add(new ValidationFailure(testProperty, testMessage));
 				return true;
 			};
-			testValidatorWithPreValidate.RuleFor(person => person.Age).MustAsync((age, token) => Task.FromResult(age >= 0));
+			testValidatorWithPreValidate.RuleFor(person => person.Age).MustAsync((age, token) => new ValueTask<bool>(Task.FromResult(age >= 0)));
 
 			var result = await testValidatorWithPreValidate.ValidateAsync(new Person() { Age = -1 });
 

--- a/src/FluentValidation.Tests/CascadingFailuresTester.cs
+++ b/src/FluentValidation.Tests/CascadingFailuresTester.cs
@@ -192,14 +192,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_continues_on_failure_async() {
+		public async ValueTask Validation_continues_on_failure_async() {
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
 			var results = await validator.ValidateAsync(new Person());
 			results.Errors.Count.ShouldEqual(2);
 		}
 
 		[Fact]
-		public async Task Validation_stops_on_first_failure_async() {
+		public async ValueTask Validation_stops_on_first_failure_async() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.Stop;
 
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -208,7 +208,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_stops_on_first_failure_async_legacy() {
+		public async ValueTask Validation_stops_on_first_failure_async_legacy() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.StopOnFirstFailure;
 
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -217,7 +217,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_continues_on_failure_when_set_to_Stop_globally_and_overriden_at_rule_level_async() {
+		public async ValueTask Validation_continues_on_failure_when_set_to_Stop_globally_and_overriden_at_rule_level_async() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.Stop;
 
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.Continue).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -226,7 +226,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_continues_on_failure_when_set_to_Stop_globally_and_overriden_at_rule_level_async_legacy() {
+		public async ValueTask Validation_continues_on_failure_when_set_to_Stop_globally_and_overriden_at_rule_level_async_legacy() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.StopOnFirstFailure;
 
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.Continue).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -235,7 +235,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_stops_on_first_Failure_when_set_to_Continue_globally_and_overriden_at_rule_level_async() {
+		public async ValueTask Validation_stops_on_first_Failure_when_set_to_Continue_globally_and_overriden_at_rule_level_async() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.Continue;
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.Stop).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
 			var results = await validator.ValidateAsync(new Person());
@@ -243,7 +243,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_stops_on_first_Failure_when_set_to_Continue_globally_and_overriden_at_rule_level_async_legacy() {
+		public async ValueTask Validation_stops_on_first_Failure_when_set_to_Continue_globally_and_overriden_at_rule_level_async_legacy() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.Continue;
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.StopOnFirstFailure).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
 			var results = await validator.ValidateAsync(new Person());
@@ -252,7 +252,7 @@ namespace FluentValidation.Tests {
 
 
 		[Fact]
-		public async Task Validation_stops_on_first_Failure_when_set_to_Continue_globally_and_overriden_at_rule_level_and_async_validator_is_invoked_synchronously() {
+		public async ValueTask Validation_stops_on_first_Failure_when_set_to_Continue_globally_and_overriden_at_rule_level_and_async_validator_is_invoked_synchronously() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.Continue;
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.Stop).NotNull().Equal("Foo");
 			var results = await validator.ValidateAsync(new Person());
@@ -260,7 +260,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_stops_on_first_Failure_when_set_to_Continue_globally_and_overriden_at_rule_level_and_async_validator_is_invoked_synchronously_legacy() {
+		public async ValueTask Validation_stops_on_first_Failure_when_set_to_Continue_globally_and_overriden_at_rule_level_and_async_validator_is_invoked_synchronously_legacy() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.Continue;
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.StopOnFirstFailure).NotNull().Equal("Foo");
 			var results = await validator.ValidateAsync(new Person());
@@ -268,7 +268,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_continues_to_second_validator_when_first_validator_succeeds_and_cascade_set_to_stop_async() {
+		public async ValueTask Validation_continues_to_second_validator_when_first_validator_succeeds_and_cascade_set_to_stop_async() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.Stop;
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
 			var result = await validator.ValidateAsync(new Person {Surname = "x"});
@@ -276,7 +276,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_continues_to_second_validator_when_first_validator_succeeds_and_cascade_set_to_stop_async_legacy() {
+		public async ValueTask Validation_continues_to_second_validator_when_first_validator_succeeds_and_cascade_set_to_stop_async_legacy() {
 			ValidatorOptions.Global.CascadeMode = CascadeMode.StopOnFirstFailure;
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
 			var result = await validator.ValidateAsync(new Person {Surname = "x"});
@@ -284,7 +284,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_stops_on_first_failure_when_set_to_StopOnFirstFailure_at_validator_level_async() {
+		public async ValueTask Validation_stops_on_first_failure_when_set_to_StopOnFirstFailure_at_validator_level_async() {
 			validator.CascadeMode = CascadeMode.Stop;
 
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -293,7 +293,7 @@ namespace FluentValidation.Tests {
 			results.Errors.Count.ShouldEqual(1);
 		}
 
-		[Fact] public async Task Validation_stops_on_first_failure_when_set_to_StopOnFirstFailure_at_validator_level_async_legacy() {
+		[Fact] public async ValueTask Validation_stops_on_first_failure_when_set_to_StopOnFirstFailure_at_validator_level_async_legacy() {
 			validator.CascadeMode = CascadeMode.StopOnFirstFailure;
 
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -302,7 +302,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_continues_when_set_to_Continue_at_validator_level_async() {
+		public async ValueTask Validation_continues_when_set_to_Continue_at_validator_level_async() {
 			validator.CascadeMode = CascadeMode.Continue;
 
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -311,7 +311,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_continues_on_failure_when_set_to_StopOnFirstFailure_at_validator_level_and_overriden_at_rule_level_async() {
+		public async ValueTask Validation_continues_on_failure_when_set_to_StopOnFirstFailure_at_validator_level_and_overriden_at_rule_level_async() {
 			validator.CascadeMode = CascadeMode.Stop;
 
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.Continue).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -320,7 +320,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_continues_on_failure_when_set_to_StopOnFirstFailure_at_validator_level_and_overriden_at_rule_level_async_legacy() {
+		public async ValueTask Validation_continues_on_failure_when_set_to_StopOnFirstFailure_at_validator_level_and_overriden_at_rule_level_async_legacy() {
 			validator.CascadeMode = CascadeMode.StopOnFirstFailure;
 
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.Continue).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -329,7 +329,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_stops_on_failure_when_set_to_Continue_and_overriden_at_rule_level_async() {
+		public async ValueTask Validation_stops_on_failure_when_set_to_Continue_and_overriden_at_rule_level_async() {
 			validator.CascadeMode = CascadeMode.Continue;
 
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.Stop).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -338,7 +338,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_stops_on_failure_when_set_to_Continue_and_overriden_at_rule_level_async_legacy() {
+		public async ValueTask Validation_stops_on_failure_when_set_to_Continue_and_overriden_at_rule_level_async_legacy() {
 			validator.CascadeMode = CascadeMode.Continue;
 
 			validator.RuleFor(x => x.Surname).Cascade(CascadeMode.StopOnFirstFailure).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
@@ -347,7 +347,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Cascade_mode_can_be_set_after_validator_instantiated_async() {
+		public async ValueTask Cascade_mode_can_be_set_after_validator_instantiated_async() {
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
 			validator.CascadeMode = CascadeMode.Stop;
 			var results = await validator.ValidateAsync(new Person());
@@ -355,7 +355,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Cascade_mode_can_be_set_after_validator_instantiated_async_legacy() {
+		public async ValueTask Cascade_mode_can_be_set_after_validator_instantiated_async_legacy() {
 			validator.RuleFor(x => x.Surname).MustAsync(async (x, c) => x != null).MustAsync(async (x, c) => x == "foo");
 			validator.CascadeMode = CascadeMode.StopOnFirstFailure;
 			var results = await validator.ValidateAsync(new Person());

--- a/src/FluentValidation.Tests/ComplexValidationTester.cs
+++ b/src/FluentValidation.Tests/ComplexValidationTester.cs
@@ -113,7 +113,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Condition_should_work_with_complex_property_when_invoked_async() {
+		public async ValueTask Condition_should_work_with_complex_property_when_invoked_async() {
 			var validator = new TestValidator() {
 				v => v.RuleFor(x => x.Address).SetValidator(new AddressValidator()).When(x => x.Address.Line1 == "foo")
 			};
@@ -124,7 +124,7 @@ namespace FluentValidation.Tests {
 
 
 		[Fact]
-		public async Task Async_condition_should_work_with_complex_property() {
+		public async ValueTask Async_condition_should_work_with_complex_property() {
 			var validator = new TestValidator() {
 				v => v.RuleFor(x => x.Address).SetValidator(new AddressValidator()).WhenAsync(async (x, c) => x.Address.Line1 == "foo")
 			};
@@ -205,13 +205,13 @@ namespace FluentValidation.Tests {
 
 
 		[Fact]
-		public async Task Multiple_rules_in_chain_with_childvalidator_shouldnt_reuse_accessor_async() {
+		public async ValueTask Multiple_rules_in_chain_with_childvalidator_shouldnt_reuse_accessor_async() {
 			var validator = new InlineValidator<Person>();
 			var addrValidator = new InlineValidator<Address>();
-			addrValidator.RuleFor(x => x.Line1).MustAsync((l, t) => Task.FromResult(l != null));
+			addrValidator.RuleFor(x => x.Line1).MustAsync((l, t) => new ValueTask<bool>(Task.FromResult(l != null)));
 
 			validator.RuleFor(x => x.Address).SetValidator(addrValidator)
-				.MustAsync((a, t) => Task.FromResult(a != null));
+				.MustAsync((a, t) => new ValueTask<bool>(Task.FromResult(a != null)));
 
 			var result = await validator.ValidateAsync(new Person() {Address = new Address()});
 			result.Errors.Count.ShouldEqual(1);
@@ -296,7 +296,7 @@ namespace FluentValidation.Tests {
 				return base.Validate(context);
 			}
 
-			public override Task<ValidationResult> ValidateAsync(ValidationContext<T> context, CancellationToken cancellation = new CancellationToken()) {
+			public override ValueTask<ValidationResult> ValidateAsync(ValidationContext<T> context, CancellationToken cancellation = new CancellationToken()) {
 				WasCalledAsync = true;
 				return base.ValidateAsync(context, cancellation);
 			}

--- a/src/FluentValidation.Tests/ConditionTests.cs
+++ b/src/FluentValidation.Tests/ConditionTests.cs
@@ -32,7 +32,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_should_succeed_when_async_condition_does_not_match() {
+		public async ValueTask Validation_should_succeed_when_async_condition_does_not_match() {
 			var validator = new TestConditionAsyncValidator();
 			var result = await validator.ValidateAsync(new Person {Id = 1});
             result.IsValid.ShouldBeTrue();
@@ -46,7 +46,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_should_fail_when_async_condition_matches() {
+		public async ValueTask Validation_should_fail_when_async_condition_matches() {
 			var validator = new TestConditionAsyncValidator();
 			var result = await validator.ValidateAsync(new Person());
 			result.IsValid.ShouldBeFalse();
@@ -60,7 +60,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_should_succeed_when_async_condition_matches() {
+		public async ValueTask Validation_should_succeed_when_async_condition_matches() {
 			var validator = new InverseConditionAsyncValidator();
 			var result = await validator.ValidateAsync(new Person());
 			result.IsValid.ShouldBeTrue();
@@ -74,7 +74,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validation_should_fail_when_async_condition_does_not_match() {
+		public async ValueTask Validation_should_fail_when_async_condition_does_not_match() {
 			var validator = new InverseConditionAsyncValidator();
 			var result = await validator.ValidateAsync(new Person {Id = 1});
 			result.IsValid.ShouldBeFalse();
@@ -91,7 +91,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Async_condition_is_applied_to_all_validators_in_the_chain() {
+		public async ValueTask Async_condition_is_applied_to_all_validators_in_the_chain() {
 			var validator = new TestValidator {
 				v => v.RuleFor(x => x.Surname).NotNull().NotEqual("foo").WhenAsync(async (x,c) => x.Id > 0)
 			};
@@ -111,7 +111,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Sync_condition_is_applied_to_async_validators() {
+		public async ValueTask Sync_condition_is_applied_to_async_validators() {
 			var validator = new TestValidator {
 				v => v.RuleFor(x => x.Surname)
 					.MustAsync(async (val, token) => val != null)
@@ -134,7 +134,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Async_condition_is_applied_to_single_validator_in_the_chain_when_ApplyConditionTo_set_to_CurrentValidator() {
+		public async ValueTask Async_condition_is_applied_to_single_validator_in_the_chain_when_ApplyConditionTo_set_to_CurrentValidator() {
 			var validator = new TestValidator {
 				v => v.RuleFor(x => x.Surname).NotNull().NotEqual("foo").WhenAsync(async (x,c) => x.Id > 0, ApplyConditionTo.CurrentValidator)
 			};
@@ -147,7 +147,7 @@ namespace FluentValidation.Tests {
 		public void Async_condition_executed_synchronosuly_with_synchronous_role() {
 			var validator = new TestValidator();
 			validator.RuleFor(x => x.Surname).NotNull()
-				.WhenAsync((x, token) => Task.FromResult(false));
+				.WhenAsync((x, token) => new ValueTask<bool>(Task.FromResult(false)));
 			var result = validator.Validate(new Person());
 			result.IsValid.ShouldBeTrue();
 		}
@@ -156,8 +156,8 @@ namespace FluentValidation.Tests {
 		public void Async_condition_executed_synchronosuly_with_asynchronous_rule() {
 			var validator = new TestValidator();
 			validator.RuleFor(x => x.Surname)
-				.MustAsync((surname, c) => Task.FromResult(surname != null))
-				.WhenAsync((x, token) => Task.FromResult(false));
+				.MustAsync((surname, c) => new ValueTask<bool>(Task.FromResult(surname != null)))
+				.WhenAsync((x, token) => new ValueTask<bool>(Task.FromResult(false)));
 			var result = validator.Validate(new Person());
 			result.IsValid.ShouldBeTrue();
 		}
@@ -166,7 +166,7 @@ namespace FluentValidation.Tests {
 		public void Async_condition_executed_synchronosuly_with_synchronous_collection_role() {
 			var validator = new TestValidator();
 			validator.RuleForEach(x => x.NickNames).NotNull()
-				.WhenAsync((x, token) => Task.FromResult(false));
+				.WhenAsync((x, token) => new ValueTask<bool>(Task.FromResult(false)));
 			var result = validator.Validate(new Person { NickNames = new string[0] });
 			result.IsValid.ShouldBeTrue();
 		}
@@ -175,8 +175,8 @@ namespace FluentValidation.Tests {
 		public void Async_condition_executed_synchronosuly_with_asynchronous_collection_rule() {
 			var validator = new TestValidator();
 			validator.RuleForEach(x => x.NickNames)
-				.MustAsync((n, c) => Task.FromResult(n != null))
-				.WhenAsync((x, token) => Task.FromResult(false));
+				.MustAsync((n, c) => new ValueTask<bool>(Task.FromResult(n != null)))
+				.WhenAsync((x, token) => new ValueTask<bool>(Task.FromResult(false)));
 			var result = validator.Validate(new Person { NickNames = new string[0]});
 			result.IsValid.ShouldBeTrue();
 		}

--- a/src/FluentValidation.Tests/CustomValidatorTester.cs
+++ b/src/FluentValidation.Tests/CustomValidatorTester.cs
@@ -44,12 +44,12 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task New_Custom_Returns_single_failure_async() {
+		public async ValueTask New_Custom_Returns_single_failure_async() {
 			validator
 				.RuleFor(x => x)
 				.CustomAsync((x, context, cancel) => {
 					context.AddFailure("Surname", "Fail");
-					return Task.CompletedTask;
+					return new ValueTask(Task.CompletedTask);
 				});
 
 			var result = await validator.ValidateAsync(new Person());
@@ -90,20 +90,20 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task New_CustomAsync_within_ruleset() {
+		public async ValueTask New_CustomAsync_within_ruleset() {
 			var validator = new InlineValidator<Person>();
 
 			validator.RuleSet("foo", () => {
 				validator.RuleFor(x => x).CustomAsync((x, ctx,cancel) => {
 					ctx.AddFailure("x", "y");
-					return Task.CompletedTask;
+					return new ValueTask(Task.CompletedTask);
 				});
 			});
 
 			validator.RuleSet("bar", () => {
 				validator.RuleFor(x => x).CustomAsync((x, ctx,cancel) => {
 					ctx.AddFailure("x", "y");
-					return Task.CompletedTask;
+					return new ValueTask(Task.CompletedTask);
 				});
 			});
 
@@ -147,14 +147,14 @@ namespace FluentValidation.Tests {
 		public void Runs_async_rule_synchronously_when_validator_invoked_synchronously() {
 			validator.RuleFor(x => x.Forename).CustomAsync((x, context, cancel) => {
 				context.AddFailure("foo");
-				return Task.CompletedTask;
+				return new ValueTask(Task.CompletedTask);
 			});
 			var result = validator.Validate(new Person());
 			result.Errors.Count.ShouldEqual(1);
 		}
 
 		[Fact]
-		public async void Runs_sync_rule_asynchronously_when_validator_invoked_asynchronously() {
+		public async ValueTask Runs_sync_rule_asynchronously_when_validator_invoked_asynchronously() {
 			validator.RuleFor(x => x.Forename).Custom((x, context) => context.AddFailure("foo"));
 			var result = await validator.ValidateAsync(new Person());
 			result.Errors.Count.ShouldEqual(1);
@@ -184,11 +184,11 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Allows_conditions_async() {
+		public async ValueTask Allows_conditions_async() {
 			validator.RuleFor(x => x.Forename).CustomAsync((name, ctx, ct) => {
 				ctx.AddFailure("foo");
-				return Task.CompletedTask;
-			}).WhenAsync((x, ct) => Task.FromResult(x.Age < 18));
+				return new ValueTask(Task.CompletedTask);
+			}).WhenAsync((x, ct) => new ValueTask<bool>(Task.FromResult(x.Age < 18)));
 
 			var result = await validator.ValidateAsync(new Person() {Age = 17});
 			result.IsValid.ShouldBeFalse();

--- a/src/FluentValidation.Tests/DefaultValidatorExtensionTester.cs
+++ b/src/FluentValidation.Tests/DefaultValidatorExtensionTester.cs
@@ -139,15 +139,15 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void MustAsync_should_create_AsyncPredicateValidator_with_PropertyValidatorContext() {
+		public async ValueTask MustAsync_should_create_AsyncPredicateValidator_with_PropertyValidatorContext() {
 			var hasPropertyValidatorContext = false;
 			this.validator.RuleFor(x => x.Surname).MustAsync(async (x, val, ctx, cancel) => {
 				hasPropertyValidatorContext = ctx != null;
 				return true;
 			});
-			this.validator.ValidateAsync(new Person {
+			await this.validator.ValidateAsync(new Person {
 				Surname = "Surname"
-			}).Wait();
+			});
 			this.AssertValidator<AsyncPredicateValidator<Person,string>>();
 			hasPropertyValidatorContext.ShouldBeTrue();
 		}
@@ -225,7 +225,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task MustAsync_should_not_throw_InvalidCastException() {
+		public async ValueTask MustAsync_should_not_throw_InvalidCastException() {
 			var model = new Model {
 				Ids = new Guid[0]
 			};
@@ -247,7 +247,7 @@ namespace FluentValidation.Tests {
 		class AsyncModelTestValidator : AbstractValidator<Model> {
 			public AsyncModelTestValidator() {
 				RuleForEach(m => m.Ids)
-					.MustAsync((g, cancel) => Task.FromResult(true));
+					.MustAsync((g, cancel) => new ValueTask<bool>(Task.FromResult(true)));
 			}
 		}
 	}

--- a/src/FluentValidation.Tests/InheritanceValidatorTest.cs
+++ b/src/FluentValidation.Tests/InheritanceValidatorTest.cs
@@ -50,13 +50,13 @@ namespace FluentValidation.Tests {
 
 
 		[Fact]
-		public async Task Validates_inheritance_async() {
+		public async ValueTask Validates_inheritance_async() {
 			var validator = new InlineValidator<Root>();
 			var impl1Validator = new InlineValidator<FooImpl1>();
 			var impl2Validator = new InlineValidator<FooImpl2>();
 
-			impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => Task.FromResult(s != null));
-			impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => Task.FromResult(i > 0));
+			impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => new ValueTask<bool>(Task.FromResult(s != null)));
+			impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => new ValueTask<bool>(Task.FromResult(i > 0)));
 
 			validator.RuleFor(x => x.Foo).SetInheritanceValidator(v => {
 				v.Add(impl1Validator)
@@ -97,13 +97,13 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validates_collection_async() {
+		public async ValueTask Validates_collection_async() {
 			var validator = new InlineValidator<Root>();
 			var impl1Validator = new InlineValidator<FooImpl1>();
 			var impl2Validator = new InlineValidator<FooImpl2>();
 
-			impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => Task.FromResult(s != null));
-			impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => Task.FromResult(i > 0));
+			impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => new ValueTask<bool>(Task.FromResult(s != null)));
+			impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => new ValueTask<bool>(Task.FromResult(i > 0)));
 
 			validator.RuleForEach(x => x.Foos).SetInheritanceValidator(v => {
 				v.Add(impl1Validator)
@@ -144,13 +144,13 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validates_with_callback_async() {
+		public async ValueTask Validates_with_callback_async() {
 			var validator = new InlineValidator<Root>();
 			var impl1Validator = new InlineValidator<FooImpl1>();
 			var impl2Validator = new InlineValidator<FooImpl2>();
 
-			impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => Task.FromResult(s != null));
-			impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => Task.FromResult(i > 0));
+			impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => new ValueTask<bool>(Task.FromResult(s != null)));
+			impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => new ValueTask<bool>(Task.FromResult(i > 0)));
 
 			validator.RuleFor(x => x.Foo).SetInheritanceValidator(v => {
 				v.Add(x => impl1Validator)
@@ -198,13 +198,13 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validates_with_callback_accepting_derived_async() {
+		public async ValueTask Validates_with_callback_accepting_derived_async() {
 			var validator = new InlineValidator<Root>();
 			var impl1Validator = new InlineValidator<FooImpl1>();
 			var impl2Validator = new InlineValidator<FooImpl2>();
 
-			impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => Task.FromResult(s != null));
-			impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => Task.FromResult(i > 0));
+			impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => new ValueTask<bool>(Task.FromResult(s != null)));
+			impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => new ValueTask<bool>(Task.FromResult(i > 0)));
 
 			validator.RuleFor(x => x.Foo).SetInheritanceValidator(v => {
 				v.Add<FooImpl1>((x, impl1) => {
@@ -262,20 +262,20 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Validates_ruleset_async() {
+		public async ValueTask Validates_ruleset_async() {
 			var validator = new InlineValidator<Root>();
 			var impl1Validator = new InlineValidator<FooImpl1>();
 			var impl2Validator = new InlineValidator<FooImpl2>();
 
 			impl1Validator.RuleFor(x => x.Name).Equal("Foo");
 			impl1Validator.RuleSet("RuleSet1", () => {
-				impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => Task.FromResult(s != null));
+				impl1Validator.RuleFor(x => x.Name).MustAsync((s, token) => new ValueTask<bool>(Task.FromResult(s != null)));
 			});
 
 
 			impl2Validator.RuleFor(x => x.Number).Equal(42);
 			impl2Validator.RuleSet("RuleSet2", () => {
-				impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => Task.FromResult(i > 0));
+				impl2Validator.RuleFor(x => x.Number).MustAsync((i, token) => new ValueTask<bool>(Task.FromResult(i > 0)));
 			});
 
 			validator.RuleFor(x => x.Foo).SetInheritanceValidator(v => {

--- a/src/FluentValidation.Tests/LegacyPropertyValidatorTests.cs
+++ b/src/FluentValidation.Tests/LegacyPropertyValidatorTests.cs
@@ -34,7 +34,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Invokes_custom_validator_async() {
+		public async ValueTask Invokes_custom_validator_async() {
 			var validator = new InlineValidator<Person>();
 			validator.RuleFor(x => x.Forename).SetValidator(new LegacyNotNullValidator());
 			var result = await validator.ValidateAsync(new Person());

--- a/src/FluentValidation.Tests/OnFailureTests.cs
+++ b/src/FluentValidation.Tests/OnFailureTests.cs
@@ -40,7 +40,7 @@
 		}
 
 		[Fact]
-		public async Task OnFailure_called_for_each_failed_rule_asyncAsync() {
+		public async ValueTask OnFailure_called_for_each_failed_rule_asyncAsync() {
 			_validator.CascadeMode = CascadeMode.Continue;
 
 			int invoked = 0;
@@ -111,12 +111,12 @@
 		}
 
 		[Fact]
-		public async Task WhenAsyncWithOnFailure_should_invoke_condition_on_inner_validator() {
+		public async ValueTask WhenAsyncWithOnFailure_should_invoke_condition_on_inner_validator() {
 			bool shouldNotBeTrue = false;
 			var validator = new TestValidator();
 			validator.RuleFor(x => x.Surname)
 				.NotEqual("foo")
-				.WhenAsync((x, token) => Task.FromResult(x.Id > 0))
+				.WhenAsync((x, token) => new ValueTask<bool>(Task.FromResult(x.Id > 0)))
 				.OnFailure(x => shouldNotBeTrue = true);
 
 			var result = await validator.ValidateAsync(new Person {Id = 0, Surname = "foo"});
@@ -130,7 +130,7 @@
 			var validator = new TestValidator();
 			validator.RuleFor(x => x.Surname)
 				.NotEqual("foo")
-				.WhenAsync((x, token) => Task.FromResult(x.Id > 0))
+				.WhenAsync((x, token) => new ValueTask<bool>(Task.FromResult(x.Id > 0)))
 				.OnFailure(x => shouldNotBeTrue = true);
 
 			var result = validator.Validate(new Person {Id = 0, Surname = "foo"});
@@ -139,11 +139,11 @@
 		}
 
 		[Fact]
-		public async Task WhenWithOnFailure_should_invoke_condition_on_async_inner_validator() {
+		public async ValueTask WhenWithOnFailure_should_invoke_condition_on_async_inner_validator() {
 			bool shouldNotBeTrue = false;
 			var validator = new TestValidator();
 			validator.RuleFor(x => x.Surname)
-				.MustAsync((x, ctx) => Task.FromResult(false))
+				.MustAsync((x, ctx) => new ValueTask<bool>(Task.FromResult(false)))
 				.When(x => x.Id > 0)
 				.OnFailure(x => shouldNotBeTrue = true);
 
@@ -153,12 +153,12 @@
 		}
 
 		[Fact]
-		public async Task WhenAsyncWithOnFailure_should_invoke_condition_on_async_inner_validator() {
+		public async ValueTask WhenAsyncWithOnFailure_should_invoke_condition_on_async_inner_validator() {
 			bool shouldNotBeTrue = false;
 			var validator = new TestValidator();
 			validator.RuleFor(x => x.Surname)
-				.MustAsync((x, ctx) => Task.FromResult(false))
-				.WhenAsync((x, ctx) => Task.FromResult(x.Id > 0))
+				.MustAsync((x, ctx) => new ValueTask<bool>(Task.FromResult(false)))
+				.WhenAsync((x, ctx) => new ValueTask<bool>(Task.FromResult(x.Id > 0)))
 				.OnFailure(x => shouldNotBeTrue = true);
 
 			var result = await validator.ValidateAsync(new Person {Id = 0, Surname = "foo"});

--- a/src/FluentValidation.Tests/RuleBuilderTests.cs
+++ b/src/FluentValidation.Tests/RuleBuilderTests.cs
@@ -98,7 +98,7 @@ namespace FluentValidation.Tests {
 
 		[Fact]
 		public void Should_throw_when_async_predicate_is_null() {
-			Assert.Throws<ArgumentNullException>(() => builder.SetValidator(new TestPropertyValidator<Person, string>()).WhenAsync((Func<Person, CancellationToken, Task<bool>>) null));
+			Assert.Throws<ArgumentNullException>(() => builder.SetValidator(new TestPropertyValidator<Person, string>()).WhenAsync((Func<Person, CancellationToken, ValueTask<bool>>) null));
 		}
 
 		[Fact]
@@ -113,7 +113,7 @@ namespace FluentValidation.Tests {
 
 		[Fact]
 		public void Should_throw_when_async_inverse_predicate_is_null() {
-			Assert.Throws<ArgumentNullException>(() => builder.SetValidator(new TestPropertyValidator<Person, string>()).UnlessAsync((Func<Person, CancellationToken, Task<bool>>) null));
+			Assert.Throws<ArgumentNullException>(() => builder.SetValidator(new TestPropertyValidator<Person, string>()).UnlessAsync((Func<Person, CancellationToken, ValueTask<bool>>) null));
 		}
 
 		[Fact]
@@ -143,7 +143,7 @@ namespace FluentValidation.Tests {
 		[Fact]
 		public void Nullable_object_with_async_condition_should_not_throw() {
 			_validator.RuleFor(x => x.NullableInt.Value)
-				.GreaterThanOrEqualTo(3).WhenAsync((x,c) => Task.FromResult(x.NullableInt != null));
+				.GreaterThanOrEqualTo(3).WhenAsync((x,c) => new ValueTask<bool>(Task.FromResult(x.NullableInt != null)));
 			_validator.Validate(new ValidationContext<Person>(new Person(), new PropertyChain(), new DefaultValidatorSelector()));
 		}
 

--- a/src/FluentValidation.Tests/RuleDependencyTests.cs
+++ b/src/FluentValidation.Tests/RuleDependencyTests.cs
@@ -102,13 +102,13 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task TestAsyncWithDependentRules_SyncEntry() {
+		public async ValueTask TestAsyncWithDependentRules_SyncEntry() {
 			var validator = new TestValidator();
 			validator.RuleFor(o => o.Forename)
 				.NotNull()
 				.DependentRules(() => {
 					validator.RuleFor(o => o.Address).NotNull();
-					validator.RuleFor(o => o.Age).MustAsync(async (p, token) => await Task.FromResult(p > 10));
+					validator.RuleFor(o => o.Age).MustAsync((p, token) => new ValueTask<bool>(Task.FromResult(p > 10)));
 				});
 
 			var result = await validator.ValidateAsync(new Person());
@@ -122,13 +122,13 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task TestAsyncWithDependentRules_AsyncEntry() {
+		public async ValueTask TestAsyncWithDependentRules_AsyncEntry() {
 			var validator = new TestValidator();
 			validator.RuleFor(o => o)
 				.MustAsync(async (p, ct) => await Task.FromResult(p.Forename != null))
 				.DependentRules(() => {
 					validator.RuleFor(o => o.Address).NotNull();
-					validator.RuleFor(o => o.Age).MustAsync(async (p, token) => await Task.FromResult(p > 10));
+					validator.RuleFor(o => o.Age).MustAsync((p, token) => new ValueTask<bool>(Task.FromResult(p > 10)));
 				});
 
 			var result = await validator.ValidateAsync(new Person());
@@ -142,14 +142,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Async_inside_dependent_rules() {
+		public async ValueTask Async_inside_dependent_rules() {
 			var validator = new AsyncValidator();
 			var result = await validator.ValidateAsync(0);
 			result.IsValid.ShouldBeFalse();
 		}
 
 		[Fact]
-		public async Task Async_inside_dependent_rules_when_parent_rule_not_async() {
+		public async ValueTask Async_inside_dependent_rules_when_parent_rule_not_async() {
 			var validator = new AsyncValidator2();
 			var result = await validator.ValidateAsync(0);
 			result.IsValid.ShouldBeFalse();

--- a/src/FluentValidation.Tests/RulesetTests.cs
+++ b/src/FluentValidation.Tests/RulesetTests.cs
@@ -255,12 +255,12 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Combines_rulesets_and_explicit_properties_async() {
+		public async ValueTask Combines_rulesets_and_explicit_properties_async() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Forename).MustAsync((x,t) => Task.FromResult(x != null));
-			validator.RuleFor(x => x.Surname).MustAsync((x,t) => Task.FromResult(x != null));
+			validator.RuleFor(x => x.Forename).MustAsync((x,t) => new ValueTask<bool>(Task.FromResult(x != null)));
+			validator.RuleFor(x => x.Surname).MustAsync((x,t) => new ValueTask<bool>(Task.FromResult(x != null)));
 			validator.RuleSet("Test", () => {
-				validator.RuleFor(x => x.Age).MustAsync((x,t) => Task.FromResult(x > 0));
+				validator.RuleFor(x => x.Age).MustAsync((x,t) => new ValueTask<bool>(Task.FromResult(x > 0)));
 			});
 
 			var result = await validator.ValidateAsync(new Person(), options => {
@@ -294,14 +294,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Includes_combination_of_rulesets_async() {
+		public async ValueTask Includes_combination_of_rulesets_async() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Forename).MustAsync((x,t) => Task.FromResult(x != null));
+			validator.RuleFor(x => x.Forename).MustAsync((x,t) => new ValueTask<bool>(Task.FromResult(x != null)));
 			validator.RuleSet("Test1", () => {
-				validator.RuleFor(x => x.Surname).MustAsync((x,t) => Task.FromResult(x != null));
+				validator.RuleFor(x => x.Surname).MustAsync((x,t) => new ValueTask<bool>(Task.FromResult(x != null)));
 			});
 			validator.RuleSet("Test2", () => {
-				validator.RuleFor(x => x.Age).MustAsync((x,t) => Task.FromResult(x > 0));
+				validator.RuleFor(x => x.Age).MustAsync((x,t) => new ValueTask<bool>(Task.FromResult(x > 0)));
 			});
 
 			var result = await validator.ValidateAsync(new Person(), options => {
@@ -332,14 +332,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Includes_all_rulesets_async() {
+		public async ValueTask Includes_all_rulesets_async() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Forename).MustAsync((x,t) => Task.FromResult(x != null));
+			validator.RuleFor(x => x.Forename).MustAsync((x,t) => new ValueTask<bool>(Task.FromResult(x != null)));
 			validator.RuleSet("Test1", () => {
-				validator.RuleFor(x => x.Surname).MustAsync((x,t) => Task.FromResult(x != null));
+				validator.RuleFor(x => x.Surname).MustAsync((x,t) => new ValueTask<bool>(Task.FromResult(x != null)));
 			});
 			validator.RuleSet("Test2", () => {
-				validator.RuleFor(x => x.Age).MustAsync((x,t) => Task.FromResult(x > 0));
+				validator.RuleFor(x => x.Age).MustAsync((x,t) => new ValueTask<bool>(Task.FromResult(x > 0)));
 			});
 
 			var result = await validator.ValidateAsync(new Person(), options => {

--- a/src/FluentValidation.Tests/SharedConditionTests.cs
+++ b/src/FluentValidation.Tests/SharedConditionTests.cs
@@ -136,7 +136,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Shared_async_When_is_not_applied_to_grouped_rules_when_initial_predicate_is_false() {
+		public async ValueTask Shared_async_When_is_not_applied_to_grouped_rules_when_initial_predicate_is_false() {
 			var validator = new SharedAsyncConditionValidator();
 			var person = new Person(); // fails the shared When predicate
 
@@ -156,7 +156,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Shared_async_When_is_applied_to_grouped_rules_when_initial_predicate_is_true() {
+		public async ValueTask Shared_async_When_is_applied_to_grouped_rules_when_initial_predicate_is_true() {
 			var validator = new SharedAsyncConditionValidator();
 			var person = new Person() {
 				Id = 4 // triggers the shared When predicate
@@ -180,7 +180,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Shared_async_When_is_applied_to_groupd_rules_when_initial_predicate_is_true_and_all_individual_rules_are_satisfied() {
+		public async ValueTask Shared_async_When_is_applied_to_groupd_rules_when_initial_predicate_is_true_and_all_individual_rules_are_satisfied() {
 			var validator = new SharedAsyncConditionValidator();
 			var person = new Person() {
 			                          	Id = 4, // triggers the shared When predicate
@@ -207,7 +207,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Shared_async_When_respects_the_smaller_scope_of_an_inner_Unless_when_the_inner_Unless_predicate_is_satisfied() {
+		public async ValueTask Shared_async_When_respects_the_smaller_scope_of_an_inner_Unless_when_the_inner_Unless_predicate_is_satisfied() {
 			var validator = new SharedAsyncConditionWithScopedUnlessValidator();
 			var person = new Person() {
 			                          	Id = 4 // triggers the shared When predicate
@@ -234,7 +234,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Shared_async_When_respects_the_smaller_scope_of_a_inner_Unless_when_the_inner_Unless_predicate_fails() {
+		public async ValueTask Shared_async_When_respects_the_smaller_scope_of_a_inner_Unless_when_the_inner_Unless_predicate_fails() {
 			var validator = new SharedAsyncConditionWithScopedUnlessValidator();
 			var person = new Person() {
 			                          	Id = 4 // triggers the shared When predicate
@@ -261,7 +261,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Outer_async_Unless_clause_will_trump_an_inner_Unless_clause_when_inner_fails_but_the_outer_is_satisfied() {
+		public async ValueTask Outer_async_Unless_clause_will_trump_an_inner_Unless_clause_when_inner_fails_but_the_outer_is_satisfied() {
 			var validator = new SharedAsyncConditionWithScopedUnlessValidator();
 			var person = new Person() {
 			                          	Id = 4, // triggers the shared When predicate
@@ -288,7 +288,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Async_condition_can_be_used_inside_ruleset() {
+		public async ValueTask Async_condition_can_be_used_inside_ruleset() {
 			var validator = new TestValidator();
 			validator.RuleSet("foo", () => {
 				validator.WhenAsync(async (x,c) => (x.Id > 0), () => {
@@ -316,7 +316,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task RuleSet_can_be_used_inside_async_condition() {
+		public async ValueTask RuleSet_can_be_used_inside_async_condition() {
 			var validator = new TestValidator();
 
 			validator.WhenAsync(async (x,c) => (x.Id > 0), () => { validator.RuleSet("foo", () => { validator.RuleFor(x => x.Forename).NotNull(); }); });
@@ -336,7 +336,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Rules_invoke_when_inverse_shared_async_condition_matches() {
+		public async ValueTask Rules_invoke_when_inverse_shared_async_condition_matches() {
 			var validator = new SharedAsyncConditionInverseValidator();
 			var result = await validator.ValidateAsync(new Person {Id = 1});
 			result.IsValid.ShouldBeFalse();
@@ -350,14 +350,14 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Rules_not_invoked_when_inverse_shared_async_condition_does_not_match() {
+		public async ValueTask Rules_not_invoked_when_inverse_shared_async_condition_does_not_match() {
 			var validator = new SharedAsyncConditionInverseValidator();
 			var result = await validator.ValidateAsync(new Person());
 			result.IsValid.ShouldBeTrue();
 		}
 
 		[Fact]
-		public async Task Does_not_execute_custom_Rule_when_condition_false() {
+		public async ValueTask Does_not_execute_custom_Rule_when_condition_false() {
 			var validator = new TestValidator();
 			validator.When(x => false, () => {
 				validator.RuleFor(x=>x).Custom((x,ctx)=> ctx.AddFailure(new ValidationFailure("foo", "bar")));
@@ -368,7 +368,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Does_not_execute_custom_Rule_when_async_condition_false() {
+		public async ValueTask Does_not_execute_custom_Rule_when_async_condition_false() {
 			var validator = new TestValidator();
 			validator.WhenAsync(async (x,c) =>(false), () => {
 				validator.RuleFor(x=>x).Custom((x,ctx)=> ctx.AddFailure(new ValidationFailure("foo", "bar")));
@@ -392,7 +392,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Does_not_execute_customasync_Rule_when_async_condition_false() {
+		public async ValueTask Does_not_execute_customasync_Rule_when_async_condition_false() {
 			var validator = new TestValidator();
 			validator.WhenAsync(async (x,c) =>(false), () => {
 
@@ -428,7 +428,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Executes_customasync_rule_when_condition_true() {
+		public async ValueTask Executes_customasync_rule_when_condition_true() {
 			var validator = new TestValidator();
 			validator.When(x => true, () => validator.RuleFor(x=>x).CustomAsync(async (x,ctx,c) => ctx.AddFailure(new ValidationFailure("foo", "bar"))));
 
@@ -437,7 +437,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Executes_customasync_rule_when_async_condition_true() {
+		public async ValueTask Executes_customasync_rule_when_async_condition_true() {
 			var validator = new TestValidator();
 			validator.WhenAsync(async (x,c) =>(true), () => validator.RuleFor(x=>x).CustomAsync(async (x,ctx,c) => ctx.AddFailure(new ValidationFailure("foo", "bar"))));
 
@@ -471,7 +471,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Nested_conditions_with_CustomAsync_rule() {
+		public async ValueTask Nested_conditions_with_CustomAsync_rule() {
 			var validator = new TestValidator();
 			validator.When(x => true, () => {
 				validator.When(x => false, () => {
@@ -483,7 +483,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Nested_async_conditions_with_CustomAsync_rule() {
+		public async ValueTask Nested_async_conditions_with_CustomAsync_rule() {
 			var validator = new TestValidator();
 			validator.When(x => true, () => {
 				validator.WhenAsync(async (x,c) =>(false), () => {
@@ -511,7 +511,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task WhenAsync_condition_only_executed_once() {
+		public async ValueTask WhenAsync_condition_only_executed_once() {
 			var validator = new TestValidator();
 			int executions = 0;
 			validator.WhenAsync(async (x, ct) => {
@@ -557,7 +557,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Runs_otherwise_conditions_for_WhenAsync() {
+		public async ValueTask Runs_otherwise_conditions_for_WhenAsync() {
 			var validator = new TestValidator();
 			validator.WhenAsync(async (x, ct) => x.Age > 10, () => {
 				validator.RuleFor(x => x.Forename).NotNull();
@@ -572,7 +572,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Runs_otherwise_conditions_for_UnlessAsync() {
+		public async ValueTask Runs_otherwise_conditions_for_UnlessAsync() {
 			var validator = new TestValidator();
 			validator.UnlessAsync(async (x, ct) => x.Age > 10, () => {
 				validator.RuleFor(x => x.Forename).NotNull();
@@ -633,7 +633,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task When_async_condition_executed_for_each_instance_of_RuleForEach_condition_should_not_be_cached() {
+		public async ValueTask When_async_condition_executed_for_each_instance_of_RuleForEach_condition_should_not_be_cached() {
 			var person = new Person {
 				Children = new List<Person> {
 					new Person { Id = 1},
@@ -666,7 +666,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Doesnt_throw_NullReferenceException_when_instance_not_null_async() {
+		public async ValueTask Doesnt_throw_NullReferenceException_when_instance_not_null_async() {
 			var v = new BadValidatorDisablesNullCheck();
 			var result = await v.ValidateAsync((string) null);
 			result.IsValid.ShouldBeTrue();
@@ -695,15 +695,15 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Shouldnt_break_with_hashcode_collision_async() {
+		public async ValueTask Shouldnt_break_with_hashcode_collision_async() {
 			var v1 = new InlineValidator<Collision1>();
 			var v2 = new InlineValidator<Collision2>();
 
 			var v = new InlineValidator<CollisionBase>();
-			v.WhenAsync((x, ct) => Task.FromResult(x is Collision1), () => {
+			v.WhenAsync((x, ct) => new ValueTask<bool>(Task.FromResult(x is Collision1)), () => {
 				v.RuleFor(x => ((Collision1)x).Name).NotNull();
 			});
-			v.WhenAsync((x, ct) => Task.FromResult(x is Collision2), () => {
+			v.WhenAsync((x, ct) => new ValueTask<bool>(Task.FromResult(x is Collision2)), () => {
 				v.RuleFor(x => ((Collision2)x).Name).NotNull();
 			});
 

--- a/src/FluentValidation.Tests/TransformTests.cs
+++ b/src/FluentValidation.Tests/TransformTests.cs
@@ -53,7 +53,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Transforms_property_value_with_propagated_original_object_async() {
+		public async ValueTask Transforms_property_value_with_propagated_original_object_async() {
 			var validator = new InlineValidator<Person>();
 			validator.Transform(x => x.Forename, (person, forename) => new {Nicks = person.NickNames, Name = forename})
 				.Must(context => context.Nicks.Any(nick => nick == context.Name.ToLower()));
@@ -73,10 +73,10 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Transforms_collection_element_async() {
+		public async ValueTask Transforms_collection_element_async() {
 			var validator = new InlineValidator<Person>();
 			validator.TransformForEach(x => x.Orders, order => order.Amount)
-				.MustAsync((amt, token) => Task.FromResult(amt > 0));
+				.MustAsync((amt, token) => new ValueTask<bool>(Task.FromResult(amt > 0)));
 
 			var result = await validator.ValidateAsync(new Person() {Orders = new List<Order> {new Order()}});
 			result.Errors.Count.ShouldEqual(1);
@@ -95,7 +95,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Transforms_collection_element_with_propagated_original_object_async() {
+		public async ValueTask Transforms_collection_element_with_propagated_original_object_async() {
 			var validator = new InlineValidator<Person>();
 			validator.TransformForEach(x => x.Children, (parent, children) => new {ParentName = parent.Surname, Children = children})
 				.Must(context => context.ParentName == context.Children.Surname);

--- a/src/FluentValidation.Tests/ValidateAndThrowTester.cs
+++ b/src/FluentValidation.Tests/ValidateAndThrowTester.cs
@@ -36,7 +36,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Throws_exception_async() {
+		public async ValueTask Throws_exception_async() {
 			var validator = new TestValidator {
 				v => v.RuleFor(x => x.Surname).NotNull()
 			};
@@ -47,7 +47,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Throws_exception_with_a_ruleset_async() {
+		public async ValueTask Throws_exception_with_a_ruleset_async() {
 			var validator = new TestValidator {
 				v => v.RuleFor(x => x.Surname).NotNull()
 			};
@@ -86,7 +86,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Does_not_throw_when_valid_async() {
+		public async ValueTask Does_not_throw_when_valid_async() {
 			var validator = new TestValidator {
 				v => v.RuleFor(x => x.Surname).NotNull()
 			};
@@ -95,7 +95,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Does_not_throw_when_valid_and_a_ruleset_async() {
+		public async ValueTask Does_not_throw_when_valid_and_a_ruleset_async() {
 			var validator = new TestValidator {
 				v => v.RuleFor(x => x.Surname).NotNull()
 			};
@@ -218,7 +218,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Throws_exception_when_preValidate_fails_and_continueValidation_true_async() {
+		public async ValueTask Throws_exception_when_preValidate_fails_and_continueValidation_true_async() {
 			var validator = new TestValidatorWithPreValidate {
 				PreValidateMethod = (context, result) => {
 					result.Errors.Add(new ValidationFailure("test", "test"));
@@ -232,7 +232,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Throws_exception_when_preValidate_fails_and_continueValidation_false_async() {
+		public async ValueTask Throws_exception_when_preValidate_fails_and_continueValidation_false_async() {
 			var validator = new TestValidatorWithPreValidate {
 				PreValidateMethod = (context, result) => {
 					result.Errors.Add(new ValidationFailure("test", "test"));
@@ -246,7 +246,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Does_not_throws_exception_when_preValidate_ends_with_continueValidation_false_async() {
+		public async ValueTask Does_not_throws_exception_when_preValidate_ends_with_continueValidation_false_async() {
 			var validator = new TestValidatorWithPreValidate {
 				PreValidateMethod = (context, result) => false
 			};

--- a/src/FluentValidation.Tests/ValidatorSelectorTests.cs
+++ b/src/FluentValidation.Tests/ValidatorSelectorTests.cs
@@ -135,7 +135,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task Executes_correct_rule_when_using_property_with_include_async() {
+		public async ValueTask Executes_correct_rule_when_using_property_with_include_async() {
 			var validator = new TestValidator();
 			var validator2 = new TestValidator();
 			validator2.RuleFor(x => x.Forename).NotNull();

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -32,7 +32,7 @@ namespace FluentValidation.Tests {
 
 		public ValidatorTesterTester() {
 			validator = new TestValidator();
-			validator.RuleFor(x => x.CreditCard).Must(creditCard => !string.IsNullOrEmpty(creditCard)).WhenAsync((x, cancel) => Task.Run(() => { return x.Age >= 18; }));
+			validator.RuleFor(x => x.CreditCard).Must(creditCard => !string.IsNullOrEmpty(creditCard)).WhenAsync((x, cancel) => new ValueTask<bool>(Task.FromResult(x.Age >= 18)));
 			validator.RuleFor(x => x.Forename).NotNull();
 			validator.RuleForEach(person => person.NickNames).MinimumLength(5);
 			CultureScope.SetDefaultCulture();
@@ -740,17 +740,17 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task TestValidate_runs_async() {
+		public async ValueTask TestValidate_runs_async() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(false));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(false)));
 			var result = await validator.TestValidateAsync(new Person());
 			result.ShouldHaveValidationErrorFor(x => x.Surname);
 		}
 
 		[Fact]
-		public async Task TestValidate_runs_async_throws() {
+		public async ValueTask TestValidate_runs_async_throws() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(false));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(false)));
 			var result = await validator.TestValidateAsync(new Person());
 			Assert.Throws<ValidationTestException>(() => {
 				result.ShouldNotHaveValidationErrorFor(x => x.Surname);
@@ -758,64 +758,64 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public async Task ShouldHaveValidationError_async() {
+		public async ValueTask ShouldHaveValidationError_async() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(false));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(false)));
 			(await validator.TestValidateAsync(new Person())).ShouldHaveValidationErrorFor(x => x.Surname);
 		}
 
 		[Fact]
-		public async Task ShouldHaveValidationError_async_throws() {
+		public async ValueTask ShouldHaveValidationError_async_throws() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(true));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(true)));
 			await Assert.ThrowsAsync<ValidationTestException>(async () => {
 				(await validator.TestValidateAsync(new Person())).ShouldHaveValidationErrorFor(x => x.Surname);
 			});
 		}
 
 		[Fact]
-		public async Task ShouldNotHaveValidationError_async() {
+		public async ValueTask ShouldNotHaveValidationError_async() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(true));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(true)));
 			(await validator.TestValidateAsync(new Person())).ShouldNotHaveValidationErrorFor(x => x.Surname);
 		}
 
 		[Fact]
-		public async Task ShouldNotHaveValidationError_async_throws() {
+		public async ValueTask ShouldNotHaveValidationError_async_throws() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(false));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(false)));
 			await Assert.ThrowsAsync<ValidationTestException>(async () => {
 				(await validator.TestValidateAsync(new Person())).ShouldNotHaveValidationErrorFor(x => x.Surname);
 			});
 		}
 
 		[Fact]
-		public async Task ShouldHaveValidationError_model_async() {
+		public async ValueTask ShouldHaveValidationError_model_async() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(false));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(false)));
 			(await validator.TestValidateAsync(new Person())).ShouldHaveValidationErrorFor(x => x.Surname);
 		}
 
 		[Fact]
-		public async Task ShouldHaveValidationError_model_async_throws() {
+		public async ValueTask ShouldHaveValidationError_model_async_throws() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(true));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(true)));
 			await Assert.ThrowsAsync<ValidationTestException>(async () => {
 				(await validator.TestValidateAsync(new Person())).ShouldHaveValidationErrorFor(x => x.Surname);
 			});
 		}
 
 		[Fact]
-		public async Task ShouldNotHaveValidationError_model_async() {
+		public async ValueTask ShouldNotHaveValidationError_model_async() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(true));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(true)));
 			(await validator.TestValidateAsync(new Person())).ShouldNotHaveValidationErrorFor(x => x.Surname);
 		}
 
 		[Fact]
-		public async Task ShouldNotHaveValidationError_async_model_throws() {
+		public async ValueTask ShouldNotHaveValidationError_async_model_throws() {
 			var validator = new InlineValidator<Person>();
-			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => Task.FromResult(false));
+			validator.RuleFor(x => x.Surname).MustAsync((x, ct) => new ValueTask<bool>(Task.FromResult(false)));
 			await Assert.ThrowsAsync<ValidationTestException>(async () => {
 				(await validator.TestValidateAsync(new Person())).ShouldNotHaveValidationErrorFor(x => x.Surname);
 			});

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -48,7 +48,7 @@ namespace FluentValidation {
 			return Validate(ValidationContext<T>.GetFromNonGenericContext(context));
 		}
 
-		Task<ValidationResult> IValidator.ValidateAsync(IValidationContext context, CancellationToken cancellation) {
+		ValueTask<ValidationResult> IValidator.ValidateAsync(IValidationContext context, CancellationToken cancellation) {
 			context.Guard("Cannot pass null to Validate", nameof(context));
 			return ValidateAsync(ValidationContext<T>.GetFromNonGenericContext(context), cancellation);
 		}
@@ -68,7 +68,7 @@ namespace FluentValidation {
 		/// <param name="instance">The object to validate</param>
 		/// <param name="cancellation">Cancellation token</param>
 		/// <returns>A ValidationResult object containing any validation failures</returns>
-		public Task<ValidationResult> ValidateAsync(T instance, CancellationToken cancellation = new CancellationToken()) {
+		public ValueTask<ValidationResult> ValidateAsync(T instance, CancellationToken cancellation = new CancellationToken()) {
 			return ValidateAsync(new ValidationContext<T>(instance, new PropertyChain(), ValidatorOptions.Global.ValidatorSelectors.DefaultValidatorSelectorFactory()), cancellation);
 		}
 
@@ -120,7 +120,7 @@ namespace FluentValidation {
 		/// <param name="context">Validation Context</param>
 		/// <param name="cancellation">Cancellation token</param>
 		/// <returns>A ValidationResult object containing any validation failures.</returns>
-		public virtual async Task<ValidationResult> ValidateAsync(ValidationContext<T> context, CancellationToken cancellation = new CancellationToken()) {
+		public virtual async ValueTask<ValidationResult> ValidateAsync(ValidationContext<T> context, CancellationToken cancellation = new CancellationToken()) {
 			context.Guard("Cannot pass null to Validate", nameof(context));
 			context.IsAsync = true;
 
@@ -334,7 +334,7 @@ namespace FluentValidation {
 		/// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules.</param>
 		/// <returns></returns>
-		public IConditionBuilder WhenAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
+		public IConditionBuilder WhenAsync(Func<T, CancellationToken, ValueTask<bool>> predicate, Action action) {
 			return WhenAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
@@ -344,7 +344,7 @@ namespace FluentValidation {
 		/// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules.</param>
 		/// <returns></returns>
-		public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
+		public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, Action action) {
 			return new AsyncConditionBuilder<T>(Rules).WhenAsync(predicate, action);
 		}
 
@@ -353,7 +353,7 @@ namespace FluentValidation {
 		/// </summary>
 		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules</param>
-		public IConditionBuilder UnlessAsync(Func<T, CancellationToken, Task<bool>> predicate, Action action) {
+		public IConditionBuilder UnlessAsync(Func<T, CancellationToken, ValueTask<bool>> predicate, Action action) {
 			return UnlessAsync((x, ctx, cancel) => predicate(x, cancel), action);
 		}
 
@@ -362,7 +362,7 @@ namespace FluentValidation {
 		/// </summary>
 		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules</param>
-		public IConditionBuilder UnlessAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
+		public IConditionBuilder UnlessAsync(Func<T, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, Action action) {
 			return new AsyncConditionBuilder<T>(Rules).UnlessAsync(predicate, action);
 		}
 

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -482,7 +482,7 @@ namespace FluentValidation {
 		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
 		/// <param name="predicate">A lambda expression specifying the predicate</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<TProperty, CancellationToken, Task<bool>> predicate) {
+		public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<TProperty, CancellationToken, ValueTask<bool>> predicate) {
 			predicate.Guard("Cannot pass a null predicate to Must.", nameof(predicate));
 
 			return ruleBuilder.MustAsync((x, val, ctx, cancel) => predicate(val, cancel));
@@ -499,7 +499,7 @@ namespace FluentValidation {
 		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
 		/// <param name="predicate">A lambda expression specifying the predicate</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, TProperty, CancellationToken, Task<bool>> predicate) {
+		public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, TProperty, CancellationToken, ValueTask<bool>> predicate) {
 			predicate.Guard("Cannot pass a null predicate to Must.", nameof(predicate));
 			return ruleBuilder.MustAsync((x, val, _, cancel) => predicate(x, val, cancel));
 		}
@@ -515,7 +515,7 @@ namespace FluentValidation {
 		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
 		/// <param name="predicate">A lambda expression specifying the predicate</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, TProperty, ValidationContext<T>, CancellationToken, Task<bool>> predicate) {
+		public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, TProperty, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate) {
 			predicate.Guard("Cannot pass a null predicate to Must.", nameof(predicate));
 			return ruleBuilder.SetAsyncValidator(new AsyncPredicateValidator<T,TProperty>(predicate));
 		}
@@ -1145,7 +1145,7 @@ namespace FluentValidation {
 		/// <param name="ruleBuilder"></param>
 		/// <param name="action"></param>
 		/// <returns></returns>
-		public static IRuleBuilderOptionsConditions<T, TProperty> CustomAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<TProperty, ValidationContext<T>, CancellationToken, Task> action) {
+		public static IRuleBuilderOptionsConditions<T, TProperty> CustomAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<TProperty, ValidationContext<T>, CancellationToken, ValueTask> action) {
 			if (action == null) throw new ArgumentNullException(nameof(action));
 			return (IRuleBuilderOptionsConditions<T, TProperty>)ruleBuilder.MustAsync(async (parent, value, context, cancel) => {
 				await action(value, context, cancel);

--- a/src/FluentValidation/DefaultValidatorExtensions_Validate.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions_Validate.cs
@@ -48,7 +48,7 @@ namespace FluentValidation {
 		/// <param name="options">Callback to configure additional options</param>
 		/// <typeparam name="T"></typeparam>
 		/// <returns></returns>
-		public static Task<ValidationResult> ValidateAsync<T>(this IValidator<T> validator, T instance, Action<ValidationStrategy<T>> options, CancellationToken cancellation = default) {
+		public static ValueTask<ValidationResult> ValidateAsync<T>(this IValidator<T> validator, T instance, Action<ValidationStrategy<T>> options, CancellationToken cancellation = default) {
 			return validator.ValidateAsync(ValidationContext<T>.CreateWithOptions(instance, options), cancellation);
 		}
 
@@ -71,7 +71,7 @@ namespace FluentValidation {
 		/// <param name="validator">The validator this method is extending.</param>
 		/// <param name="instance">The instance of the type we are validating.</param>
 		/// <param name="cancellationToken"></param>
-		public static async Task ValidateAndThrowAsync<T>(this IValidator<T> validator, T instance, CancellationToken cancellationToken = default) {
+		public static async ValueTask ValidateAndThrowAsync<T>(this IValidator<T> validator, T instance, CancellationToken cancellationToken = default) {
 			await validator.ValidateAsync(instance, options => {
 				options.ThrowOnFailures();
 			}, cancellationToken);

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -301,7 +301,7 @@ namespace FluentValidation {
 		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should run</param>
 		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+		public static IRuleBuilderOptions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
 			return rule.WhenAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
 		}
@@ -314,7 +314,7 @@ namespace FluentValidation {
 		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should run</param>
 		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptionsConditions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+		public static IRuleBuilderOptionsConditions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
 			return rule.WhenAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
 		}
@@ -327,7 +327,7 @@ namespace FluentValidation {
 		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should run</param>
 		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+		public static IRuleBuilderOptions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
 			// Default behaviour for When/Unless as of v1.3 is to apply the condition to all previous validators in the chain.
 			Configurable(rule).ApplyAsyncCondition((ctx, ct) => predicate((T)ctx.InstanceToValidate, ValidationContext<T>.GetFromNonGenericContext(ctx), ct), applyConditionTo);
@@ -342,7 +342,7 @@ namespace FluentValidation {
 		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should run</param>
 		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptionsConditions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+		public static IRuleBuilderOptionsConditions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
 			// Default behaviour for When/Unless as of v1.3 is to apply the condition to all previous validators in the chain.
 			Configurable(rule).ApplyAsyncCondition((ctx, ct) => predicate((T)ctx.InstanceToValidate, ValidationContext<T>.GetFromNonGenericContext(ctx), ct), applyConditionTo);
@@ -357,7 +357,7 @@ namespace FluentValidation {
 		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should not run</param>
 		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+		public static IRuleBuilderOptions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
 			return rule.UnlessAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
 		}
@@ -370,7 +370,7 @@ namespace FluentValidation {
 		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should not run</param>
 		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptionsConditions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+		public static IRuleBuilderOptionsConditions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
 			return rule.UnlessAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
 		}
@@ -383,7 +383,7 @@ namespace FluentValidation {
 		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should not run</param>
 		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+		public static IRuleBuilderOptions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
 			return rule.WhenAsync(async (x, ctx, ct) => !await predicate(x, ctx, ct), applyConditionTo);
 		}
@@ -396,7 +396,7 @@ namespace FluentValidation {
 		/// <param name="predicate">A lambda expression that specifies a condition for when the validator should not run</param>
 		/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptionsConditions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+		public static IRuleBuilderOptionsConditions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
 			return rule.WhenAsync(async (x, ctx, ct) => !await predicate(x, ctx, ct), applyConditionTo);
 		}

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
     <Description>A validation library for .NET that uses a fluent interface to construct strongly-typed validation rules.</Description>
     <PackageReleaseNotes>
 FluentValidation 10 is a major release. Please read the upgrade guide at https://docs.fluentvalidation.net/en/latest/upgrading-to-10.html
@@ -19,7 +19,7 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/src/FluentValidation/IValidationRule.cs
+++ b/src/FluentValidation/IValidationRule.cs
@@ -143,7 +143,7 @@ namespace FluentValidation {
 		/// </summary>
 		/// <param name="predicate">The condition to apply</param>
 		/// <param name="applyConditionTo">Whether the condition should be applied to the current property validator in the chain, or all preceding property validators in the chain.</param>
-		void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators);
+		void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators);
 
 		/// <summary>
 		/// Applies a pre-condition to this rule.
@@ -155,7 +155,7 @@ namespace FluentValidation {
 		/// Applies an async pre-condition to this rule.
 		/// </summary>
 		/// <param name="condition"></param>
-		void ApplySharedAsyncCondition(Func<ValidationContext<T>, CancellationToken, Task<bool>> condition);
+		void ApplySharedAsyncCondition(Func<ValidationContext<T>, CancellationToken, ValueTask<bool>> condition);
 
 		/// <summary>
 		/// Gets the property value for this rule. Note that this bypasses all conditions.

--- a/src/FluentValidation/IValidationRuleInternal.cs
+++ b/src/FluentValidation/IValidationRuleInternal.cs
@@ -25,7 +25,7 @@ namespace FluentValidation {
 	internal interface IValidationRuleInternal<T> : IValidationRule<T> {
 		void Validate(ValidationContext<T> context);
 
-		Task ValidateAsync(ValidationContext<T> context, CancellationToken cancellation);
+		ValueTask ValidateAsync(ValidationContext<T> context, CancellationToken cancellation);
 
 		void AddDependentRules(IEnumerable<IValidationRuleInternal<T>> rules);
 	}

--- a/src/FluentValidation/IValidator.cs
+++ b/src/FluentValidation/IValidator.cs
@@ -43,7 +43,7 @@ namespace FluentValidation {
 		/// <param name="instance">The instance to validate</param>
 		/// <param name="cancellation"></param>
 		/// <returns>A ValidationResult object containing any validation failures.</returns>
-		Task<ValidationResult> ValidateAsync(T instance, CancellationToken cancellation = new CancellationToken());
+		ValueTask<ValidationResult> ValidateAsync(T instance, CancellationToken cancellation = new CancellationToken());
 	}
 
 	/// <summary>
@@ -63,7 +63,7 @@ namespace FluentValidation {
 		/// <param name="context">A ValidationContext</param>
 		/// <param name="cancellation">Cancellation token</param>
 		/// <returns>A ValidationResult object contains any validation failures.</returns>
-		Task<ValidationResult> ValidateAsync(IValidationContext context, CancellationToken cancellation = new CancellationToken());
+		ValueTask<ValidationResult> ValidateAsync(IValidationContext context, CancellationToken cancellation = new CancellationToken());
 
 		/// <summary>
 		/// Creates a hook to access various meta data properties

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -199,7 +199,7 @@ namespace FluentValidation.Internal {
 			}
 		}
 
-		async Task IValidationRuleInternal<T>.ValidateAsync(ValidationContext<T> context, CancellationToken cancellation) {
+		async ValueTask IValidationRuleInternal<T>.ValidateAsync(ValidationContext<T> context, CancellationToken cancellation) {
 			if (!context.IsAsync) {
 				context.IsAsync = true;
 			}
@@ -348,7 +348,7 @@ namespace FluentValidation.Internal {
 			return validators;
 		}
 
-		private async Task<List<RuleComponent<T,TElement>>> GetValidatorsToExecuteAsync(ValidationContext<T> context, CancellationToken cancellation) {
+		private async ValueTask<List<RuleComponent<T,TElement>>> GetValidatorsToExecuteAsync(ValidationContext<T> context, CancellationToken cancellation) {
 			// Loop over each validator and check if its condition allows it to run.
 			// This needs to be done prior to the main loop as within a collection rule
 			// validators' conditions still act upon the root object, not upon the collection property.
@@ -374,7 +374,7 @@ namespace FluentValidation.Internal {
 			return validators;
 		}
 
-		private async Task InvokePropertyValidatorAsync(ValidationContext<T> context, TElement value, string propertyName, RuleComponent<T,TElement> component, int index, CancellationToken cancellation) {
+		private async ValueTask InvokePropertyValidatorAsync(ValidationContext<T> context, TElement value, string propertyName, RuleComponent<T,TElement> component, int index, CancellationToken cancellation) {
 			context.MessageFormatter.AppendArgument("CollectionIndex", index);
 			bool valid = await component.ValidateAsync(context, value, cancellation);
 

--- a/src/FluentValidation/Internal/ConditionBuilder.cs
+++ b/src/FluentValidation/Internal/ConditionBuilder.cs
@@ -102,7 +102,7 @@ namespace FluentValidation.Internal {
 		/// <param name="predicate">The asynchronous condition that should apply to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules.</param>
 		/// <returns></returns>
-		public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
+		public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, Action action) {
 			var propertyRules = new List<IValidationRuleInternal<T>>();
 
 			using (_rules.OnItemAdded(propertyRules.Add)) {
@@ -112,7 +112,7 @@ namespace FluentValidation.Internal {
 			// Generate unique ID for this shared condition.
 			var id = "_FV_AsyncCondition_" + Guid.NewGuid();
 
-			async Task<bool> Condition(IValidationContext context, CancellationToken ct) {
+			async ValueTask<bool> Condition(IValidationContext context, CancellationToken ct) {
 				var actualContext = ValidationContext<T>.GetFromNonGenericContext(context);
 
 				if (actualContext.InstanceToValidate != null) {
@@ -149,7 +149,7 @@ namespace FluentValidation.Internal {
 		/// </summary>
 		/// <param name="predicate">The asynchronous condition that should be applied to multiple rules</param>
 		/// <param name="action">Action that encapsulates the rules</param>
-		public IConditionBuilder UnlessAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
+		public IConditionBuilder UnlessAsync(Func<T, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, Action action) {
 			return WhenAsync(async (x, context, ct) => !await predicate(x, context, ct), action);
 		}
 	}
@@ -180,9 +180,9 @@ namespace FluentValidation.Internal {
 
 	internal class AsyncConditionOtherwiseBuilder<T> : IConditionBuilder {
 		private TrackingCollection<IValidationRuleInternal<T>> _rules;
-		private readonly Func<IValidationContext, CancellationToken, Task<bool>> _condition;
+		private readonly Func<IValidationContext, CancellationToken, ValueTask<bool>> _condition;
 
-		public AsyncConditionOtherwiseBuilder(TrackingCollection<IValidationRuleInternal<T>> rules, Func<IValidationContext, CancellationToken, Task<bool>> condition) {
+		public AsyncConditionOtherwiseBuilder(TrackingCollection<IValidationRuleInternal<T>> rules, Func<IValidationContext, CancellationToken, ValueTask<bool>> condition) {
 			_rules = rules;
 			_condition = condition;
 		}

--- a/src/FluentValidation/Internal/IRuleComponent.cs
+++ b/src/FluentValidation/Internal/IRuleComponent.cs
@@ -53,7 +53,7 @@ namespace FluentValidation.Internal {
 		/// Adds a condition for this validator. If there's already a condition, they're combined together with an AND.
 		/// </summary>
 		/// <param name="condition"></param>
-		void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, Task<bool>> condition);
+		void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, ValueTask<bool>> condition);
 
 		/// <summary>
 		/// Sets the overridden error message template for this validator.

--- a/src/FluentValidation/Internal/IncludeRule.cs
+++ b/src/FluentValidation/Internal/IncludeRule.cs
@@ -60,7 +60,7 @@ namespace FluentValidation.Internal {
 			context.RootContextData.Remove(MemberNameValidatorSelector.DisableCascadeKey);
 		}
 
-		public override async Task ValidateAsync(ValidationContext<T> context, CancellationToken cancellation) {
+		public override async ValueTask ValidateAsync(ValidationContext<T> context, CancellationToken cancellation) {
 			context.RootContextData[MemberNameValidatorSelector.DisableCascadeKey] = true;
 			await base.ValidateAsync(context, cancellation);
 			context.RootContextData.Remove(MemberNameValidatorSelector.DisableCascadeKey);

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -157,7 +157,7 @@ namespace FluentValidation.Internal {
 		/// <param name="context">Validation Context</param>
 		/// <param name="cancellation"></param>
 		/// <returns>A collection of validation failures</returns>
-		public virtual async Task ValidateAsync(ValidationContext<T> context, CancellationToken cancellation) {
+		public virtual async ValueTask ValidateAsync(ValidationContext<T> context, CancellationToken cancellation) {
 			if (!context.IsAsync) {
 				context.IsAsync = true;
 			}
@@ -238,7 +238,7 @@ namespace FluentValidation.Internal {
 			}
 		}
 
-		private async Task InvokePropertyValidatorAsync(ValidationContext<T> context, Lazy<TProperty> accessor, string propertyName, RuleComponent<T,TProperty> component, CancellationToken cancellation) {
+		private async ValueTask InvokePropertyValidatorAsync(ValidationContext<T> context, Lazy<TProperty> accessor, string propertyName, RuleComponent<T,TProperty> component, CancellationToken cancellation) {
 			bool valid = await component.ValidateAsync(context, accessor.Value, cancellation);
 
 			if (!valid) {

--- a/src/FluentValidation/Internal/RuleBase.cs
+++ b/src/FluentValidation/Internal/RuleBase.cs
@@ -33,7 +33,7 @@ namespace FluentValidation.Internal {
 		private string _propertyDisplayName;
 		private string _propertyName;
 		private Func<ValidationContext<T>, bool> _condition;
-		private Func<ValidationContext<T>, CancellationToken, Task<bool>> _asyncCondition;
+		private Func<ValidationContext<T>, CancellationToken, ValueTask<bool>> _asyncCondition;
 		private string _displayName;
 		private Func<ValidationContext<T>, string> _displayNameFactory;
 
@@ -50,7 +50,7 @@ namespace FluentValidation.Internal {
 		/// <summary>
 		/// Asynchronous condition for all validators in this rule.
 		/// </summary>
-		internal Func<ValidationContext<T>, CancellationToken, Task<bool>> AsyncCondition => _asyncCondition;
+		internal Func<ValidationContext<T>, CancellationToken, ValueTask<bool>> AsyncCondition => _asyncCondition;
 
 		/// <summary>
 		/// Property associated with this rule.
@@ -249,7 +249,7 @@ namespace FluentValidation.Internal {
 		/// </summary>
 		/// <param name="predicate"></param>
 		/// <param name="applyConditionTo"></param>
-		public void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
+		public void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
 			// Default behaviour for When/Unless as of v1.3 is to apply the condition to all previous validators in the chain.
 			if (applyConditionTo == ApplyConditionTo.AllValidators) {
 				foreach (var validator in _components) {
@@ -277,7 +277,7 @@ namespace FluentValidation.Internal {
 			}
 		}
 
-		public void ApplySharedAsyncCondition(Func<ValidationContext<T>, CancellationToken, Task<bool>> condition) {
+		public void ApplySharedAsyncCondition(Func<ValidationContext<T>, CancellationToken, ValueTask<bool>> condition) {
 			if (_asyncCondition == null) {
 				_asyncCondition = condition;
 			}

--- a/src/FluentValidation/Internal/RuleComponent.cs
+++ b/src/FluentValidation/Internal/RuleComponent.cs
@@ -34,7 +34,7 @@ namespace FluentValidation.Internal {
 		private string _errorMessage;
 		private Func<ValidationContext<T>, TProperty, string> _errorMessageFactory;
 		private Func<ValidationContext<T>, bool> _condition;
-		private Func<ValidationContext<T>, CancellationToken, Task<bool>> _asyncCondition;
+		private Func<ValidationContext<T>, CancellationToken, ValueTask<bool>> _asyncCondition;
 		private readonly IPropertyValidator<T, TProperty> _propertyValidator;
 		private readonly IAsyncPropertyValidator<T, TProperty> _asyncPropertyValidator;
 
@@ -97,7 +97,7 @@ namespace FluentValidation.Internal {
 		internal virtual bool Validate(ValidationContext<T> context, TProperty value)
 			=> _propertyValidator.IsValid(context, value);
 
-		internal virtual Task<bool> ValidateAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation)
+		internal virtual ValueTask<bool> ValidateAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation)
 			=> _asyncPropertyValidator.IsValidAsync(context, value, cancellation);
 
 		/// <summary>
@@ -118,7 +118,7 @@ namespace FluentValidation.Internal {
 		/// Adds a condition for this validator. If there's already a condition, they're combined together with an AND.
 		/// </summary>
 		/// <param name="condition"></param>
-		public void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, Task<bool>> condition) {
+		public void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, ValueTask<bool>> condition) {
 			if (_asyncCondition == null) {
 				_asyncCondition = condition;
 			}
@@ -136,7 +136,7 @@ namespace FluentValidation.Internal {
 			return true;
 		}
 
-		internal async Task<bool> InvokeAsyncCondition(ValidationContext<T> context, CancellationToken token) {
+		internal async ValueTask<bool> InvokeAsyncCondition(ValidationContext<T> context, CancellationToken token) {
 			if (_asyncCondition != null) {
 				return await _asyncCondition(context, token);
 			}

--- a/src/FluentValidation/Internal/RuleComponentForNullableStruct.cs
+++ b/src/FluentValidation/Internal/RuleComponentForNullableStruct.cs
@@ -57,7 +57,7 @@ namespace FluentValidation.Internal {
 			return _propertyValidator.IsValid(context, value.Value);
 		}
 
-		internal override async Task<bool> ValidateAsync(ValidationContext<T> context, TProperty? value, CancellationToken cancellation) {
+		internal override async ValueTask<bool> ValidateAsync(ValidationContext<T> context, TProperty? value, CancellationToken cancellation) {
 			if (!value.HasValue) return true;
 			return await _asyncPropertyValidator.IsValidAsync(context, value.Value, cancellation);
 		}

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -76,7 +76,7 @@ namespace FluentValidation.TestHelper {
 		}
 
 		[Obsolete("This method is deprecated and will be removed in version 11. Use the TestValidateAsync method instead. See https://docs.fluentvalidation.net/en/latest/testing.html")]
-		public static async Task<IEnumerable<ValidationFailure>> ShouldHaveValidationErrorForAsync<T, TValue>(this IValidator<T> validator,
+		public static async ValueTask<IEnumerable<ValidationFailure>> ShouldHaveValidationErrorForAsync<T, TValue>(this IValidator<T> validator,
 			Expression<Func<T, TValue>> expression, TValue value, CancellationToken cancellationToken = default, string ruleSet = null) where T : class, new() {
 			var instanceToValidate = new T();
 
@@ -88,14 +88,14 @@ namespace FluentValidation.TestHelper {
 		}
 
 		[Obsolete("This method is deprecated and will be removed in version 11. Use the TestValidateAsync method instead. See https://docs.fluentvalidation.net/en/latest/testing.html")]
-		public static async Task<IEnumerable<ValidationFailure>> ShouldHaveValidationErrorForAsync<T, TValue>(this IValidator<T> validator, Expression<Func<T, TValue>> expression, T objectToTest, CancellationToken cancellationToken = default, string ruleSet = null) {
+		public static async ValueTask<IEnumerable<ValidationFailure>> ShouldHaveValidationErrorForAsync<T, TValue>(this IValidator<T> validator, Expression<Func<T, TValue>> expression, T objectToTest, CancellationToken cancellationToken = default, string ruleSet = null) {
 			var value = expression.Compile()(objectToTest);
 			var testValidationResult = await validator.TestValidateAsync(objectToTest, cancellationToken, ruleSet);
 			return testValidationResult.ShouldHaveValidationErrorFor(expression);
 		}
 
 		[Obsolete("This method is deprecated and will be removed in version 11. Use the TestValidateAsync method instead. See https://docs.fluentvalidation.net/en/latest/testing.html")]
-		public static async Task ShouldNotHaveValidationErrorForAsync<T, TValue>(this IValidator<T> validator,
+		public static async ValueTask ShouldNotHaveValidationErrorForAsync<T, TValue>(this IValidator<T> validator,
 			Expression<Func<T, TValue>> expression, TValue value, CancellationToken cancellationToken = default, string ruleSet = null) where T : class, new() {
 
 			var instanceToValidate = new T();
@@ -108,7 +108,7 @@ namespace FluentValidation.TestHelper {
 		}
 
 		[Obsolete("This method is deprecated and will be removed in version 11. Use the TestValidateAsync method instead. See https://docs.fluentvalidation.net/en/latest/testing.html")]
-		public static async Task ShouldNotHaveValidationErrorForAsync<T, TValue>(this IValidator<T> validator, Expression<Func<T, TValue>> expression, T objectToTest, CancellationToken cancellationToken = default, string ruleSet = null) {
+		public static async ValueTask ShouldNotHaveValidationErrorForAsync<T, TValue>(this IValidator<T> validator, Expression<Func<T, TValue>> expression, T objectToTest, CancellationToken cancellationToken = default, string ruleSet = null) {
 			var testValidationResult = await validator.TestValidateAsync(objectToTest, cancellationToken, ruleSet);
 			testValidationResult.ShouldNotHaveValidationErrorFor(expression);
 		}
@@ -170,7 +170,7 @@ namespace FluentValidation.TestHelper {
 		}
 
 		[Obsolete("Use the overload that takes an Action<ValidationStrategy> instead, which allows the ruleset to be specified inside the delegate.")]
-		public static async Task<TestValidationResult<T>> TestValidateAsync<T>(this IValidator<T> validator, T objectToTest, CancellationToken cancellationToken, string ruleSet) {
+		public static async ValueTask<TestValidationResult<T>> TestValidateAsync<T>(this IValidator<T> validator, T objectToTest, CancellationToken cancellationToken, string ruleSet) {
 			return await validator.TestValidateAsync(objectToTest, options => {
 				if (ruleSet != null) {
 					options.IncludeRuleSets(RulesetValidatorSelector.LegacyRulesetSplit(ruleSet));
@@ -190,7 +190,7 @@ namespace FluentValidation.TestHelper {
 		/// <summary>
 		/// Performs async validation, returning a TestValidationResult which allows assertions to be performed.
 		/// </summary>
-		public static async Task<TestValidationResult<T>> TestValidateAsync<T>(this IValidator<T> validator, T objectToTest, Action<ValidationStrategy<T>> options = null, CancellationToken cancellationToken = default) {
+		public static async ValueTask<TestValidationResult<T>> TestValidateAsync<T>(this IValidator<T> validator, T objectToTest, Action<ValidationStrategy<T>> options = null, CancellationToken cancellationToken = default) {
 			options ??= _ => { };
 			var validationResult = await validator.ValidateAsync(objectToTest, options, cancellationToken);
 			return new TestValidationResult<T>(validationResult);

--- a/src/FluentValidation/Validators/AsyncPredicateValidator.cs
+++ b/src/FluentValidation/Validators/AsyncPredicateValidator.cs
@@ -27,7 +27,7 @@ namespace FluentValidation.Validators {
 	/// Asynchronous custom validator
 	/// </summary>
 	public class AsyncPredicateValidator<T,TProperty> : AsyncPropertyValidator<T,TProperty> {
-		private readonly Func<T, TProperty, ValidationContext<T>, CancellationToken, Task<bool>> _predicate;
+		private readonly Func<T, TProperty, ValidationContext<T>, CancellationToken, ValueTask<bool>> _predicate;
 
 		public override string Name => "AsyncPredicateValidator";
 
@@ -35,12 +35,12 @@ namespace FluentValidation.Validators {
 		/// Creates a new AsyncPredicateValidator
 		/// </summary>
 		/// <param name="predicate"></param>
-		public AsyncPredicateValidator(Func<T, TProperty, ValidationContext<T>, CancellationToken, Task<bool>> predicate) {
+		public AsyncPredicateValidator(Func<T, TProperty, ValidationContext<T>, CancellationToken, ValueTask<bool>> predicate) {
 			predicate.Guard("A predicate must be specified.", nameof(predicate));
 			this._predicate = predicate;
 		}
 
-		public override Task<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation) {
+		public override ValueTask<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation) {
 			return _predicate(context.InstanceToValidate, value, context, cancellation);
 		}
 

--- a/src/FluentValidation/Validators/AsyncPropertyValidator.cs
+++ b/src/FluentValidation/Validators/AsyncPropertyValidator.cs
@@ -36,7 +36,7 @@ namespace FluentValidation.Validators {
 		protected virtual string GetDefaultMessageTemplate(string errorCode) => "No default error message has been specified";
 
 		/// <inheritdoc />
-		public abstract Task<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation);
+		public abstract ValueTask<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation);
 
 		/// <summary>
 		/// Retrieves a localized string from the LanguageManager.

--- a/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
+++ b/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
@@ -65,7 +65,7 @@ namespace FluentValidation.Validators {
 			return true;
 		}
 
-		public virtual async Task<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation) {
+		public virtual async ValueTask<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation) {
 			if (value == null) {
 				return true;
 			}

--- a/src/FluentValidation/Validators/IPropertyValidator.cs
+++ b/src/FluentValidation/Validators/IPropertyValidator.cs
@@ -32,7 +32,7 @@ namespace FluentValidation.Validators {
 		/// <param name="value">The current property value to validate</param>
 		/// <param name="cancellation">Cancellation token</param>
 		/// <returns>True if valid, otherwise false.</returns>
-		Task<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation);
+		ValueTask<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation);
 	}
 
 	public interface IPropertyValidator<T, in TProperty> : IPropertyValidator {

--- a/src/FluentValidation/Validators/LegacyPropertyValidator.cs
+++ b/src/FluentValidation/Validators/LegacyPropertyValidator.cs
@@ -44,7 +44,7 @@ namespace FluentValidation.Validators {
 			return _inner.IsValidInternal(pvc);
 		}
 
-		public Task<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation) {
+		public ValueTask<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation) {
 			var pvc = new PropertyValidatorContext(context, context.PropertyName, value, () => context.DisplayName);
 			return _inner.IsValidInternalAsync(pvc, cancellation);
 		}
@@ -63,13 +63,13 @@ namespace FluentValidation.Validators {
 		internal bool IsValidInternal(PropertyValidatorContext context)
 			=> IsValid(context);
 
-		internal Task<bool> IsValidInternalAsync(PropertyValidatorContext context, CancellationToken cancellation)
+		internal ValueTask<bool> IsValidInternalAsync(PropertyValidatorContext context, CancellationToken cancellation)
 			=> IsValidAsync(context, cancellation);
 
 		protected abstract bool IsValid(PropertyValidatorContext context);
 
-		protected virtual Task<bool> IsValidAsync(PropertyValidatorContext context, CancellationToken cancellation) {
-			return Task.FromResult(IsValid(context));
+		protected virtual ValueTask<bool> IsValidAsync(PropertyValidatorContext context, CancellationToken cancellation) {
+			return new ValueTask<bool>(Task.FromResult(IsValid(context)));
 		}
 
 		string IPropertyValidator.Name => GetType().Name;


### PR DESCRIPTION
Hi.

I've decided to suggest (via this merge request) switching all `Task` method results (and/or lambdas') into `ValueTask`. As it's said [here](https://blog.marcgravell.com/2019/08/prefer-valuetask-to-task-always-and.html), "always use ValueTask over Task", and however [here](https://devblogs.microsoft.com/dotnet/understanding-the-whys-whats-and-whens-of-valuetask/?ranMID=46131&ranEAID=a1LgFw09t88&ranSiteID=a1LgFw09t88-lqQBDxFLeGtsmfVLPqIecA&epi=a1LgFw09t88-lqQBDxFLeGtsmfVLPqIecA&irgwc=1&OCID=AID2200057_aff_7806_1243925&tduid=%28ir__1k329be3hokf6jneo33yzzo9bn2xt2gr9zx23jp900%29%287806%29%281243925%29%28a1LgFw09t88-lqQBDxFLeGtsmfVLPqIecA%29%28%29&irclickid=_1k329be3hokf6jneo33yzzo9bn2xt2gr9zx23jp900) Stephen Toub suggests only to use ValueTasks "when considered necessary".

I personally consider using ValueTasks in this library for the optimization reasons, but of course it is ultimately up to you to decide whether to accept this request.

Changes done:

1. Removed NETStandard2.0 support (as you have already planned to do, according to #1704).
2. Carefully switched from Task to ValueTask all around the sources. Each change was reviewed manually.

Comments are welcome.  
Thank you.