### PR TITLE
Register validators once per type

### DIFF
--- a/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
+++ b/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@
 namespace FluentValidation;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -92,14 +93,14 @@ public static class ServiceCollectionExtensions	{
 		bool shouldRegister = filter?.Invoke(scanResult) ?? true;
 		if (shouldRegister) {
 			//Register as interface
-			services.Add(
+			services.TryAddEnumerable(
 				new ServiceDescriptor(
 					serviceType: scanResult.InterfaceType,
 					implementationType: scanResult.ValidatorType,
 					lifetime: lifetime));
 
 			//Register as self
-			services.Add(
+			services.TryAdd(
 				new ServiceDescriptor(
 					serviceType: scanResult.ValidatorType,
 					implementationType: scanResult.ValidatorType,

--- a/src/FluentValidation.Tests/DependencyInjectionExtensions/ServiceCollectionExtensionsTests.cs
+++ b/src/FluentValidation.Tests/DependencyInjectionExtensions/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,80 @@
+﻿#region License
+// Copyright (c) .NET Foundation and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/FluentValidation/FluentValidation
+#endregion
+
+namespace FluentValidation.Tests.DependencyInjectionExtensions;
+
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Xunit;
+
+public class ServiceCollectionExtensionsTests {
+
+	[Fact]
+	public void Should_register_validators_as_individual_service_types() {
+		var services = new ServiceCollection().AddValidatorsFromAssemblyContaining(GetType(), filter: ValidatorsFromThisFile);
+
+		Assert.Single(services, service => service.ServiceType == typeof(FirstDummyValidator));
+		Assert.Single(services, service => service.ServiceType == typeof(SecondDummyValidator));
+	}
+
+	[Fact]
+	public void Should_register_validator_service_types_only_once() {
+		var services = new ServiceCollection().AddValidatorsFromAssemblyContaining(GetType(), filter: ValidatorsFromThisFile)
+																					.AddValidatorsFromAssemblyContaining(GetType(), filter: ValidatorsFromThisFile)
+																					.AddValidatorsFromAssemblyContaining(GetType(), filter: ValidatorsFromThisFile);
+
+		Assert.Single(services, service => service.ImplementationType == typeof(FirstDummyValidator) && service.ServiceType == typeof(FirstDummyValidator));
+	}
+
+	[Fact]
+	public void Should_register_validators_as_enumerable_interface_type() {
+		var services = new ServiceCollection().AddValidatorsFromAssemblyContaining(GetType(), filter: ValidatorsFromThisFile);
+
+		var validatorServices = services.Where(s => s.ServiceType == typeof(IValidator<DummyModel>));
+		Assert.Collection(validatorServices, first => {
+			Assert.Equal(typeof(FirstDummyValidator), first.ImplementationType);
+		}, second => {
+			Assert.Equal(typeof(SecondDummyValidator), second.ImplementationType);
+		});
+	}
+
+	[Fact]
+	public void Should_register_validators_as_enumerable_interface_type_only_once() {
+		var services = new ServiceCollection().AddValidatorsFromAssemblyContaining(GetType(), filter: ValidatorsFromThisFile)
+																					.AddValidatorsFromAssemblyContaining(GetType(), filter: ValidatorsFromThisFile)
+																					.AddValidatorsFromAssemblyContaining(GetType(), filter: ValidatorsFromThisFile);
+
+		var validatorServices = services.Where(s => s.ServiceType == typeof(IValidator<DummyModel>));
+		Assert.Collection(validatorServices, first => {
+			Assert.Equal(typeof(FirstDummyValidator), first.ImplementationType);
+		}, second => {
+			Assert.Equal(typeof(SecondDummyValidator), second.ImplementationType);
+		});
+	}
+
+	private bool ValidatorsFromThisFile(AssemblyScanner.AssemblyScanResult result) {
+		return result.ValidatorType == typeof(FirstDummyValidator)
+				|| result.ValidatorType == typeof(SecondDummyValidator);
+	}
+}
+
+public record DummyModel { }
+
+public class FirstDummyValidator : AbstractValidator<DummyModel> { }
+
+public class SecondDummyValidator : AbstractValidator<DummyModel> { }

--- a/src/FluentValidation.Tests/FluentValidation.Tests.csproj
+++ b/src/FluentValidation.Tests/FluentValidation.Tests.csproj
@@ -14,6 +14,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
@@ -22,7 +23,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FluentValidation\FluentValidation.csproj" />
+    <ProjectReference Include="..\FluentValidation.DependencyInjectionExtensions\FluentValidation.DependencyInjectionExtensions.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="TestMessages.Designer.cs">


### PR DESCRIPTION
Fixes #2182 

A few thoughts on that:
- I wrote unit tests, but had to reference `FluentValidation.DependencyInjectionExtensions.csproj` from the test project to not create a whole new project for one test class. But feel free to move it around as you like.
- Creating `ServiceCollection`s to test the behavior required a new package reference on `Microsoft.Extensions.DependencyInjection`. I referenced the newest version of that package (8.0.0), as it is compatible with netstandard2.0. This does not reflect the runtime environments of projects targeting .NET 6 or .NET 7, as corresponding versions of that package would be used by an enclosing framework version. But since it likely doesn't make a difference and to maintain readability, I didn't include the conditional TFM-madness in the project file. If that is desired, just ping me and I will submit it later.
- I tried to adhere to the coding style, naming and formatting that I saw. But also feel free to reformat as you like.