### PR TITLE
Performance optimization: focusing on allocation reduction

### DIFF
--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -238,6 +238,7 @@ public abstract class AbstractValidator<T> : IValidator<T>, IEnumerable<IValidat
 
 		int count = Rules.Count;
 
+		// Performance: Use for loop rather than foreach to reduce allocations.
 		for (int i = 0; i < count; i++) {
 			cancellation.ThrowIfCancellationRequested();
 			await Rules[i].ValidateAsync(context, useAsync, cancellation);

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -236,9 +236,11 @@ public abstract class AbstractValidator<T> : IValidator<T>, IEnumerable<IValidat
 		EnsureInstanceNotNull(context.InstanceToValidate);
 #pragma warning restore CS0618
 
-		foreach (var rule in Rules) {
+		int count = Rules.Count;
+
+		for (int i = 0; i < count; i++) {
 			cancellation.ThrowIfCancellationRequested();
-			await rule.ValidateAsync(context, useAsync, cancellation);
+			await Rules[i].ValidateAsync(context, useAsync, cancellation);
 
 			if (ClassLevelCascadeMode == CascadeMode.Stop && result.Errors.Count > 0) {
 				// Bail out if we're "failing-fast".
@@ -259,8 +261,12 @@ public abstract class AbstractValidator<T> : IValidator<T>, IEnumerable<IValidat
 	}
 
 	private void SetExecutedRuleSets(ValidationResult result, ValidationContext<T> context) {
-		var executed = context.RootContextData.GetOrAdd("_FV_RuleSetsExecuted", () => new HashSet<string>{RulesetValidatorSelector.DefaultRuleSetName});
-		result.RuleSetsExecuted = executed.ToArray();
+				if ((context.RootContextData.TryGetValue("_FV_RuleSetsExecuted", out var obj)) && (obj is HashSet<string> set))
+				{
+						result.RuleSetsExecuted = set.ToArray();
+				}
+
+				result.RuleSetsExecuted = RulesetValidatorSelector.DefaultRuleSetNameInArray;
 	}
 
 	/// <summary>

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -164,7 +164,7 @@ public abstract class AbstractValidator<T> : IValidator<T>, IEnumerable<IValidat
 	/// <param name="instance">The object to validate</param>
 	/// <returns>A ValidationResult object containing any validation failures</returns>
 	public ValidationResult Validate(T instance)
-		=> Validate(new ValidationContext<T>(instance, new PropertyChain(), ValidatorOptions.Global.ValidatorSelectors.DefaultValidatorSelectorFactory()));
+		=> Validate(new ValidationContext<T>(instance, null, ValidatorOptions.Global.ValidatorSelectors.DefaultValidatorSelectorFactory()));
 
 	/// <summary>
 	/// Validates the specified instance asynchronously
@@ -173,7 +173,7 @@ public abstract class AbstractValidator<T> : IValidator<T>, IEnumerable<IValidat
 	/// <param name="cancellation">Cancellation token</param>
 	/// <returns>A ValidationResult object containing any validation failures</returns>
 	public Task<ValidationResult> ValidateAsync(T instance, CancellationToken cancellation = new())
-		=> ValidateAsync(new ValidationContext<T>(instance, new PropertyChain(), ValidatorOptions.Global.ValidatorSelectors.DefaultValidatorSelectorFactory()), cancellation);
+		=> ValidateAsync(new ValidationContext<T>(instance, null, ValidatorOptions.Global.ValidatorSelectors.DefaultValidatorSelectorFactory()), cancellation);
 
 	/// <summary>
 	/// Validates the specified instance.

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -262,12 +262,12 @@ public abstract class AbstractValidator<T> : IValidator<T>, IEnumerable<IValidat
 	}
 
 	private void SetExecutedRuleSets(ValidationResult result, ValidationContext<T> context) {
-				if ((context.RootContextData.TryGetValue("_FV_RuleSetsExecuted", out var obj)) && (obj is HashSet<string> set))
-				{
-						result.RuleSetsExecuted = set.ToArray();
-				}
-
-				result.RuleSetsExecuted = RulesetValidatorSelector.DefaultRuleSetNameInArray;
+		if (context.RootContextData.TryGetValue("_FV_RuleSetsExecuted", out var obj) && obj is HashSet<string> set) {
+			result.RuleSetsExecuted = set.ToArray();
+		}
+		else {
+			result.RuleSetsExecuted = RulesetValidatorSelector.DefaultRuleSetNameInArray;
+		}
 	}
 
 	/// <summary>

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -166,7 +166,7 @@ internal class CollectionPropertyRule<T, TElement> : RuleBase<T, IEnumerable<TEl
 				var valueToValidate = element;
 				var propertyPath = context.PropertyChain.ToString();
 				var totalFailuresInner = context.Failures.Count;
-				context.InitializeForPropertyValidator(propertyPath, GetDisplayName, PropertyName);
+				context.InitializeForPropertyValidator(propertyPath, _displayNameFunc, PropertyName);
 
 				foreach (var component in filteredValidators) {
 					context.MessageFormatter.Reset();

--- a/src/FluentValidation/Internal/PropertyChain.cs
+++ b/src/FluentValidation/Internal/PropertyChain.cs
@@ -27,7 +27,6 @@ using System.Reflection;
 /// Represents a chain of properties
 /// </summary>
 public class PropertyChain : List<string> {
-	private List<string> _memberNames => this;
 
 	/// <summary>
 	/// Creates a new PropertyChain.
@@ -39,9 +38,8 @@ public class PropertyChain : List<string> {
 	/// Creates a new PropertyChain based on another.
 	/// </summary>
 	public PropertyChain(PropertyChain parent) {
-		if(parent != null
-		   && parent._memberNames.Count > 0) {
-			_memberNames.AddRange(parent._memberNames);
+		if(parent != null && parent.Count > 0) {
+			AddRange(parent);
 		}
 	}
 
@@ -50,7 +48,7 @@ public class PropertyChain : List<string> {
 	/// </summary>
 	/// <param name="memberNames"></param>
 	public PropertyChain(IEnumerable<string> memberNames) {
-		this._memberNames.AddRange(memberNames);
+		AddRange(memberNames);
 	}
 
 	/// <summary>
@@ -84,8 +82,9 @@ public class PropertyChain : List<string> {
 	/// </summary>
 	/// <param name="member">Member to add</param>
 	public void Add(MemberInfo member) {
-		if(member != null)
-			_memberNames.Add(member.Name);
+		if (member != null) {
+			Add(member.Name);
+		}
 	}
 
 	/// <summary>
@@ -93,8 +92,9 @@ public class PropertyChain : List<string> {
 	/// </summary>
 	/// <param name="propertyName">Name of the property to add</param>
 	public new void Add(string propertyName) {
-		if(!string.IsNullOrEmpty(propertyName))
-			_memberNames.Add(propertyName);
+		if (!string.IsNullOrEmpty(propertyName)) {
+			base.Add(propertyName);
+		}
 	}
 
 	/// <summary>
@@ -106,14 +106,14 @@ public class PropertyChain : List<string> {
 	/// <param name="indexer"></param>
 	/// <param name="surroundWithBrackets">Whether square brackets should be applied before and after the indexer. Default true.</param>
 	public void AddIndexer(object indexer, bool surroundWithBrackets = true) {
-		if(_memberNames.Count == 0) {
+		if(Count == 0) {
 			throw new InvalidOperationException("Could not apply an Indexer because the property chain is empty.");
 		}
 
-		string last = _memberNames[_memberNames.Count - 1];
+		string last = this[Count - 1];
 		last += surroundWithBrackets ? "[" + indexer + "]" : indexer;
 
-		_memberNames[_memberNames.Count - 1] = last;
+		this[Count - 1] = last;
 	}
 
 	/// <summary>
@@ -121,13 +121,13 @@ public class PropertyChain : List<string> {
 	/// </summary>
 	public override string ToString() {
 		// Performance: Calling string.Join causes much overhead when it's not needed.
-		switch (_memberNames.Count) {
+		switch (Count) {
 			case 0:
 				return string.Empty;
 			case 1:
-				return _memberNames[0];
+				return this[0];
 			default:
-				return string.Join(ValidatorOptions.Global.PropertyChainSeparator, _memberNames);
+				return string.Join(ValidatorOptions.Global.PropertyChainSeparator, this);
 		}
 	}
 
@@ -150,7 +150,7 @@ public class PropertyChain : List<string> {
 	/// Builds a property path.
 	/// </summary>
 	public string BuildPropertyPath(string propertyName) {
-		if (_memberNames.Count == 0) {
+		if (Count == 0) {
 			return propertyName;
 		}
 

--- a/src/FluentValidation/Internal/PropertyChain.cs
+++ b/src/FluentValidation/Internal/PropertyChain.cs
@@ -26,7 +26,8 @@ using System.Reflection;
 /// <summary>
 /// Represents a chain of properties
 /// </summary>
-public class PropertyChain : List<string> {
+public class PropertyChain {
+	readonly List<string> _memberNames = new(2);
 
 	/// <summary>
 	/// Creates a new PropertyChain.
@@ -38,8 +39,9 @@ public class PropertyChain : List<string> {
 	/// Creates a new PropertyChain based on another.
 	/// </summary>
 	public PropertyChain(PropertyChain parent) {
-		if(parent != null && parent.Count > 0) {
-			AddRange(parent);
+		if(parent != null
+		   && parent._memberNames.Count > 0) {
+			_memberNames.AddRange(parent._memberNames);
 		}
 	}
 
@@ -48,7 +50,7 @@ public class PropertyChain : List<string> {
 	/// </summary>
 	/// <param name="memberNames"></param>
 	public PropertyChain(IEnumerable<string> memberNames) {
-		AddRange(memberNames);
+		this._memberNames.AddRange(memberNames);
 	}
 
 	/// <summary>
@@ -82,19 +84,17 @@ public class PropertyChain : List<string> {
 	/// </summary>
 	/// <param name="member">Member to add</param>
 	public void Add(MemberInfo member) {
-		if (member != null) {
-			Add(member.Name);
-		}
+		if(member != null)
+			_memberNames.Add(member.Name);
 	}
 
 	/// <summary>
 	/// Adds a property name to the chain
 	/// </summary>
 	/// <param name="propertyName">Name of the property to add</param>
-	public new void Add(string propertyName) {
-		if (!string.IsNullOrEmpty(propertyName)) {
-			base.Add(propertyName);
-		}
+	public void Add(string propertyName) {
+		if(!string.IsNullOrEmpty(propertyName))
+			_memberNames.Add(propertyName);
 	}
 
 	/// <summary>
@@ -106,14 +106,14 @@ public class PropertyChain : List<string> {
 	/// <param name="indexer"></param>
 	/// <param name="surroundWithBrackets">Whether square brackets should be applied before and after the indexer. Default true.</param>
 	public void AddIndexer(object indexer, bool surroundWithBrackets = true) {
-		if(Count == 0) {
+		if(_memberNames.Count == 0) {
 			throw new InvalidOperationException("Could not apply an Indexer because the property chain is empty.");
 		}
 
-		string last = this[Count - 1];
+		string last = _memberNames[_memberNames.Count - 1];
 		last += surroundWithBrackets ? "[" + indexer + "]" : indexer;
 
-		this[Count - 1] = last;
+		_memberNames[_memberNames.Count - 1] = last;
 	}
 
 	/// <summary>
@@ -121,13 +121,13 @@ public class PropertyChain : List<string> {
 	/// </summary>
 	public override string ToString() {
 		// Performance: Calling string.Join causes much overhead when it's not needed.
-		switch (Count) {
+		switch (_memberNames.Count) {
 			case 0:
 				return string.Empty;
 			case 1:
-				return this[0];
+				return _memberNames[0];
 			default:
-				return string.Join(ValidatorOptions.Global.PropertyChainSeparator, this);
+				return string.Join(ValidatorOptions.Global.PropertyChainSeparator, _memberNames);
 		}
 	}
 
@@ -150,7 +150,7 @@ public class PropertyChain : List<string> {
 	/// Builds a property path.
 	/// </summary>
 	public string BuildPropertyPath(string propertyName) {
-		if (Count == 0) {
+		if (_memberNames.Count == 0) {
 			return propertyName;
 		}
 
@@ -158,4 +158,9 @@ public class PropertyChain : List<string> {
 		chain.Add(propertyName);
 		return chain.ToString();
 	}
+
+	/// <summary>
+	/// Number of member names in the chain
+	/// </summary>
+	public int Count => _memberNames.Count;
 }

--- a/src/FluentValidation/Internal/PropertyChain.cs
+++ b/src/FluentValidation/Internal/PropertyChain.cs
@@ -26,8 +26,8 @@ using System.Reflection;
 /// <summary>
 /// Represents a chain of properties
 /// </summary>
-public class PropertyChain {
-	readonly List<string> _memberNames = new(2);
+public class PropertyChain : List<string> {
+	private List<string> _memberNames => this;
 
 	/// <summary>
 	/// Creates a new PropertyChain.
@@ -92,7 +92,7 @@ public class PropertyChain {
 	/// Adds a property name to the chain
 	/// </summary>
 	/// <param name="propertyName">Name of the property to add</param>
-	public void Add(string propertyName) {
+	public new void Add(string propertyName) {
 		if(!string.IsNullOrEmpty(propertyName))
 			_memberNames.Add(propertyName);
 	}
@@ -158,9 +158,4 @@ public class PropertyChain {
 		chain.Add(propertyName);
 		return chain.ToString();
 	}
-
-	/// <summary>
-	/// Number of member names in the chain
-	/// </summary>
-	public int Count => _memberNames.Count;
 }

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -30,8 +30,6 @@ using System.Threading.Tasks;
 /// </summary>
 internal class PropertyRule<T, TProperty> : RuleBase<T, TProperty, TProperty>, IValidationRuleInternal<T, TProperty> {
 
-	private Func<ValidationContext<T>, string> _displayNameFunc;
-
 	public PropertyRule(MemberInfo member, Func<T, TProperty> propertyFunc, LambdaExpression expression, Func<CascadeMode> cascadeModeThunk, Type typeToValidate)
 		: base(member, propertyFunc, expression, cascadeModeThunk, typeToValidate) {
 	}
@@ -122,10 +120,6 @@ internal class PropertyRule<T, TProperty> : RuleBase<T, TProperty, TProperty>, I
 
 		var cascade = CascadeMode;
 		var totalFailures = context.Failures.Count;
-
-		if (_displayNameFunc == null) {
-			_displayNameFunc = GetDisplayName;
-		}
 
 		context.InitializeForPropertyValidator(propertyPath, _displayNameFunc, PropertyName);
 

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -30,6 +30,8 @@ using System.Threading.Tasks;
 /// </summary>
 internal class PropertyRule<T, TProperty> : RuleBase<T, TProperty, TProperty>, IValidationRuleInternal<T, TProperty> {
 
+	private Func<ValidationContext<T>, string> _displayNameFunc;
+
 	public PropertyRule(MemberInfo member, Func<T, TProperty> propertyFunc, LambdaExpression expression, Func<CascadeMode> cascadeModeThunk, Type typeToValidate)
 		: base(member, propertyFunc, expression, cascadeModeThunk, typeToValidate) {
 	}
@@ -115,10 +117,17 @@ internal class PropertyRule<T, TProperty> : RuleBase<T, TProperty, TProperty>, I
 			}
 		}
 
+		bool first = true;
+		TProperty propValue = default(TProperty);
+
 		var cascade = CascadeMode;
-		var accessor = new Lazy<TProperty>(() => PropertyFunc(context.InstanceToValidate), LazyThreadSafetyMode.None);
 		var totalFailures = context.Failures.Count;
-		context.InitializeForPropertyValidator(propertyPath, GetDisplayName, PropertyName);
+
+		if (_displayNameFunc == null) {
+			_displayNameFunc = GetDisplayName;
+		}
+
+		context.InitializeForPropertyValidator(propertyPath, _displayNameFunc, PropertyName);
 
 		// Invoke each validator and collect its results.
 		foreach (var component in Components) {
@@ -140,11 +149,16 @@ internal class PropertyRule<T, TProperty> : RuleBase<T, TProperty, TProperty>, I
 				}
 			}
 
-			bool valid = await component.ValidateAsync(context, accessor.Value, useAsync, cancellation);
+			if (first) {
+				first = false;
+				propValue = PropertyFunc(context.InstanceToValidate);
+			}
+
+			bool valid = await component.ValidateAsync(context, propValue, useAsync, cancellation);
 
 			if (!valid) {
-				PrepareMessageFormatterForValidationError(context, accessor.Value);
-				var failure = CreateValidationError(context, accessor.Value, component);
+				PrepareMessageFormatterForValidationError(context, propValue);
+				var failure = CreateValidationError(context, propValue, component);
 				context.Failures.Add(failure);
 			}
 

--- a/src/FluentValidation/Internal/RuleBase.cs
+++ b/src/FluentValidation/Internal/RuleBase.cs
@@ -38,6 +38,8 @@ internal abstract class RuleBase<T, TProperty, TValue> : IValidationRule<T, TVal
 	private string _displayName;
 	private Func<ValidationContext<T>, string> _displayNameFactory;
 
+	protected readonly Func<ValidationContext<T>, string> _displayNameFunc;
+
 	public List<RuleComponent<T, TValue>> Components => _components;
 
 	/// <inheritdoc />
@@ -140,6 +142,9 @@ internal abstract class RuleBase<T, TProperty, TValue> : IValidationRule<T, TVal
 		var containerType = typeof(T);
 		PropertyName = ValidatorOptions.Global.PropertyNameResolver(containerType, member, expression);
 		_displayNameFactory = context => ValidatorOptions.Global.DisplayNameResolver(containerType, member, expression);
+
+		// Performance: Cache the display name function to reduce allocations.
+		_displayNameFunc = GetDisplayName;
 	}
 
 	public void AddValidator(IPropertyValidator<T, TValue> validator) {

--- a/src/FluentValidation/Internal/RulesetValidatorSelector.cs
+++ b/src/FluentValidation/Internal/RulesetValidatorSelector.cs
@@ -13,6 +13,7 @@ public class RulesetValidatorSelector : IValidatorSelector {
 	readonly IEnumerable<string> _rulesetsToExecute;
 	public const string DefaultRuleSetName = "default";
 	public const string WildcardRuleSetName = "*";
+	internal static readonly string[] DefaultRuleSetNameInArray = new string[] { DefaultRuleSetName };
 
 	/// <summary>
 	/// Rule sets

--- a/src/FluentValidation/Internal/TrackingCollection.cs
+++ b/src/FluentValidation/Internal/TrackingCollection.cs
@@ -40,6 +40,8 @@ internal class TrackingCollection<T> : IEnumerable<T> {
 
 	public int Count => _innerCollection.Count;
 
+	public T this[int index] => _innerCollection[index];
+
 	public void Remove(T item) {
 		_innerCollection.Remove(item);
 	}

--- a/src/FluentValidation/Validators/EmptyValidator.cs
+++ b/src/FluentValidation/Validators/EmptyValidator.cs
@@ -30,13 +30,20 @@ public class EmptyValidator<T,TProperty> : PropertyValidator<T,TProperty> {
 	public override string Name => "EmptyValidator";
 
 	public override bool IsValid(ValidationContext<T> context, TProperty value) {
-		switch (value) {
-			case null:
-			case string s when string.IsNullOrWhiteSpace(s):
-			case ICollection {Count: 0}:
-			case Array {Length: 0}:
-			case IEnumerable e when !e.GetEnumerator().MoveNext():
-				return true;
+		if (value == null) {
+			return true;
+		}
+
+		if (value is string s) {
+			return string.IsNullOrWhiteSpace(s);
+		}
+
+		if (value is ICollection col) {
+			return col.Count == 0;
+		}
+
+		if (value is IEnumerable e) {
+			return !e.GetEnumerator().MoveNext();
 		}
 
 		return EqualityComparer<TProperty>.Default.Equals(value, default);

--- a/src/FluentValidation/Validators/NotEmptyValidator.cs
+++ b/src/FluentValidation/Validators/NotEmptyValidator.cs
@@ -42,7 +42,7 @@ public class NotEmptyValidator<T,TProperty> : PropertyValidator<T, TProperty>, I
 			}
 
 			if (value is IEnumerable e) {
-				return !e.GetEnumerator().MoveNext();
+				return e.GetEnumerator().MoveNext();
 			}
 
 			return !EqualityComparer<TProperty>.Default.Equals(value, default);

--- a/src/FluentValidation/Validators/NotEmptyValidator.cs
+++ b/src/FluentValidation/Validators/NotEmptyValidator.cs
@@ -29,23 +29,23 @@ public class NotEmptyValidator<T,TProperty> : PropertyValidator<T, TProperty>, I
 	public override string Name => "NotEmptyValidator";
 
 	public override bool IsValid(ValidationContext<T> context, TProperty value) {
-			if (value == null) {
-				return false;	
-			}
+		if (value == null) {
+			return false;
+		}
 
-			if (value is string s) {
-				return !string.IsNullOrWhiteSpace(s);
-			}
+		if (value is string s) {
+			return !string.IsNullOrWhiteSpace(s);
+		}
 
-			if (value is ICollection col) {
-				return col.Count > 0;
-			}
+		if (value is ICollection col) {
+			return col.Count > 0;
+		}
 
-			if (value is IEnumerable e) {
-				return e.GetEnumerator().MoveNext();
-			}
+		if (value is IEnumerable e) {
+			return e.GetEnumerator().MoveNext();
+		}
 
-			return !EqualityComparer<TProperty>.Default.Equals(value, default);
+		return !EqualityComparer<TProperty>.Default.Equals(value, default);
 	}
 
 	protected override string GetDefaultMessageTemplate(string errorCode) {

--- a/src/FluentValidation/Validators/NotEmptyValidator.cs
+++ b/src/FluentValidation/Validators/NotEmptyValidator.cs
@@ -29,16 +29,23 @@ public class NotEmptyValidator<T,TProperty> : PropertyValidator<T, TProperty>, I
 	public override string Name => "NotEmptyValidator";
 
 	public override bool IsValid(ValidationContext<T> context, TProperty value) {
-		switch (value) {
-			case null:
-			case string s when string.IsNullOrWhiteSpace(s):
-			case ICollection {Count: 0}:
-			case Array {Length: 0}:
-			case IEnumerable e when !e.GetEnumerator().MoveNext():
-				return false;
-		}
+			if (value == null) {
+				return false;	
+			}
 
-		return !EqualityComparer<TProperty>.Default.Equals(value, default);
+			if (value is string s) {
+				return !string.IsNullOrWhiteSpace(s);
+			}
+
+			if (value is ICollection col) {
+				return col.Count > 0;
+			}
+
+			if (value is IEnumerable e) {
+				return !e.GetEnumerator().MoveNext();
+			}
+
+			return !EqualityComparer<TProperty>.Default.Equals(value, default);
 	}
 
 	protected override string GetDefaultMessageTemplate(string errorCode) {


### PR DESCRIPTION
Even in the non failure case, FluentValidation has too many allocations. For the Customer example, single validation has 44 allocations, 2,172 bytes in total. This can be reduced to 10 allocations (including the Customer object), 604 bytes, 72% reduction.