### PR TITLE
Fix assertions Without*** when there are multiple failures (#1937)

### DIFF
--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -486,8 +486,23 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void Expected_with_error_code_check() {
+		public void Unexpected_with_error_message_check() {
 			//#1937
+			var validator = new InlineValidator<Person>
+			{
+				v => v.RuleFor(x => x.Forename).NotEmpty(),
+				v => v.RuleFor(x => x.Surname).NotEmpty()
+			};
+
+			var ex = Assert.Throws<ValidationTestException>(() =>
+				validator.TestValidate(new Person())
+					.ShouldHaveValidationErrorFor(x => x.Surname)
+					.WithErrorMessage("bar"));
+			ex.Message.ShouldEqual("Expected an error message of 'bar'. Actual message was ''Surname' must not be empty.'");
+		}
+
+		[Fact]
+		public void Expected_with_error_code_check() {
 			var validator = new InlineValidator<Person> {
 				v => v.RuleFor(x => x.Forename).NotNull(),
 				v => v.RuleFor(x => x.Surname).NotNull()

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -470,6 +470,22 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
+		public void Unexpected_without_error_code_check() {
+			//#1937
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Surname).NotNull(),
+				v => v.RuleFor(x => x.Forename).NotNull()
+			};
+
+			validator.TestValidate(new Person())
+				.ShouldHaveValidationErrorFor(x => x.Surname)
+				.WithoutErrorCode("foo")
+				.WithoutErrorMessage("bar")
+				.WithoutSeverity(Severity.Warning)
+				.WithoutCustomState(1);
+		}
+
+		[Fact]
 		public void Expected_severity_check() {
 			var validator = new InlineValidator<Person> {
 				v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Warning)

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -470,7 +470,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void Unexpected_without_error_code_check() {
+		public void Expected_without_error_code_check() {
 			//#1937
 			var validator = new InlineValidator<Person> {
 				v => v.RuleFor(x => x.Surname).NotNull(),
@@ -483,6 +483,26 @@ namespace FluentValidation.Tests {
 				.WithoutErrorMessage("bar")
 				.WithoutSeverity(Severity.Warning)
 				.WithoutCustomState(1);
+		}
+
+		[Fact]
+		public void Expected_with_error_code_check() {
+			//#1937
+			var validator = new InlineValidator<Person> {
+				v => v.RuleFor(x => x.Forename).NotNull(),
+				v => v.RuleFor(x => x.Surname).NotNull()
+					.WithErrorCode("foo")
+					.WithMessage("bar")
+					.WithSeverity(Severity.Warning)
+					.WithState(_ => 1)
+			};
+
+			validator.TestValidate(new Person())
+				.ShouldHaveValidationErrorFor(x => x.Surname)
+				.WithErrorCode("foo")
+				.WithErrorMessage("bar")
+				.WithSeverity(Severity.Warning)
+				.WithCustomState(1);
 		}
 
 		[Fact]

--- a/src/FluentValidation/TestHelper/ITestValidationContinuation.cs
+++ b/src/FluentValidation/TestHelper/ITestValidationContinuation.cs
@@ -9,7 +9,6 @@ namespace FluentValidation.TestHelper {
 	}
 
 	public interface ITestValidationContinuation : IEnumerable<ValidationFailure> {
-		IEnumerable<ValidationFailure> MatchedFailures { get; }
 		IEnumerable<ValidationFailure> UnmatchedFailures { get; }
 	}
 

--- a/src/FluentValidation/TestHelper/ITestValidationContinuation.cs
+++ b/src/FluentValidation/TestHelper/ITestValidationContinuation.cs
@@ -9,6 +9,7 @@ namespace FluentValidation.TestHelper {
 	}
 
 	public interface ITestValidationContinuation : IEnumerable<ValidationFailure> {
+		IEnumerable<ValidationFailure> MatchedFailures { get; }
 		IEnumerable<ValidationFailure> UnmatchedFailures { get; }
 	}
 

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -198,7 +198,7 @@ namespace FluentValidation.TestHelper {
 		}
 
 		public static ITestValidationContinuation WhenAll(this ITestValidationContinuation failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null) {
-			var result = TestValidationContinuation.Create(failures.MatchedFailures);
+			var result = TestValidationContinuation.Create(((TestValidationContinuation)failures).MatchedFailures);
 			result.ApplyPredicate(failurePredicate);
 
 			bool allMatched = !result.UnmatchedFailures.Any();

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -198,7 +198,7 @@ namespace FluentValidation.TestHelper {
 		}
 
 		public static ITestValidationContinuation WhenAll(this ITestValidationContinuation failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null) {
-			var result = TestValidationContinuation.Create(failures);
+			var result = TestValidationContinuation.Create(failures.MatchedFailures);
 			result.ApplyPredicate(failurePredicate);
 
 			bool allMatched = !result.UnmatchedFailures.Any();

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -184,7 +184,7 @@ namespace FluentValidation.TestHelper {
 		}
 
 		public static ITestValidationWith When(this ITestValidationContinuation failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null) {
-			var result = TestValidationContinuation.Create(failures);
+			var result = TestValidationContinuation.Create(((TestValidationContinuation)failures).MatchedFailures);
 			result.ApplyPredicate(failurePredicate);
 
 			var anyMatched = result.Any();


### PR DESCRIPTION
For assertions in a form of `Without***` we need to use only failures that are matching to previously applied predicates (such as property name). Otherwise, we are treating failures for other properties as violating current assertion.

Example:

* Failure 1: `Name must not be empty`
* Failure 2: `Surname must not be empty`

`results.ShouldHaveValidationErrorFor(x => x.Surname)` has Failure 1 in `UnmatchingFailures` and Failure 2 in `MatchingFailures`. If we then add a predicate `.WithoutErrorCode("foo")` and apply it to all failures (as we did before), then Failure 1 will be considered a violation. In this PR we change `WhenAll` to only consider `MatchingFailures` - and Failure 1 does not have effect.

Similar logic applies to `With***` assertions: when they are multiple failing rules and one of the expectations was not met (for ex., `WithMessage` specifies a wrong text) we should be using `MatchingFailures` to correctly display a validation messsage.

Fixes #1937