### PR TITLE
Optimize regex validator

### DIFF
--- a/src/FluentValidation/Validators/RegularExpressionValidator.cs
+++ b/src/FluentValidation/Validators/RegularExpressionValidator.cs
@@ -58,7 +58,7 @@ public class RegularExpressionValidator<T> : PropertyValidator<T,string>, IRegul
 
 	public override bool IsValid(ValidationContext<T> context, string value) {
 		if (value == null) {
-			return true	
+			return true;
 		}
 		
 		var regex = _regexFunc(context.InstanceToValidate);

--- a/src/FluentValidation/Validators/RegularExpressionValidator.cs
+++ b/src/FluentValidation/Validators/RegularExpressionValidator.cs
@@ -57,9 +57,13 @@ public class RegularExpressionValidator<T> : PropertyValidator<T,string>, IRegul
 	}
 
 	public override bool IsValid(ValidationContext<T> context, string value) {
+		if (value == null) {
+			return true	
+		}
+		
 		var regex = _regexFunc(context.InstanceToValidate);
 
-		if (regex != null && value != null && !regex.IsMatch(value)) {
+		if (regex != null && !regex.IsMatch(value)) {
 			context.MessageFormatter.AppendArgument("RegularExpression", regex.ToString());
 			return false;
 		}


### PR DESCRIPTION
Probably no need to instantiate the regex if the value being null never means it gets executed.