### PR TITLE
Change lambda parameter name to order

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -76,9 +76,9 @@ public class CustomerValidator : AbstractValidator<Customer>
 {
   public CustomerValidator() 
   {
-    RuleForEach(x => x.Orders).ChildRules(orders => 
+    RuleForEach(x => x.Orders).ChildRules(order => 
     {
-      orders.RuleFor(x => x.Total).GreaterThan(0);
+      order.RuleFor(x => x.Total).GreaterThan(0);
     });
   }
 }


### PR DESCRIPTION
A small improvement to an example code – the lambda parameter is named `orders` despite that it's a single order. I renamed it to `order` to emphasize that it is indeed **one** order.