### PR TITLE
fix: MinimumLengthValidator supports null validation

### DIFF
--- a/src/FluentValidation.Tests/LengthValidatorTests.cs
+++ b/src/FluentValidation.Tests/LengthValidatorTests.cs
@@ -143,6 +143,12 @@ public class LengthValidatorTests {
 		result.Errors.Single().ErrorMessage.ShouldEqual("The length of 'Surname' must be at least 4 characters. You entered 3 characters.");
 	}
 
+	[Fact]
+	public void When_the_minlength_validator_fails_the_content_is_null_and_error_message_should_be_set() {
+		var validator = new TestValidator(v => v.RuleFor(x => x.Surname).MinimumLength(4));
+		var result = validator.Validate(new Person { Surname = null });
+		result.Errors.Single().ErrorMessage.ShouldEqual("The length of 'Surname' must be at least 4 characters. You entered 0 characters.");
+	}
 
 	[Fact]
 	public void When_the_maxlength_validator_fails_the_error_message_should_be_set() {

--- a/src/FluentValidation/Validators/LengthValidator.cs
+++ b/src/FluentValidation/Validators/LengthValidator.cs
@@ -20,7 +20,7 @@ namespace FluentValidation.Validators;
 
 using System;
 
-public class LengthValidator<T> : PropertyValidator<T,string>, ILengthValidator {
+public class LengthValidator<T> : PropertyValidator<T, string>, ILengthValidator {
 	public override string Name => "LengthValidator";
 
 	public int Min { get; }
@@ -76,7 +76,7 @@ public class LengthValidator<T> : PropertyValidator<T,string>, ILengthValidator 
 public class ExactLengthValidator<T> : LengthValidator<T>, IExactLengthValidator {
 	public override string Name => "ExactLengthValidator";
 
-	public ExactLengthValidator(int length) : base(length,length) {
+	public ExactLengthValidator(int length) : base(length, length) {
 
 	}
 
@@ -123,6 +123,29 @@ public class MinimumLengthValidator<T> : LengthValidator<T>, IMinimumLengthValid
 
 	protected override string GetDefaultMessageTemplate(string errorCode) {
 		return Localized(errorCode, Name);
+	}
+
+	public override bool IsValid(ValidationContext<T> context, string value) {
+		var min = Min;
+		var max = Max;
+
+		if (MaxFunc != null && MinFunc != null) {
+			max = MaxFunc(context.InstanceToValidate);
+			min = MinFunc(context.InstanceToValidate);
+		}
+
+		int length = value?.Length ?? 0;
+
+		if (length < min || (length > max && max != -1)) {
+			context.MessageFormatter
+				.AppendArgument("MinLength", min)
+				.AppendArgument("MaxLength", max)
+				.AppendArgument("TotalLength", length);
+
+			return false;
+		}
+
+		return true;
 	}
 }
 


### PR DESCRIPTION
MinimumLengthValidator supports null validation. When the parameter to be validated is null, the input should be considered as a null value, and the final result will be obtained after comparing with the minimum length, see unit test for details