### PR TITLE
Chinese  language tags change

### DIFF
--- a/src/FluentValidation.Tests/LanguageManagerTests.cs
+++ b/src/FluentValidation.Tests/LanguageManagerTests.cs
@@ -53,6 +53,11 @@ public class LanguageManagerTests {
 			var msg = _languages.GetString("NotNullValidator");
 			msg.ShouldEqual("'{PropertyName}' 不能为Null。");
 		}
+
+		using (new CultureScope("zh-SG")) {
+			var msg = _languages.GetString("NotNullValidator");
+			msg.ShouldEqual("'{PropertyName}' 不能为Null。");
+		}
 	}
 
 	[Fact]

--- a/src/FluentValidation/Resources/Languages/ChineseSimplifiedLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/ChineseSimplifiedLanguage.cs
@@ -23,7 +23,7 @@
 namespace FluentValidation.Resources;
 
 internal class ChineseSimplifiedLanguage {
-	public const string Culture = "zh-CN";
+	public const string Culture = "zh-Hans";
 
 	public static string GetTranslation(string key) => key switch {
 		"EmailValidator" => "'{PropertyName}' 不是有效的电子邮件地址。",

--- a/src/FluentValidation/Resources/Languages/ChineseTraditionalLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/ChineseTraditionalLanguage.cs
@@ -23,7 +23,7 @@
 namespace FluentValidation.Resources;
 
 internal class ChineseTraditionalLanguage {
-	public const string Culture = "zh-TW";
+	public const string Culture = "zh-Hant";
 
 	public static string GetTranslation(string key) => key switch {
 		"EmailValidator" => "'{PropertyName}' 不是有效的電子郵件地址。",


### PR DESCRIPTION
The Language tags for Simplified Chinese and Traditional Chinese have been modified. The parent tag for zh-CN is zh-Hans, and the parent tag for zh-TW is zh-Hant.