### PR TITLE
Introduce PrecisionScale validator as replacement for ScalePrecision validator

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,6 @@
+11.4.0 - 23 Nov 2022
+Deprecate ScalePrecision validator and introduce PrecisionScale validator as its replacement (#2030)
+
 11.3.0 - 10 Nov 2022
 Annotate string parameters with StringSyntaxAttribute.Regex in net7 builds (#1957)
 Fixes to SourceLink integration (#2019)

--- a/docs/built-in-validators.md
+++ b/docs/built-in-validators.md
@@ -417,3 +417,5 @@ Note that the 3rd parameter of this method is `ignoreTrailingZeros`. When set to
 Example:
 - When `ignoreTrailingZeros` is `false` then the decimal `123.4500` will be considered to have a precision of 7 and scale of 4
 - When `ignoreTrailingZeros` is `true` then the decimal `123.4500` will be considered to have a precision of 5 and scale of 2. 
+
+Note that prior to FluentValidation 11.4, this this method was called `ScalePrecision` instead and had its parameters reversed. For more details [see this GitHub issue](https://github.com/FluentValidation/FluentValidation/issues/2030)

--- a/docs/built-in-validators.md
+++ b/docs/built-in-validators.md
@@ -397,10 +397,10 @@ String format args:
 * `{From}` – Lower bound of the range
 * `{To}` – Upper bound of the range
 
-## ScalePrecision Validator
-Checks whether a decimal value has the specified scale and precision.
+## PrecisionScale Validator
+Checks whether a decimal value has the specified precision and scale.
 ```csharp
-RuleFor(x => x.Amount).ScalePrecision(2, 4);
+RuleFor(x => x.Amount).PrecisionScale(4, 2, false);
 ```
 Example error: *'Amount' must not be more than 4 digits in total, with allowance for 2 decimals. 5 digits and 3 decimals were found.*
 
@@ -412,4 +412,8 @@ String format args:
 * `{Digits}` – Total number of digits in the property value
 * `{ActualScale}` – Actual scale of the property value
 
-Note that this method contains an additional optional parameter `ignoreTrailingZeros`. When set to `true`, trailing zeros after the decimal point will not count towards the expected number of decimal places. By default, this is set to `false`.
+Note that the 3rd parameter of this method is `ignoreTrailingZeros`. When set to `true`, trailing zeros after the decimal point will not count towards the expected number of decimal places. 
+
+Example:
+- When `ignoreTrailingZeros` is `false` then the decimal `123.4500` will be considered to have a precision of 7 and scale of 4
+- When `ignoreTrailingZeros` is `true` then the decimal `123.4500` will be considered to have a precision of 5 and scale of 2. 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>11.3.0</VersionPrefix>
+    <VersionPrefix>11.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <!-- Use CI build number as version suffix (if defined) -->
     <!--<VersionSuffix Condition="'$(GITHUB_RUN_NUMBER)'!=''">ci-$(GITHUB_RUN_NUMBER)</VersionSuffix>-->

--- a/src/FluentValidation.Tests/DefaultValidatorExtensionTester.cs
+++ b/src/FluentValidation.Tests/DefaultValidatorExtensionTester.cs
@@ -214,13 +214,13 @@ public class DefaultValidatorExtensionTester {
 
 	[Fact]
 	public void ScalePrecision_should_create_ScalePrecisionValidator() {
-		validator.RuleFor(x => x.Discount).ScalePrecision(2, 5);
+		validator.RuleFor(x => x.Discount).PrecisionScale(5, 2, false);
 		AssertValidator<ScalePrecisionValidator<Person>>();
 	}
 
 	[Fact]
 	public void ScalePrecision_should_create_ScalePrecisionValidator_with_ignore_trailing_zeros() {
-		validator.RuleFor(x => x.Discount).ScalePrecision(2, 5, true);
+		validator.RuleFor(x => x.Discount).PrecisionScale(5, 2, true);
 		AssertValidator<ScalePrecisionValidator<Person>>();
 	}
 

--- a/src/FluentValidation.Tests/ScalePrecisionValidatorTests.cs
+++ b/src/FluentValidation.Tests/ScalePrecisionValidatorTests.cs
@@ -27,7 +27,7 @@ public class ScalePrecisionValidatorTests {
 
 	[Fact]
 	public void Scale_precision_should_be_valid() {
-		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).ScalePrecision(2, 4));
+		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).PrecisionScale(4, 2, false));
 
 		var result = validator.Validate(new Person { Discount = 12.34M });
 		result.IsValid.ShouldBeTrue();
@@ -47,7 +47,7 @@ public class ScalePrecisionValidatorTests {
 
 	[Fact]
 	public void Scale_precision_should_be_valid_nullable() {
-		var validator = new TestValidator(v => v.RuleFor(x => x.NullableDiscount).ScalePrecision(2, 4));
+		var validator = new TestValidator(v => v.RuleFor(x => x.NullableDiscount).PrecisionScale(4, 2, false));
 
 		var result = validator.Validate(new Person { NullableDiscount = 12.34M });
 		result.IsValid.ShouldBeTrue();
@@ -67,7 +67,7 @@ public class ScalePrecisionValidatorTests {
 
 	[Fact]
 	public void Scale_precision_should_not_be_valid() {
-		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).ScalePrecision(2, 4));
+		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).PrecisionScale(4, 2, false));
 
 		var result = validator.Validate(new Person { Discount = 123.456778m });
 		result.IsValid.ShouldBeFalse();
@@ -100,7 +100,7 @@ public class ScalePrecisionValidatorTests {
 
 	[Fact]
 	public void Scale_precision_should_not_be_valid_nullable() {
-		var validator = new TestValidator(v => v.RuleFor(x => x.NullableDiscount).ScalePrecision(2, 4).WithName("Discount"));
+		var validator = new TestValidator(v => v.RuleFor(x => x.NullableDiscount).PrecisionScale(4, 2, false).WithName("Discount"));
 
 		var result = validator.Validate(new Person { NullableDiscount = 123.456778m });
 		result.IsValid.ShouldBeFalse();
@@ -125,7 +125,7 @@ public class ScalePrecisionValidatorTests {
 
 	[Fact]
 	public void Scale_precision_should_be_valid_when_they_are_equal() {
-		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).ScalePrecision(2, 2));
+		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).PrecisionScale(2, 2, false));
 
 		var result = validator.Validate(new Person { Discount = 0.34M });
 		result.IsValid.ShouldBeTrue();
@@ -142,7 +142,7 @@ public class ScalePrecisionValidatorTests {
 
 	[Fact]
 	public void Scale_precision_should_not_be_valid_when_they_are_equal() {
-		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).ScalePrecision(2, 2));
+		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).PrecisionScale(2, 2, false));
 
 		var result = validator.Validate(new Person { Discount = 123.456778m });
 		result.IsValid.ShouldBeFalse();
@@ -167,7 +167,7 @@ public class ScalePrecisionValidatorTests {
 
 	[Fact]
 	public void Scale_precision_should_be_valid_when_ignoring_trailing_zeroes() {
-		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).ScalePrecision(2, 4, true));
+		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).PrecisionScale(4, 2, true));
 
 		var result = validator.Validate(new Person { Discount = 15.0000000000000000000000000M });
 		result.IsValid.ShouldBeTrue();
