### PR TITLE
Add execution callbacks

### DIFF
--- a/src/FluentValidation.Tests/OnFailureExtension.cs
+++ b/src/FluentValidation.Tests/OnFailureExtension.cs
@@ -1,0 +1,62 @@
+namespace FluentValidation.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Results;
+
+// These methods replicate the old OnFailure/OnAnyFailure methods
+// that were in FluentValidation versions older than 11.0.
+// These serve as an example of how to re-implement this functionality for users
+// that still want this by using the AfterExecuted callbacks.
+public static class OnFailureExtension {
+
+	public static IRuleBuilderOptions<T, TProperty> OnAnyFailure<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Action<T> onFailure) {
+		return rule.Configure(cfg => {
+			cfg.AfterRuleExecuted = (context, failures) => {
+				if (failures.Any()) {
+					onFailure(context.InstanceToValidate);
+				}
+			};
+		});
+	}
+
+	public static IRuleBuilderOptions<T, TProperty> OnAnyFailure<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Action<T, IEnumerable<ValidationFailure>> onFailure) {
+		return rule.Configure(cfg => {
+			cfg.AfterRuleExecuted = (context, failures) => {
+				if (failures.Any()) {
+					onFailure(context.InstanceToValidate, failures);
+				}
+			};
+		});	}
+
+	public static IRuleBuilderOptions<T, TProperty> OnFailure<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Action<T> onFailure) {
+		return rule.Configure(cfg => {
+			cfg.Current.SetAfterExecuted((context, value, failure) => {
+				if (failure != null) {
+					onFailure(context.InstanceToValidate);
+				}
+			});
+		});
+	}
+
+	public static IRuleBuilderOptions<T, TProperty> OnFailure<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Action<T, ValidationContext<T>, TProperty> onFailure) {
+		return rule.Configure(cfg => {
+			cfg.Current.SetAfterExecuted((context, value, failure) => {
+				if (failure != null) {
+					onFailure(context.InstanceToValidate, context, value);
+				}
+			});
+		});
+	}
+
+	public static IRuleBuilderOptions<T, TProperty> OnFailure<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Action<T, ValidationContext<T>, TProperty, string> onFailure) {
+		return rule.Configure(cfg => {
+			cfg.Current.SetAfterExecuted((context, value, failure) => {
+				if (failure != null) {
+					onFailure(context.InstanceToValidate, context, value, failure.ErrorMessage);
+				}
+			});
+		});
+	}
+}

