### PR TITLE
Add service collection extension for a single validator

### DIFF
--- a/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
+++ b/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
@@ -28,10 +28,10 @@ public static class ServiceCollectionExtensions	{
 	/// <summary>
 	/// Add explicit model and validator
 	/// </summary>
-	/// <param name="services"></param>
-	/// <param name="lifetime"></param>
-	/// <typeparam name="TModel"></typeparam>
-	/// <typeparam name="TValidator"></typeparam>
+	/// <param name="services">The collection of services</param>
+	/// <param name="lifetime">The lifetime of the validators. The default is scoped (per-request in web applications)</param>
+	/// <typeparam name="TModel">The model to be validated. I.E. Person</typeparam>
+	/// <typeparam name="TValidator">The validator for the model. I.E. PersonValidator</typeparam>
 	/// <returns></returns>
 	public static IServiceCollection AddValidator<TModel, TValidator>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped) where TValidator : class, IValidator<TModel> {
 		services.Add(

--- a/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
+++ b/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
@@ -24,15 +24,22 @@ using System.Collections.Generic;
 using System.Reflection;
 
 public static class ServiceCollectionExtensions	{
+
 	/// <summary>
-	/// Adds a single validator explicitly
+	/// Add explicit model and validator
 	/// </summary>
 	/// <param name="services"></param>
 	/// <param name="lifetime"></param>
-	/// <typeparam name="T"></typeparam>
+	/// <typeparam name="TModel"></typeparam>
+	/// <typeparam name="TValidator"></typeparam>
 	/// <returns></returns>
-	public static IServiceCollection AddValidator<T>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped) where T : IValidator<T> {
-		services.AddScanResult(new AssemblyScanner.AssemblyScanResult(typeof(IValidator<T>), typeof(T)), lifetime, null);
+	public static IServiceCollection AddValidator<TModel, TValidator>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped) where TValidator : class, IValidator<TModel> {
+		services.Add(
+			new ServiceDescriptor(
+				serviceType: typeof(IValidator<TModel>),
+				implementationType: typeof(TValidator),
+				lifetime: lifetime));
+
 		return services;
 	}
 

--- a/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
+++ b/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,18 @@ using System.Reflection;
 
 public static class ServiceCollectionExtensions	{
 	/// <summary>
+	/// Adds a single validator explicitly
+	/// </summary>
+	/// <param name="services"></param>
+	/// <param name="lifetime"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public static IServiceCollection AddValidator<T>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped) where T : IValidator<T> {
+		services.AddScanResult(new AssemblyScanner.AssemblyScanResult(typeof(IValidator<T>), typeof(T)), lifetime, null);
+		return services;
+	}
+
+	/// <summary>
 	/// Adds all validators in specified assemblies
 	/// </summary>
 	/// <param name="services">The collection of services</param>


### PR DESCRIPTION
It would be nice to include an extension method for a single validator within the library itself. In my own project, I have an extension method like this.  This is to make the container registrations more explicit to avoid having classes (Validators) in the project which appear not to be used anywhere in the project.