@@ -181,7 +181,7 @@ public class ScalePrecisionValidatorTests {
 
 	[Fact]
 	public void Scale_precision_should_not_be_valid_when_ignoring_trailing_zeroes() {
-		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).ScalePrecision(2, 4, true));
+		var validator = new TestValidator(v => v.RuleFor(x => x.Discount).PrecisionScale(4, 2, true));
 
 		var result = validator.Validate(new Person { Discount = 1565.0M });
 		result.IsValid.ShouldBeFalse();

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1079,6 +1079,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="precision">Allowed precision of the value</param>
 	/// <param name="ignoreTrailingZeros">Whether the validator will ignore trailing zeros.</param>
 	/// <returns></returns>
+	[Obsolete("Please use the PrecisionScale method instead, which takes precision as the first parameter and scale as the second.")]
 	public static IRuleBuilderOptions<T, decimal> ScalePrecision<T>(this IRuleBuilder<T, decimal> ruleBuilder, int scale, int precision, bool ignoreTrailingZeros = false)
 		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
 
@@ -1091,7 +1092,32 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="precision">Allowed precision of the value</param>
 	/// <param name="ignoreTrailingZeros">Whether the validator will ignore trailing zeros.</param>
 	/// <returns></returns>
+	[Obsolete("Please use the PrecisionScale method instead, which takes precision as the first parameter and scale as the second.")]
 	public static IRuleBuilderOptions<T, decimal?> ScalePrecision<T>(this IRuleBuilder<T, decimal?> ruleBuilder, int scale, int precision, bool ignoreTrailingZeros = false)
