### PR TITLE
Support caching root-level parameter expressions.

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,7 @@
-11.8.2 - 
+11.8.2 -
 Fix memory leak in NotEmptyValidator/EmptyValidator (#2174)
+Add support for caching root parameter expressions (eg RuleFor(x => x)) (#2168)
+Add builds for .net 8
 
 11.8.1 - 22 Nov 2023
 Fix unintentional behavioural changes in introduced in the previous release as part of #2158
@@ -34,7 +36,7 @@ Deprecated the ability to disable the root model null check via overriding Abstr
 Deprecated the Transform and TransformAsync methods (#2072)
 
 11.5.0 - 13 Feb 2023
-MemberNameValidatorSelector now supports wildcard indexes in property paths (#2056) 
+MemberNameValidatorSelector now supports wildcard indexes in property paths (#2056)
 Added overload of TestValidateAsync that accepts a context (#2052)
 Minor optimization to regex validator (#2035)
 Added Kazakh translations (#2036)

--- a/src/FluentValidation.Tests/AccessorCacheTests.cs
+++ b/src/FluentValidation.Tests/AccessorCacheTests.cs
@@ -51,6 +51,32 @@ public class AccessorCacheTests {
 	}
 
 	[Fact]
+	public void Gets_accessor_for_parameter_expression() {
+		Expression<Func<Person, Person>> expr1 = x => x;
+
+		var compiled1 = expr1.Compile();
+		var compiled2 = expr1.Compile();
+
+		Assert.NotEqual(compiled1, compiled2);
+
+		var compiled3 = AccessorCache<Person>.GetCachedAccessor(null, expr1);
+		var compiled4 = AccessorCache<Person>.GetCachedAccessor(null, expr1);
+
+		// Expression should have been cached.
+		Assert.Equal(compiled3, compiled4);
+
+		Expression<Func<Person, Person>> expr2 = x => x;
+		var compiled5 = AccessorCache<Person>.GetCachedAccessor(null, expr2);
+
+		// Technically a different expression, but for the same type, so should still be cached.
+		Assert.Equal(compiled3, compiled5);
+
+		// Different expression for a different type. Shouldn't try and cache and cast.
+		Expression<Func<Address, Address>> expr3 = x => x;
+		var compiled6 = AccessorCache<Address>.GetCachedAccessor(null, expr3);
+	}
+
+	[Fact]
 	public void Equality_comparison_check() {
 		Expression<Func<Person, string>> expr1 = x => x.Surname;
 		Expression<Func<Person, string>> expr2 = x => x.Surname;


### PR DESCRIPTION
Resolves #2168 