--- a/src/FluentValidation.Tests/OnFailureTests.cs
+++ b/src/FluentValidation.Tests/OnFailureTests.cs
@@ -1,0 +1,244 @@
+namespace FluentValidation.Tests;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+using TestHelper;
+
+public class OnFailureTests {
+	private TestValidator _validator;
+
+	public OnFailureTests() {
+		_validator = new TestValidator();
+	}
+
+	[Fact]
+	public void OnFailure_called_for_each_failed_rule() {
+		int invoked = 0;
+		_validator.RuleFor(person => person.Surname).NotNull().NotEmpty().OnFailure(person => {
+			invoked += 1;
+		});
+
+		_validator.RuleFor(person => person.Surname).NotEmpty().OnFailure((person, ctx, value) => {
+			Debug.WriteLine(ctx.PropertyName);
+			invoked += 1;
+		});
+
+		_validator.RuleFor(person => person.Forename).NotEqual("John").OnFailure((person, ctx, value) => {
+			invoked += 1;
+		});
+
+		_validator.RuleFor(person => person.Age).GreaterThanOrEqualTo(18).OnFailure((person, ctx, value) => {
+			invoked += 1;
+		});
+
+		_validator.Validate(new Person { Forename = "John", Age = 17 });
+
+		invoked.ShouldEqual(4);
+	}
+
+	[Fact]
+	public async Task OnFailure_called_for_each_failed_rule_asyncAsync() {
+		int invoked = 0;
+		_validator.RuleFor(person => person.Surname).NotNull().NotEmpty().OnFailure(person => {
+			invoked += 1;
+		});
+
+		_validator.RuleFor(person => person.Surname).NotEmpty().OnFailure((person, ctx, value) => {
+			Debug.WriteLine(ctx.PropertyName);
+			invoked += 1;
+		});
+
+		_validator.RuleFor(person => person.Forename).NotEqual("John").OnFailure((person, ctx, value) => {
+			invoked += 1;
+		});
+
+		_validator.RuleFor(person => person.Age).GreaterThanOrEqualTo(18).OnFailure((person, ctx, value) => {
+			invoked += 1;
+		});
+
+		await _validator.ValidateAsync(new Person { Forename = "John", Age = 17 });
+
+		invoked.ShouldEqual(4);
+	}
+
+	[Fact]
+	public void Should_be_able_to_access_error_message_in_OnFailure() {
+		string errorMessage = string.Empty;
+		_validator.RuleFor(person => person.Surname).NotNull().WithMessage("You must specify Surname!").OnFailure((person,ctx, value, message) => {
+			errorMessage = message;
+		});
+
+
+		_validator.Validate(new Person());
+
+		errorMessage.ShouldEqual("You must specify Surname!");
+	}
+
+	[Fact]
+	public void ShouldHaveChildValidator_should_be_true() {
+		_validator.RuleFor(person => person.Address).SetValidator(new AddressValidatorWithOnFailure()).OnFailure((p,ctx, value)=> { Debug.WriteLine(p.Forename); });
+		_validator.ShouldHaveChildValidator(x => x.Address, typeof(AddressValidatorWithOnFailure));
+	}
+
+	[Fact]
+	public void ShouldHaveChildValidator_works_with_Include() {
+		_validator.Include(new InlineValidator<Person>() {
+			v => v.RuleFor(x => x.Forename).NotNull(),
+		});
+
+		_validator.ShouldHaveChildValidator(x => x, typeof(InlineValidator<Person>));
+	}
+
+	[Fact]
+	public void WhenWithOnFailure_should_invoke_condition_on_inner_validator() {
+		bool shouldNotBeTrue = false;
+		var validator = new TestValidator();
+		validator.RuleFor(x => x.Surname)
+			.NotEqual("foo")
+			.When(x => x.Id > 0)
+			.OnFailure(x => shouldNotBeTrue = true);
+
+		var result = validator.Validate(new Person {Id = 0, Surname = "foo"});
+		result.Errors.Count.ShouldEqual(0);
+		shouldNotBeTrue.ShouldBeFalse();
+	}
+
+	[Fact]
+	public async Task WhenAsyncWithOnFailure_should_invoke_condition_on_inner_validator() {
+		bool shouldNotBeTrue = false;
+		var validator = new TestValidator();
+		validator.RuleFor(x => x.Surname)
+			.NotEqual("foo")
+			.WhenAsync((x, token) => Task.FromResult(x.Id > 0))
+			.OnFailure(x => shouldNotBeTrue = true);
+
+		var result = await validator.ValidateAsync(new Person {Id = 0, Surname = "foo"});
+		result.Errors.Count.ShouldEqual(0);
+		shouldNotBeTrue.ShouldBeFalse();
+	}
+
+	[Fact]
+	public async Task WhenWithOnFailure_should_invoke_condition_on_async_inner_validator() {
+		bool shouldNotBeTrue = false;
+		var validator = new TestValidator();
+		validator.RuleFor(x => x.Surname)
+			.MustAsync((x, ctx) => Task.FromResult(false))
+			.When(x => x.Id > 0)
+			.OnFailure(x => shouldNotBeTrue = true);
+
+		var result = await validator.ValidateAsync(new Person {Id = 0, Surname = "foo"});
+		result.Errors.Count.ShouldEqual(0);
+		shouldNotBeTrue.ShouldBeFalse();
+	}
+
+	[Fact]
+	public async Task WhenAsyncWithOnFailure_should_invoke_condition_on_async_inner_validator() {
+		bool shouldNotBeTrue = false;
+		var validator = new TestValidator();
+		validator.RuleFor(x => x.Surname)
+			.MustAsync((x, ctx) => Task.FromResult(false))
+			.WhenAsync((x, ctx) => Task.FromResult(x.Id > 0))
+			.OnFailure(x => shouldNotBeTrue = true);
+
+		var result = await validator.ValidateAsync(new Person {Id = 0, Surname = "foo"});
+		result.Errors.Count.ShouldEqual(0);
+		shouldNotBeTrue.ShouldBeFalse();
+	}
+
+	[Fact]
+	public void Invokes_custom_action_on_failure() {
+		bool invoked = false;
+		_validator.RuleFor(x => x.Surname).NotNull().OnAnyFailure(x => {
+			invoked = true;
+		});
+
+		_validator.Validate(new Person());
+
+		invoked.ShouldBeTrue();
+	}
+
+	[Fact]
+	public async Task Invokes_custom_action_on_failure_async() {
+		bool invoked = false;
+		_validator.RuleFor(x => x.Surname).MustAsync((s, c) => Task.FromResult(s != null)).OnAnyFailure(x => {
+			invoked = true;
+		});
+
+		await _validator.ValidateAsync(new Person());
+
+		invoked.ShouldBeTrue();
+	}
+
+	[Fact]
+	public void Passes_object_being_validated_to_action() {
+		var person = new Person();
+		Person validatedPerson = null;
+
+		_validator.RuleFor(x => x.Surname).NotNull().OnAnyFailure(x => {
+			validatedPerson = x;
+		});
+
+		_validator.Validate(person);
+
+		person.ShouldBeTheSameAs(validatedPerson);
+	}
+
+	[Fact]
+	public void Does_not_invoke_action_if_validation_success() {
+		bool invoked = false;
+		_validator.RuleFor(x => x.Surname).NotNull().OnAnyFailure(x => {
+			invoked=true;
+		});
+		_validator.Validate(new Person() { Surname = "foo" });
+		invoked.ShouldBeFalse();
+	}
+
+	[Fact]
+	public void OnFailure_called_for_each_rule_using_foreach() {
+		int invoked = 0;
+		_validator.RuleForEach(person => person.Children).NotNull().OnFailure(person => {
+			invoked += 1;
+		});
+
+		_validator.Validate(new Person {
+			Children = new List<Person> {
+				new Person(),
+				null,
+				null,
+				new Person()
+			}
+		});
+
+		invoked.ShouldEqual(2);
+	}
+
+	[Fact]
+	public async Task OnFailure_called_for_each_rule_using_foreach_async() {
+		int invoked = 0;
+		_validator.RuleForEach(person => person.Children).MustAsync((x, cancel) => Task.FromResult(x != null)).OnFailure(person => {
+			invoked += 1;
+		});
+
+		await _validator.ValidateAsync(new Person {
+			Children = new List<Person> {
+				new Person(),
+				null,
+				null,
+				new Person()
+			}
+		});
+
+		invoked.ShouldEqual(2);
+	}
+}
+
+public class AddressValidatorWithOnFailure : AbstractValidator<Address> {
+	public AddressValidatorWithOnFailure() {
+		RuleFor(x => x.Postcode).NotNull().OnFailure((address, ctx, value) => {
+			Debug.WriteLine(address.Line1);
+		});
+		RuleFor(x => x.Country).SetValidator(new ComplexValidationTester.CountryValidator());
+	}
+}

