### PR TITLE
Switch to using ValueTask for internal rule execution, and remove duplicated sync/async code path.

### DIFF
--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -202,7 +202,7 @@ namespace FluentValidation {
 				return completedValueTask.GetAwaiter().GetResult();
 			}
 			catch (AsyncValidatorInvokedSynchronouslyException) {
-				// If we tempted to execute an async validator, re-create the exception with more useful info.
+				// If we attempted to execute an async validator, re-create the exception with more useful info.
 				bool wasInvokedByMvc = context.RootContextData.ContainsKey("InvokedByMvc");
 				throw new AsyncValidatorInvokedSynchronouslyException(GetType(), wasInvokedByMvc);
 			}

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -25,4 +25,7 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
 </Project>

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -26,6 +26,6 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/src/FluentValidation/IValidationRuleInternal.cs
+++ b/src/FluentValidation/IValidationRuleInternal.cs
@@ -23,9 +23,7 @@ namespace FluentValidation {
 	using Internal;
 
 	internal interface IValidationRuleInternal<T> : IValidationRule<T> {
-		void Validate(ValidationContext<T> context);
-
-		Task ValidateAsync(ValidationContext<T> context, CancellationToken cancellation);
+		ValueTask ValidateAsync(ValidationContext<T> context, bool allowAsyncComponents, CancellationToken cancellation);
 
 		void AddDependentRules(IEnumerable<IValidationRuleInternal<T>> rules);
 	}

--- a/src/FluentValidation/IValidationRuleInternal.cs
+++ b/src/FluentValidation/IValidationRuleInternal.cs
@@ -23,7 +23,7 @@ namespace FluentValidation {
 	using Internal;
 
 	internal interface IValidationRuleInternal<T> : IValidationRule<T> {
-		ValueTask ValidateAsync(ValidationContext<T> context, bool allowAsyncComponents, CancellationToken cancellation);
+		ValueTask ValidateAsync(ValidationContext<T> context, bool useAsync, CancellationToken cancellation);
 
 		void AddDependentRules(IEnumerable<IValidationRuleInternal<T>> rules);
 	}

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -171,20 +171,7 @@ namespace FluentValidation.Internal {
 						context.MessageFormatter.Reset();
 						context.MessageFormatter.AppendArgument("CollectionIndex", index);
 
-						bool valid;
-
-						if (component.ShouldValidateAsynchronously(context)) {
-							if (useAsync) {
-								valid = await component.ValidateAsync(context, valueToValidate, cancellation);
-							}
-							else {
-								throw new AsyncValidatorInvokedSynchronouslyException();
-							}
-						}
-						else {
-							context.MessageFormatter.AppendArgument("CollectionIndex", index);
-							valid = component.Validate(context, valueToValidate);
-						}
+						bool valid = await component.ValidateAsync(context, valueToValidate, useAsync, cancellation);
 
 						if (!valid) {
 							PrepareMessageFormatterForValidationError(context, valueToValidate);

--- a/src/FluentValidation/Internal/IncludeRule.cs
+++ b/src/FluentValidation/Internal/IncludeRule.cs
@@ -51,9 +51,9 @@ namespace FluentValidation.Internal {
 			return new IncludeRule<T>((ctx, _) => func(ctx.InstanceToValidate), cascadeModeThunk, typeof(T), typeof(TValidator));
 		}
 
-		public override async ValueTask ValidateAsync(ValidationContext<T> context, bool allowAsyncComponents, CancellationToken cancellation) {
+		public override async ValueTask ValidateAsync(ValidationContext<T> context, bool useAsync, CancellationToken cancellation) {
 			context.RootContextData[MemberNameValidatorSelector.DisableCascadeKey] = true;
-			await base.ValidateAsync(context, allowAsyncComponents, cancellation);
+			await base.ValidateAsync(context, useAsync, cancellation);
 			context.RootContextData.Remove(MemberNameValidatorSelector.DisableCascadeKey);
 		}
 	}

--- a/src/FluentValidation/Internal/IncludeRule.cs
+++ b/src/FluentValidation/Internal/IncludeRule.cs
@@ -51,15 +51,9 @@ namespace FluentValidation.Internal {
 			return new IncludeRule<T>((ctx, _) => func(ctx.InstanceToValidate), cascadeModeThunk, typeof(T), typeof(TValidator));
 		}
 
-		public override void Validate(ValidationContext<T> context) {
+		public override async ValueTask ValidateAsync(ValidationContext<T> context, bool allowAsyncComponents, CancellationToken cancellation) {
 			context.RootContextData[MemberNameValidatorSelector.DisableCascadeKey] = true;
-			base.Validate(context);
-			context.RootContextData.Remove(MemberNameValidatorSelector.DisableCascadeKey);
-		}
-
-		public override async Task ValidateAsync(ValidationContext<T> context, CancellationToken cancellation) {
-			context.RootContextData[MemberNameValidatorSelector.DisableCascadeKey] = true;
-			await base.ValidateAsync(context, cancellation);
+			await base.ValidateAsync(context, allowAsyncComponents, cancellation);
 			context.RootContextData.Remove(MemberNameValidatorSelector.DisableCascadeKey);
 		}
 	}

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -139,16 +139,7 @@ namespace FluentValidation.Internal {
 					}
 				}
 
-				bool valid;
-
-				if (component.ShouldValidateAsynchronously(context)) {
-					valid = useAsync
-						? await component.ValidateAsync(context, accessor.Value, cancellation)
-						: throw new AsyncValidatorInvokedSynchronouslyException();
-				}
-				else {
-					valid = component.Validate(context, accessor.Value);
-				}
+				bool valid = await component.ValidateAsync(context, accessor.Value, useAsync, cancellation);
 
 				if (!valid) {
 					PrepareMessageFormatterForValidationError(context, accessor.Value);

--- a/src/FluentValidation/Internal/RuleComponent.cs
+++ b/src/FluentValidation/Internal/RuleComponent.cs
@@ -22,7 +22,6 @@ namespace FluentValidation.Internal {
 	using System;
 	using System.Threading;
 	using System.Threading.Tasks;
-	using Internal;
 	using Validators;
 
 	/// <summary>
@@ -63,32 +62,35 @@ namespace FluentValidation.Internal {
 		private protected virtual bool SupportsSynchronousValidation
 			=> _propertyValidator != null;
 
-		internal bool ShouldValidateAsynchronously(IValidationContext context) {
-			// If ValidateAsync has been invoked on the root validator, then always prefer
-			// the asynchronous property validator (if available).
-			if (context.IsAsync) {
+		internal async ValueTask<bool> ValidateAsync(ValidationContext<T> context, TProperty value, bool useAsync, CancellationToken cancellation) {
+			if (useAsync) {
+				// If ValidateAsync has been called on the root validator, then always prefer
+				// the asynchronous property validator (if available).
 				if (SupportsAsynchronousValidation) {
-					return true;
+					return await InvokePropertyValidatorAsync(context, value, cancellation);
 				}
 
-				// Fallback to sync if no async validator available.
-				return false;
+				// If it doesn't support Async validation, then this means
+				// the property validator is a Synchronous.
+				// We don't need to explicitly check SupportsSynchronousValidation.
+				return InvokePropertyValidator(context, value);
 			}
 
-			// If Validate has been invoked on the root validator, then always prefer
-			// the synchronous validator.
+			// If Validate has been called on the root validator, then always prefer
+			// the synchronous property validator.
 			if (SupportsSynchronousValidation) {
-				return false;
+				return InvokePropertyValidator(context, value);
 			}
 
-			// Fall back to sync-over-async if only an async validator is available.
-			return true;
+			// Root Validator invoked synchronously, but the property validator
+			// only supports asynchronous invocation.
+			throw new AsyncValidatorInvokedSynchronouslyException();
 		}
 
-		internal virtual bool Validate(ValidationContext<T> context, TProperty value)
+		private protected virtual bool InvokePropertyValidator(ValidationContext<T> context, TProperty value)
 			=> _propertyValidator.IsValid(context, value);
 
-		internal virtual Task<bool> ValidateAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation)
+		private protected virtual Task<bool> InvokePropertyValidatorAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation)
 			=> _asyncPropertyValidator.IsValidAsync(context, value, cancellation);
 
 		/// <summary>

--- a/src/FluentValidation/Internal/RuleComponentForNullableStruct.cs
+++ b/src/FluentValidation/Internal/RuleComponentForNullableStruct.cs
@@ -46,12 +46,12 @@ namespace FluentValidation.Internal {
 		private protected override bool SupportsSynchronousValidation
 			=> _propertyValidator != null;
 
-		internal override bool Validate(ValidationContext<T> context, TProperty? value) {
+		private protected override bool InvokePropertyValidator(ValidationContext<T> context, TProperty? value) {
 			if (!value.HasValue) return true;
 			return _propertyValidator.IsValid(context, value.Value);
 		}
 
-		internal override async Task<bool> ValidateAsync(ValidationContext<T> context, TProperty? value, CancellationToken cancellation) {
+		private protected override async Task<bool> InvokePropertyValidatorAsync(ValidationContext<T> context, TProperty? value, CancellationToken cancellation) {
 			if (!value.HasValue) return true;
 			return await _asyncPropertyValidator.IsValidAsync(context, value.Value, cancellation);
 		}


### PR DESCRIPTION
- Internal rule execution now uses `ValueTask` instead of `Task`
- Removed the internal rule/component `Validate` overloads
- Adds `useAsync` parameter to internal rule `ValidateAsync` overloads
- No changes to public API surface.
- This approach is [used internally by the .NET team](https://github.com/dotnet/runtime/blob/fae7ee8e7e3aa7f86836318a10ed676641e813ad/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoStream.cs#L119)


`AbstractValidator.Validate` (non-async) now calls the `ValidateAsync` methods on the rules internally. Typically sync-over-async is a bad idea and leads to deadlocks, but by introducing the `useAsync` parameter we are essentially assuring that no actual async code will be executed. This also preserves the existing behaviour (exception is thrown when attempting to execute async rules synchronously).

There is a performance impact for taking this approach, but it's incredibly minor and I think it may be worth it as it drastically simplifies the codebase and removes a lot of duplication. 

This does not introduce any breaking changes to the public api surface, but as it's a major internal refactoring so it may be better to wait until a major release (12.0) 