### PR TITLE
add property resolver for include properties

### DIFF
--- a/src/FluentValidation.Tests/NameResolutionPluggabilityTester.cs
+++ b/src/FluentValidation.Tests/NameResolutionPluggabilityTester.cs
@@ -43,6 +43,20 @@ public class NameResolutionPluggabilityTester : IDisposable {
 		}
 	}
 
+	[Fact]
+	public void ShouldHaveValidationError_Should_support_custom_propertynameresolver_with_include_properties() {
+		try {
+			ValidatorOptions.Global.PropertyNameResolver = (type, prop, expr) => "foo";
+			var validator = new TestValidator() {
+				v => v.RuleFor(x => x.Surname).NotNull()
+			};
+			validator.TestValidate(new Person(), strategy => strategy.IncludeProperties(x=>x.Surname)).ShouldHaveValidationErrorFor(x => x.Surname);
+		}
+		finally {
+			ValidatorOptions.Global.PropertyNameResolver = null;
+		}
+	}
+
 	public void Dispose() {
 		ValidatorOptions.Global.PropertyNameResolver = null;
 	}

--- a/src/FluentValidation.Tests/NameResolutionPluggabilityTester.cs
+++ b/src/FluentValidation.Tests/NameResolutionPluggabilityTester.cs
@@ -26,7 +26,6 @@ public class NameResolutionPluggabilityTester : IDisposable {
 
 		var error = validator.Validate(new Person { Address = new Address() }).Errors.Single();
 		error.PropertyName.ShouldEqual("Address.Country");
-
 	}
 
 	[Fact]
@@ -50,7 +49,23 @@ public class NameResolutionPluggabilityTester : IDisposable {
 			var validator = new TestValidator() {
 				v => v.RuleFor(x => x.Surname).NotNull()
 			};
-			validator.TestValidate(new Person(), strategy => strategy.IncludeProperties(x=>x.Surname)).ShouldHaveValidationErrorFor(x => x.Surname);
+			validator.TestValidate(new Person(), strategy => strategy.IncludeProperties(x => x.Surname)).ShouldHaveValidationErrorFor(x => x.Surname);
+		}
+		finally {
+			ValidatorOptions.Global.PropertyNameResolver = null;
+		}
+	}
+
+	[Fact]
+	public void ShouldHaveValidationError_Should_support_custom_propertynameresolver_with_include_properties_and_nested_properties() {
+		try {
+			ValidatorOptions.Global.PropertyNameResolver = (type, prop, expr) => "foo";
+			var validator = new TestValidator() {
+				v => v.RuleFor(x => x.Address.Line1).NotNull()
+			};
+			validator.TestValidate(new Person {
+				Address = new Address()
+			}, strategy => strategy.IncludeProperties(x => x.Address.Line1)).ShouldHaveValidationErrorFor(x => x.Address.Line1);
 		}
 		finally {
 			ValidatorOptions.Global.PropertyNameResolver = null;

--- a/src/FluentValidation/Internal/MemberNameValidatorSelector.cs
+++ b/src/FluentValidation/Internal/MemberNameValidatorSelector.cs
@@ -79,6 +79,7 @@ public class MemberNameValidatorSelector : IValidatorSelector {
 			throw new ArgumentException($"Expression '{expression}' does not specify a valid property or field.");
 		}
 
-		return chain.ToString();
+		var propertyName = ValidatorOptions.Global.PropertyNameResolver(typeof(T), expression.GetMember(), expression);
+		return propertyName;
 	}
 }

--- a/src/FluentValidation/Internal/MemberNameValidatorSelector.cs
+++ b/src/FluentValidation/Internal/MemberNameValidatorSelector.cs
@@ -73,13 +73,12 @@ public class MemberNameValidatorSelector : IValidatorSelector {
 	}
 
 	private static string MemberFromExpression<T>(Expression<Func<T, object>> expression) {
-		var chain = PropertyChain.FromExpression(expression);
+		var propertyName = ValidatorOptions.Global.PropertyNameResolver(typeof(T), expression.GetMember(), expression);
 
-		if (chain.Count == 0) {
+		if (string.IsNullOrEmpty(propertyName)) {
 			throw new ArgumentException($"Expression '{expression}' does not specify a valid property or field.");
 		}
 
-		var propertyName = ValidatorOptions.Global.PropertyNameResolver(typeof(T), expression.GetMember(), expression);
 		return propertyName;
 	}
 }


### PR DESCRIPTION
Fix

This pull request fixes how the resolver works with `IncludeProperties`.
For example we have property resolver camelCase and when we are using 
`validator.Validate(new Person(), strategy => strategy.IncludeProperties(x=>x.Surname))`
then validator will not validate our surname property cause our resolver resolve it as "surname"

`IncludeProperties` = "Surname" but resolver (RuleFor(x=>x.Surname)) = "surname" and it can't find the right property for validate