### PR TITLE
Restore linking between chaildren and parent contexts

### DIFF
--- a/src/FluentValidation/IValidationContext.cs
+++ b/src/FluentValidation/IValidationContext.cs
@@ -238,7 +238,6 @@ namespace FluentValidation {
 		/// Creates a new validation context for use with a child validator
 		/// </summary>
 		/// <param name="instanceToValidate"></param>
-		/// <param name="preserveParentContext"></param>
 		/// <param name="selector"></param>
 		/// <returns></returns>
 		public ValidationContext<TChild> CloneForChildValidator<TChild>(TChild instanceToValidate, IValidatorSelector selector = null) {

--- a/src/FluentValidation/IValidationContext.cs
+++ b/src/FluentValidation/IValidationContext.cs
@@ -238,13 +238,14 @@ namespace FluentValidation {
 		/// Creates a new validation context for use with a child validator
 		/// </summary>
 		/// <param name="instanceToValidate"></param>
+		/// <param name="preserveParentContext"></param>
 		/// <param name="selector"></param>
 		/// <returns></returns>
-		public ValidationContext<TChild> CloneForChildValidator<TChild>(TChild instanceToValidate, IValidatorSelector selector = null) {
+		public ValidationContext<TChild> CloneForChildValidator<TChild>(TChild instanceToValidate, bool preserveParentContext = false, IValidatorSelector selector = null) {
 			return new ValidationContext<TChild>(instanceToValidate, PropertyChain, selector ?? Selector, Failures, MessageFormatter) {
 				IsChildContext = true,
 				RootContextData = RootContextData,
-				_parentContext = this,
+				_parentContext = preserveParentContext ? this : null,
 				IsAsync = IsAsync,
 			};
 		}

--- a/src/FluentValidation/IValidationContext.cs
+++ b/src/FluentValidation/IValidationContext.cs
@@ -241,11 +241,11 @@ namespace FluentValidation {
 		/// <param name="preserveParentContext"></param>
 		/// <param name="selector"></param>
 		/// <returns></returns>
-		public ValidationContext<TChild> CloneForChildValidator<TChild>(TChild instanceToValidate, bool preserveParentContext = false, IValidatorSelector selector = null) {
+		public ValidationContext<TChild> CloneForChildValidator<TChild>(TChild instanceToValidate, IValidatorSelector selector = null) {
 			return new ValidationContext<TChild>(instanceToValidate, PropertyChain, selector ?? Selector, Failures, MessageFormatter) {
 				IsChildContext = true,
 				RootContextData = RootContextData,
-				_parentContext = preserveParentContext ? this : null,
+				_parentContext = this,
 				IsAsync = IsAsync,
 			};
 		}

--- a/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
+++ b/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
@@ -97,7 +97,7 @@ namespace FluentValidation.Validators {
 
 		protected virtual IValidationContext CreateNewValidationContextForChildValidator(ValidationContext<T> context, TProperty value) {
 			var selector = GetSelector(context, value);
-			var newContext = context.CloneForChildValidator(value, selector);
+			var newContext = context.CloneForChildValidator(value, true, selector);
 
 			if(!context.IsChildCollectionContext)
 				newContext.PropertyChain.Add(context.RawPropertyName);

--- a/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
+++ b/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
@@ -27,8 +27,6 @@ namespace FluentValidation.Validators {
 
 		public string[] RuleSets { get; set; }
 
-		internal bool PassThroughParentContext { get; set; }
-
 		public ChildValidatorAdaptor(IValidator<TProperty> validator, Type validatorType) {
 			_validator = validator;
 			ValidatorType = validatorType;
@@ -99,7 +97,7 @@ namespace FluentValidation.Validators {
 
 		protected virtual IValidationContext CreateNewValidationContextForChildValidator(ValidationContext<T> context, TProperty value) {
 			var selector = GetSelector(context, value);
-			var newContext = context.CloneForChildValidator(value, PassThroughParentContext, selector);
+			var newContext = context.CloneForChildValidator(value, selector);
 
 			if(!context.IsChildCollectionContext)
 				newContext.PropertyChain.Add(context.RawPropertyName);


### PR DESCRIPTION
Hi

As I told you in #1942 it would be nice to just restore the link between parent context and children contexts. This will allow to creation of custom root contexts and traverse to root from any child validator. Otherwise, the existence of ParentContext property is just senseless.
As you said it's a volunteer project, so I trying to help you with MR. :)
I removed the obsolete boolean property and change the code to propagate _parent value by default.