--- a/src/FluentValidation/IValidationRule.cs
+++ b/src/FluentValidation/IValidationRule.cs
@@ -106,6 +106,11 @@ namespace FluentValidation {
 		/// <param name="instance">The model from which the property value should be retrieved.</param>
 		/// <returns>The property value.</returns>
 		object GetPropertyValue(T instance);
+
+		/// <summary>
+		/// Callback invoked after a rule is executed.
+		/// </summary>
+		public Action<ValidationContext<T>, IEnumerable<ValidationFailure>> AfterRuleExecuted { get; set; }
 	}
 
 	/// <summary>

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -182,6 +182,11 @@ namespace FluentValidation.Internal {
 
 			AfterValidate:
 
+			if (AfterRuleExecuted != null) {
+				var failuresThisRound = context.Failures.Skip(totalFailures).ToList();
+				AfterRuleExecuted(context, failuresThisRound);
+			}
+
 			if (context.Failures.Count <= totalFailures && DependentRules != null) {
 				foreach (var dependentRule in DependentRules) {
 					dependentRule.Validate(context);
@@ -289,6 +294,11 @@ namespace FluentValidation.Internal {
 
 			AfterValidate:
 
+			if (AfterRuleExecuted != null) {
+				var failuresThisRound = context.Failures.Skip(totalFailures).ToList();
+				AfterRuleExecuted(context, failuresThisRound);
+			}
+
 			if (context.Failures.Count <= totalFailures && DependentRules != null) {
 				foreach (var dependentRule in DependentRules) {
 					cancellation.ThrowIfCancellationRequested();
@@ -360,6 +370,10 @@ namespace FluentValidation.Internal {
 				PrepareMessageFormatterForValidationError(context, value);
 				var failure = CreateValidationError(context, value, component);
 				context.Failures.Add(failure);
+				component.AfterExecuted?.Invoke(context, value, failure);
+			}
+			else {
+				component.AfterExecuted?.Invoke(context, value, null);
 			}
 		}
 
@@ -371,6 +385,10 @@ namespace FluentValidation.Internal {
 				PrepareMessageFormatterForValidationError(context, value);
 				var failure = CreateValidationError(context, value, component);
 				context.Failures.Add(failure);
+				component.AfterExecuted?.Invoke(context, value, failure);
+			}
+			else {
+				component.AfterExecuted?.Invoke(context, value, null);
 			}
 		}
 

--- a/src/FluentValidation/Internal/IRuleComponent.cs
+++ b/src/FluentValidation/Internal/IRuleComponent.cs
@@ -22,6 +22,7 @@ namespace FluentValidation.Internal {
 	using System;
 	using System.Threading;
 	using System.Threading.Tasks;
+	using Results;
 	using Validators;
 
 	/// <summary>
@@ -66,6 +67,14 @@ namespace FluentValidation.Internal {
 		/// </summary>
 		/// <param name="errorMessage">The error message to set</param>
 		void SetErrorMessage(string errorMessage);
+
+		/// <summary>
+		/// Sets a callback which will be invoked after this component has executed.
+		/// Arguments are the context, the property value and the validation failure which was generated.
+		/// The validation failure will be null if validation succeeded.
+		/// </summary>
+		/// <param name="callback"></param>
+		void SetAfterExecuted(Action<ValidationContext<T>, TProperty, ValidationFailure> callback);
 	}
 
 	/// <summary>

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -19,6 +19,8 @@
 namespace FluentValidation.Internal {
 	using System;
 	using System.Collections.Generic;
+	using System.Globalization;
+	using System.Linq;
 	using System.Linq.Expressions;
 	using System.Reflection;
 	using System.Threading;
@@ -131,6 +133,11 @@ namespace FluentValidation.Internal {
 				}
 			}
 
+			if (AfterRuleExecuted != null) {
+				var failuresThisRound = context.Failures.Skip(totalFailures).ToList();
+				AfterRuleExecuted(context, failuresThisRound);
+			}
+
 			if (context.Failures.Count <= totalFailures && DependentRules != null) {
 				foreach (var dependentRule in DependentRules) {
 					dependentRule.Validate(context);
@@ -209,6 +216,11 @@ namespace FluentValidation.Internal {
 				}
 			}
 
+			if (AfterRuleExecuted != null) {
+				var failuresThisRound = context.Failures.Skip(totalFailures).ToList();
+				AfterRuleExecuted(context, failuresThisRound);
+			}
+
 			if (context.Failures.Count <= totalFailures && DependentRules != null) {
 				foreach (var dependentRule in DependentRules) {
 					cancellation.ThrowIfCancellationRequested();
@@ -224,6 +236,10 @@ namespace FluentValidation.Internal {
 				PrepareMessageFormatterForValidationError(context, accessor.Value);
 				var failure = CreateValidationError(context, accessor.Value, component);
 				context.Failures.Add(failure);
+				component.AfterExecuted?.Invoke(context, accessor.Value, failure);
+			}
+			else {
+				component.AfterExecuted?.Invoke(context, accessor.Value, null);
 			}
 		}
 
@@ -234,6 +250,10 @@ namespace FluentValidation.Internal {
 				PrepareMessageFormatterForValidationError(context, accessor.Value);
 				var failure = CreateValidationError(context, accessor.Value, component);
 				context.Failures.Add(failure);
+				component.AfterExecuted?.Invoke(context, accessor.Value, failure);
+			}
+			else {
+				component.AfterExecuted?.Invoke(context, accessor.Value, null);
 			}
 		}
 

--- a/src/FluentValidation/Internal/RuleBase.cs
+++ b/src/FluentValidation/Internal/RuleBase.cs
@@ -200,6 +200,8 @@ namespace FluentValidation.Internal {
 
 		IEnumerable<IValidationRule> IValidationRule.DependentRules => DependentRules;
 
+		public Action<ValidationContext<T>, IEnumerable<ValidationFailure>> AfterRuleExecuted { get; set; }
+
 		string IValidationRule.GetDisplayName(IValidationContext context) =>
 			GetDisplayName(context != null ? ValidationContext<T>.GetFromNonGenericContext(context) : null);
 

--- a/src/FluentValidation/Internal/RuleComponent.cs
+++ b/src/FluentValidation/Internal/RuleComponent.cs
@@ -23,6 +23,7 @@ namespace FluentValidation.Internal {
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Internal;
+	using Results;
 	using Validators;
 
 	/// <summary>
@@ -46,6 +47,8 @@ namespace FluentValidation.Internal {
 			_asyncPropertyValidator = asyncPropertyValidator;
 			_propertyValidator = propertyValidator;
 		}
+
+		internal Action<ValidationContext<T>, TProperty, ValidationFailure> AfterExecuted { get; private set; }
 
 		/// <inheritdoc />
 		public bool HasCondition => _condition != null;
@@ -205,6 +208,12 @@ namespace FluentValidation.Internal {
 		public void SetErrorMessage(string errorMessage) {
 			_errorMessage = errorMessage;
 			_errorMessageFactory = null;
+		}
+
+		/// <inheritdoc />
+		public void SetAfterExecuted(Action<ValidationContext<T>, TProperty, ValidationFailure> callback) {
+			if (callback == null) throw new ArgumentNullException(nameof(callback));
+			AfterExecuted = callback;
 		}
 	}
 


### PR DESCRIPTION
Adds post-execution callbacks at both the component level and rule level.

These callbacks can be used to re-implement the OnFailure/OnAnyFailure callbacks which were deprecated in 10.x and removed in 11.0. For users that still need this behaviour, they can re-implement them by building them on top of these callbacks. 