### PR TITLE
Support indexers in expression trees when generating PropertyChain for simple cases.

### DIFF
--- a/src/FluentValidation.Tests/PropertyChainTests.cs
+++ b/src/FluentValidation.Tests/PropertyChainTests.cs
@@ -84,6 +84,13 @@ public class PropertyChainTests {
 	}
 
 	[Fact]
+	public void Creates_from_expression_with_indexer() {
+		Expression<Func<Person, string>> expr = x => x.Orders[0].ProductName;
+		var chain = PropertyChain.FromExpression(expr);
+		chain.ToString().ShouldEqual("Orders[0].ProductName");
+	}
+
+	[Fact]
 	public void Should_ignore_blanks() {
 		chain.Add("");
 		chain.Add("Foo");

--- a/src/FluentValidation/Internal/PropertyChain.cs
+++ b/src/FluentValidation/Internal/PropertyChain.cs
@@ -70,10 +70,33 @@ public class PropertyChain {
 		});
 
 		var memberExp = getMemberExp(expression.Body);
+		string indexer = null;
 
 		while(memberExp != null) {
-			memberNames.Push(memberExp.Member.Name);
-			memberExp = getMemberExp(memberExp.Expression);
+			string propertyName = memberExp.Member.Name;
+
+			if (indexer != null) {
+				propertyName += $"[{indexer}]";
+				indexer = null;
+			}
+
+			memberNames.Push(propertyName);
+
+			// Handle indexers.
+			if (memberExp.Expression is MethodCallExpression mce
+			    && mce.Method is {IsSpecialName: true, Name: "get_Item"}
+			    && mce.Arguments.Count == 1
+			    && mce.Arguments[0] is ConstantExpression ce) {
+
+				memberExp = getMemberExp(mce.Object);
+				if (memberExp != null) {
+						indexer = ce.Value?.ToString();
+				}
+			}
+			else {
+				memberExp = getMemberExp(memberExp.Expression);
+			}
+
 		}
 
 		return new PropertyChain(memberNames);


### PR DESCRIPTION
- [ ] Need some tests around normalising property names for collection expressions in the test helper 

Investigate adding the additions from https://github.com/FluentValidation/FluentValidation/pull/2360 to this PR if we decide to proceed with this feature.