### PR TITLE
Support deserialization with System.Text.Json (#1928)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,6 @@
 11.0.2 - 27 May 2022
 Child validator contexts should contain a reference to their parent context (#1945)
+Support deserialization of ValidationResult using System.Text.Json (#1928)
 
 11.0.1 - 7 May 2022
 Fix regression in the Test Helper affecting the With* and Without* assertion methods (#1937)

--- a/src/FluentValidation.Tests/JsonSerializationTests.cs
+++ b/src/FluentValidation.Tests/JsonSerializationTests.cs
@@ -1,0 +1,51 @@
+namespace FluentValidation.Tests;
+
+using System.Text.Json;
+using Results;
+using Xunit;
+
+public class JsonSerializationTests {
+
+	[Fact]
+	public void SystemTextJson_deserialization_should_be_consistent_with_newtonsoft() {
+		var validationResult = new ValidationResult {
+			Errors = {
+				new ValidationFailure("MyProperty1", "Invalid MyProperty1"),
+				new ValidationFailure("MyProperty2", "Invalid MyProperty2"),
+			},
+			RuleSetsExecuted = new[] { "Test1" }
+		};
+
+		// System.Text.Json
+		var serialized1 = JsonSerializer.Serialize(validationResult);
+		var deserialized1 = JsonSerializer.Deserialize<ValidationResult>(serialized1);
+
+		// Newtonsoft.Json
+		var serialized2 = Newtonsoft.Json.JsonConvert.SerializeObject(validationResult);
+		var deserialized2 = Newtonsoft.Json.JsonConvert.DeserializeObject<ValidationResult>(serialized2);
+
+		deserialized1.IsValid.ShouldBeFalse();
+		deserialized2.IsValid.ShouldBeFalse();
+
+		deserialized1.Errors.Count.ShouldEqual(2);
+		deserialized2.Errors.Count.ShouldEqual(2);
+
+		deserialized1.Errors[0].PropertyName.ShouldEqual("MyProperty1");
+		deserialized2.Errors[0].PropertyName.ShouldEqual("MyProperty1");
+
+		deserialized1.Errors[1].PropertyName.ShouldEqual("MyProperty2");
+		deserialized2.Errors[1].PropertyName.ShouldEqual("MyProperty2");
+
+		deserialized1.Errors[0].ErrorMessage.ShouldEqual("Invalid MyProperty1");
+		deserialized2.Errors[0].ErrorMessage.ShouldEqual("Invalid MyProperty1");
+
+		deserialized1.Errors[1].ErrorMessage.ShouldEqual("Invalid MyProperty2");
+		deserialized2.Errors[1].ErrorMessage.ShouldEqual("Invalid MyProperty2");
+
+		deserialized1.RuleSetsExecuted.Length.ShouldEqual(1);
+		deserialized2.RuleSetsExecuted.Length.ShouldEqual(1);
+
+		deserialized1.RuleSetsExecuted[0].ShouldEqual("Test1");
+		deserialized2.RuleSetsExecuted[0].ShouldEqual("Test1");
+	}
+}

--- a/src/FluentValidation/Results/ValidationFailure.cs
+++ b/src/FluentValidation/Results/ValidationFailure.cs
@@ -25,7 +25,11 @@ namespace FluentValidation.Results {
 	/// </summary>
 	[Serializable]
 	public class ValidationFailure {
-		private ValidationFailure() {
+
+		/// <summary>
+		/// Creates a new validation failure.
+		/// </summary>
+		public ValidationFailure() {
 
 		}
 
@@ -33,6 +37,7 @@ namespace FluentValidation.Results {
 		/// Creates a new validation failure.
 		/// </summary>
 		public ValidationFailure(string propertyName, string errorMessage) : this(propertyName, errorMessage, null) {
+
 		}
 
 		/// <summary>

--- a/src/FluentValidation/Results/ValidationResult.cs
+++ b/src/FluentValidation/Results/ValidationResult.cs
@@ -26,7 +26,7 @@ namespace FluentValidation.Results {
 	/// </summary>
 	[Serializable]
 	public class ValidationResult {
-		private readonly List<ValidationFailure> _errors;
+		private List<ValidationFailure> _errors;
 
 		/// <summary>
 		/// Whether validation succeeded
@@ -36,9 +36,23 @@ namespace FluentValidation.Results {
 		/// <summary>
 		/// A collection of errors
 		/// </summary>
-		public List<ValidationFailure> Errors => _errors;
+		public List<ValidationFailure> Errors {
+			get => _errors;
+			set {
+				if (value == null) {
+					throw new ArgumentNullException(nameof(value));
+				}
 
-		public string[] RuleSetsExecuted { get; internal set; }
+				// Ensure any nulls are removed and the list is copied
+				// to be consistent with the constructor below.
+				_errors = value.Where(failure => failure != null).ToList();;
+			}
+		}
+
+		/// <summary>
+		/// The RuleSets that were executed during the validation run.
+		/// </summary>
+		public string[] RuleSetsExecuted { get; set; }
 
 		/// <summary>
 		/// Creates a new validationResult
@@ -50,9 +64,10 @@ namespace FluentValidation.Results {
 		/// <summary>
 		/// Creates a new ValidationResult from a collection of failures
 		/// </summary>
-		/// <param name="failures">List of <see cref="ValidationFailure"/> which is later available through <see cref="Errors"/>. This list get's copied.</param>
+		/// <param name="failures">Collection of <see cref="ValidationFailure"/> instances which is later available through the <see cref="Errors"/> property.</param>
 		/// <remarks>
-		/// Every caller is responsible for not adding <c>null</c> to the list.
+		/// Any nulls will be excluded.
+		/// The list is copied.
 		/// </remarks>
 		public ValidationResult(IEnumerable<ValidationFailure> failures) {
 			_errors = failures.Where(failure => failure != null).ToList();
@@ -76,7 +91,7 @@ namespace FluentValidation.Results {
 		/// <param name="separator">The character to separate the error messages.</param>
 		/// <returns></returns>
 		public string ToString(string separator) {
-			return	string.Join(separator, _errors.Select(failure => failure.ErrorMessage));
+			return string.Join(separator, _errors.Select(failure => failure.ErrorMessage));
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1928 

- Adds public constructor to `ValidationFailure`
- Adds setter to `ValidationResult.Errors`
  - Setter creates a copy of the list and removes nulls for consistency with the existing public constructor
- Makes the `ValidationResult.RuleSetsExecuted` setter public
- Minor cleanup to a few doc comments.
- Adds tests (ported from #1935 with some modifications)