+		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
+
+	/// <summary>
+	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale.
+	/// </summary>
+	/// <typeparam name="T">Type of object being validated</typeparam>
+	/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+	/// <param name="scale">Allowed scale of the value</param>
+	/// <param name="precision">Allowed precision of the value</param>
+	/// <param name="ignoreTrailingZeros">Whether the validator will ignore trailing zeros after the decimal point. For example, when set to true the decimal 123.4500 will be considered to have a precision of 5 and scale of 2. When set to false, it will be considered to have a precision of 7 and scale of 4.</param>
+	/// <returns></returns>
+	public static IRuleBuilderOptions<T, decimal> PrecisionScale<T>(this IRuleBuilder<T, decimal> ruleBuilder, int precision, int scale, bool ignoreTrailingZeros)
+		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
+
+	/// <summary>
+	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale.
+	/// </summary>
+	/// <typeparam name="T">Type of object being validated</typeparam>
+	/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+	/// <param name="scale">Allowed scale of the value</param>
+	/// <param name="precision">Allowed precision of the value</param>
+	/// <param name="ignoreTrailingZeros">Whether the validator will ignore trailing zeros after the decimal point. For example, when set to true the decimal 123.4500 will be considered to have a precision of 5 and scale of 2. When set to false, it will be considered to have a precision of 7 and scale of 4.</param>
+	/// <returns></returns>
+	public static IRuleBuilderOptions<T, decimal?> PrecisionScale<T>(this IRuleBuilder<T, decimal?> ruleBuilder, int precision, int scale, bool ignoreTrailingZeros)
 		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
 
 	/// <summary>

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1079,7 +1079,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="precision">Allowed precision of the value</param>
 	/// <param name="ignoreTrailingZeros">Whether the validator will ignore trailing zeros.</param>
 	/// <returns></returns>
-	[Obsolete("Please use the PrecisionScale method instead, which takes precision as the first parameter and scale as the second.")]
+	[Obsolete("Please use the PrecisionScale method instead, which takes precision as the first parameter and scale as the second. See https://github.com/FluentValidation/FluentValidation/issues/2030 for further details")]
 	public static IRuleBuilderOptions<T, decimal> ScalePrecision<T>(this IRuleBuilder<T, decimal> ruleBuilder, int scale, int precision, bool ignoreTrailingZeros = false)
 		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
 
@@ -1092,7 +1092,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="precision">Allowed precision of the value</param>
 	/// <param name="ignoreTrailingZeros">Whether the validator will ignore trailing zeros.</param>
 	/// <returns></returns>
-	[Obsolete("Please use the PrecisionScale method instead, which takes precision as the first parameter and scale as the second.")]
+	[Obsolete("Please use the PrecisionScale method instead, which takes precision as the first parameter and scale as the second. See https://github.com/FluentValidation/FluentValidation/issues/2030 for further details")]
 	public static IRuleBuilderOptions<T, decimal?> ScalePrecision<T>(this IRuleBuilder<T, decimal?> ruleBuilder, int scale, int precision, bool ignoreTrailingZeros = false)
 		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
 

--- a/src/FluentValidation/Validators/ScalePrecisionValidator.cs
+++ b/src/FluentValidation/Validators/ScalePrecisionValidator.cs
@@ -37,6 +37,8 @@ using System;
 /// and precision of 2 and 5 respectively.
 /// </summary>
 public class ScalePrecisionValidator<T> : PropertyValidator<T, decimal> {
+
+	// TODO: For 12.0 swap the parameter order to match the PrecisionScale extension methods and add parameter for IgnoreTrailingZeros.
 	public ScalePrecisionValidator(int scale, int precision) {
 		Init(scale, precision);
 	}


### PR DESCRIPTION
- Deprecates `ScalePrecision` methods
- Introduces `PrecisionScale` methods as replacements
- New methods swap the parameter order from `scale, precision` to `precision, scale` for consistency with how databases define decimals
- Makes the `ignoreTrailingZeros` parameter mandatory 