### PR TITLE
Fixed some typos in Validator Extension

### DIFF
--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -802,7 +802,7 @@ public static partial class DefaultValidatorExtensions {
 	}
 
 	/// <summary>
-	/// Defines a 'less than' validator on the current rule builder using a lambda expression.
+	/// Defines a 'greater than' validator on the current rule builder using a lambda expression.
 	/// The validation will succeed if the property value is greater than the specified value.
 	/// The validation will fail if the property value is less than or equal to the specified value.
 	/// </summary>
@@ -822,7 +822,7 @@ public static partial class DefaultValidatorExtensions {
 	}
 
 	/// <summary>
-	/// Defines a 'less than' validator on the current rule builder using a lambda expression.
+	/// Defines a 'greater than' validator on the current rule builder using a lambda expression.
 	/// The validation will succeed if the property value is greater than the specified value.
 	/// The validation will fail if the property value is less than or equal to the specified value.
 	/// </summary>
@@ -845,7 +845,7 @@ public static partial class DefaultValidatorExtensions {
 	}
 
 	/// <summary>
-	/// Defines a 'less than' validator on the current rule builder using a lambda expression.
+	/// Defines a 'greater than' validator on the current rule builder using a lambda expression.
 	/// The validation will succeed if the property value is greater than the specified value.
 	/// The validation will fail if the property value is less than or equal to the specified value.
 	/// </summary>
@@ -865,7 +865,7 @@ public static partial class DefaultValidatorExtensions {
 	}
 
 	/// <summary>
-	/// Defines a 'less than' validator on the current rule builder using a lambda expression.
+	/// Defines a 'greater than' validator on the current rule builder using a lambda expression.
 	/// The validation will succeed if the property value is greater than the specified value.
 	/// The validation will fail if the property value is less than or equal to the specified value.
 	/// </summary>
@@ -888,7 +888,7 @@ public static partial class DefaultValidatorExtensions {
 	}
 
 	/// <summary>
-	/// Defines a 'greater than' validator on the current rule builder using a lambda expression.
+	/// Defines a 'greater than or equal to' validator on the current rule builder using a lambda expression.
 	/// The validation will succeed if the property value is greater than or equal the specified value.
 	/// The validation will fail if the property value is less than the specified value.
 	/// </summary>
@@ -908,7 +908,7 @@ public static partial class DefaultValidatorExtensions {
 	}
 
 	/// <summary>
-	/// Defines a 'greater than' validator on the current rule builder using a lambda expression.
+	/// Defines a 'greater than or equal to' validator on the current rule builder using a lambda expression.
 	/// The validation will succeed if the property value is greater than or equal the specified value.
 	/// The validation will fail if the property value is less than the specified value.
 	/// </summary>


### PR DESCRIPTION
This is not a functional change nor a new feature so my understanding is I do not need to open a new Issue to talk about this change.

While using FluentValidation I noticed that IntelliSense summary for GreaterThen is wrong. This PR changes the summary for some validator extension methods.