### PR TITLE
.NET 7 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          7.0.100-rc.1.22431.12
+          6.0.x
 
     - name: Build and Test
       run: ./build.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: |
-          7.0.x
+          7.0.100
           6.0.x
 
     - name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: |
-          7.0.100-rc.1.22431.12
+          7.0.100-rc.2.22477.23
           6.0.x
 
     - name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: |
-          7.0.100-rc.2.22477.23
+          7.0.100
           6.0.x
 
     - name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: |
-          7.0.100
+          7.0.x
           6.0.x
 
     - name: Build and Test

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "7.0.100-rc.1.22431.12",
+      "version": "7.0.100-rc.2.22477.23",
       "rollForward": "latestFeature"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.100",
+      "version": "7.0.100-rc.1.22431.12",
       "rollForward": "latestFeature"
-    },
-    "others": ["3.1.201", "5.0.100"]
+    }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "7.0.100-rc.2.22477.23",
+      "version": "7.0.100",
       "rollForward": "latestFeature"
     }
 }

--- a/src/FluentValidation.Tests/FluentValidation.Tests.csproj
+++ b/src/FluentValidation.Tests/FluentValidation.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <AssemblyName>FluentValidation.Tests</AssemblyName>
     <RootNamespace>FluentValidation.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/FluentValidation.Tests/ForEachRuleTests.cs
+++ b/src/FluentValidation.Tests/ForEachRuleTests.cs
@@ -141,7 +141,7 @@ public class ForEachRuleTests {
 		result.Errors[1].PropertyName.ShouldEqual("NickNames[2]");
 	}
 
-	class request {
+	class Request {
 		public Person person = null;
 	}
 
@@ -158,10 +158,10 @@ public class ForEachRuleTests {
 
 	[Fact]
 	public void Nested_collection_for_null_property_should_not_throw_null_reference() {
-		var validator = new InlineValidator<request>();
+		var validator = new InlineValidator<Request>();
 		validator.When(r => r.person != null, () => { validator.RuleForEach(x => x.person.NickNames).NotNull(); });
 
-		var result = validator.Validate(new request());
+		var result = validator.Validate(new Request());
 		result.Errors.Count.ShouldEqual(0);
 	}
 
@@ -233,7 +233,7 @@ public class ForEachRuleTests {
 
 	[Fact]
 	public void Nested_conditions_Rule_For() {
-		var validator = new InlineValidator<request>();
+		var validator = new InlineValidator<Request>();
 		validator.When(r => true, () => {
 			validator.When(r => r.person?.NickNames?.Any() == true, () => {
 				validator.RuleFor(r => r.person.NickNames)
@@ -241,13 +241,13 @@ public class ForEachRuleTests {
 					.WithMessage("Failed RuleFor");
 			});
 		});
-		var result = validator.Validate(new request());
+		var result = validator.Validate(new Request());
 		result.IsValid.ShouldBeTrue();
 	}
 
 	[Fact]
 	public void Nested_conditions_Rule_For_Each() {
-		var validator = new InlineValidator<request>();
+		var validator = new InlineValidator<Request>();
 
 		validator.When(x => true, () => {
 			validator.When(r => r.person?.NickNames?.Any() == true, () => {
@@ -257,7 +257,7 @@ public class ForEachRuleTests {
 			});
 		});
 
-		var result = validator.Validate(new request());
+		var result = validator.Validate(new Request());
 		result.Errors.Count.ShouldEqual(0);
 	}
 

--- a/src/FluentValidation/CompatibilitySuppressions.xml
+++ b/src/FluentValidation/CompatibilitySuppressions.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:FluentValidation.Validators.PredicateValidator`2.Predicate.#ctor(System.Object,System.IntPtr)</Target>
+    <Left>lib/net6.0/FluentValidation.dll</Left>
+    <Right>lib/net7.0/FluentValidation.dll</Right>
+  </Suppression>
+</Suppressions>

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -20,6 +20,7 @@ namespace FluentValidation;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -162,7 +163,11 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
 	/// <param name="expression">The regular expression to check the value against.</param>
 	/// <returns></returns>
-	public static IRuleBuilderOptions<T, string> Matches<T>(this IRuleBuilder<T, string> ruleBuilder, string expression)
+	public static IRuleBuilderOptions<T, string> Matches<T>(this IRuleBuilder<T, string> ruleBuilder,
+		#if NET7_0_OR_GREATER
+		[StringSyntax(StringSyntaxAttribute.Regex)]
+		#endif
+		string expression)
 		=> ruleBuilder.SetValidator(new RegularExpressionValidator<T>(expression));
 
 	/// <summary>
@@ -231,7 +236,11 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="expression">The regular expression to check the value against.</param>
 	/// <param name="options">Regex options</param>
 	/// <returns></returns>
-	public static IRuleBuilderOptions<T, string> Matches<T>(this IRuleBuilder<T, string> ruleBuilder, string expression, RegexOptions options)
+	public static IRuleBuilderOptions<T, string> Matches<T>(this IRuleBuilder<T, string> ruleBuilder,
+		#if NET7_0_OR_GREATER
+		[StringSyntax(StringSyntaxAttribute.Regex)]
+		#endif
+	 	string expression, RegexOptions options)
 		=> ruleBuilder.SetValidator(new RegularExpressionValidator<T>(expression, options));
 
 	/// <summary>

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <Description>A validation library for .NET that uses a fluent interface to construct strongly-typed validation rules.</Description>
     <PackageReleaseNotes>
 FluentValidation 11 is a major release. Please read the upgrade guide at https://docs.fluentvalidation.net/en/latest/upgrading-to-11.html


### PR DESCRIPTION
- Add .NET 7 build 
- Ensures tests run against .net 7
- annotate regex methods with `StringSyntaxAttribute` (#1957)
- Adds compatibility suppression as delegates are generated with additional overloads in .net 7 to .net 6 (causing package validation to fail as the api surface area is different) 
- Fixes a type name in one of the tests that causes build to fail under .net 7 (types shouldn't start with lowercase name)