### PR TITLE
 Add overloading for WithErrorCode() method to be compatible with lambda function

### DIFF
--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -164,7 +164,21 @@ public static class DefaultValidatorOptions {
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithErrorCode<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string errorCode) {
 		errorCode.Guard("A error code must be specified when calling WithErrorCode.", nameof(errorCode));
-		Configurable(rule).Current.ErrorCode = errorCode;
+		Configurable(rule).Current.SetErrorCode(errorCode);
+		return rule;
+	}
+
+	/// <summary>
+	/// Specifies a custom error code to use if validation fails.
+	/// </summary>
+	/// <param name="rule">The current rule</param>
+	/// <param name="codeProvider">Delegate that will be invoked to retrieve the localized code. </param>
+	/// <returns></returns>
+	public static IRuleBuilderOptions<T, TProperty> WithErrorCode<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, string> codeProvider) {
+		codeProvider.Guard("A codeProvider must be provided.", nameof(codeProvider));
+		Configurable(rule).Current.SetErrorCode((ctx, val) => {
+			return codeProvider(ctx == null ? default : ctx.InstanceToValidate);
+		});
 		return rule;
 	}
 

--- a/src/FluentValidation/Internal/IRuleComponent.cs
+++ b/src/FluentValidation/Internal/IRuleComponent.cs
@@ -29,10 +29,6 @@ using Validators;
 /// An individual component within a rule with a validator attached.
 /// </summary>
 public interface IRuleComponent<T, out TProperty> : IRuleComponent {
-	/// <summary>
-	/// The error code associated with this rule component.
-	/// </summary>
-	new string ErrorCode { get; set; }
 
 	/// <summary>
 	/// Function used to retrieve custom state for the validator
@@ -59,14 +55,26 @@ public interface IRuleComponent<T, out TProperty> : IRuleComponent {
 	/// <summary>
 	/// Sets the overridden error message template for this validator.
 	/// </summary>
-	/// <param name="errorFactory">A function for retrieving the error message template.</param>
-	void SetErrorMessage(Func<ValidationContext<T>, TProperty, string> errorFactory);
+	/// <param name="errorMessageFactory">A function for retrieving the error message template.</param>
+	void SetErrorMessage(Func<ValidationContext<T>, TProperty, string> errorMessageFactory);
 
 	/// <summary>
 	/// Sets the overridden error message template for this validator.
 	/// </summary>
 	/// <param name="errorMessage">The error message to set</param>
 	void SetErrorMessage(string errorMessage);
+
+	/// <summary>
+	/// Sets the overridden error code template for this validator.
+	/// </summary>
+	/// <param name="errorCodeFactory">A function for retrieving the error code template.</param>
+	void SetErrorCode(Func<ValidationContext<T>, TProperty, string> errorCodeFactory);
+
+	/// <summary>
+	/// Sets the overridden error code template for this validator.
+	/// </summary>
+	/// <param name="errorCode">The error code to set</param>
+	void SetErrorCode(string errorCode);
 }
 
 /// <summary>
@@ -93,9 +101,4 @@ public interface IRuleComponent {
 	/// </summary>
 	/// <returns></returns>
 	string GetUnformattedErrorMessage();
-
-	/// <summary>
-	/// The error code associated with this rule component.
-	/// </summary>
-	string ErrorCode { get; }
 }

--- a/src/FluentValidation/Internal/RuleBase.cs
+++ b/src/FluentValidation/Internal/RuleBase.cs
@@ -321,7 +321,7 @@ internal abstract class RuleBase<T, TProperty, TValue> : IValidationRule<T, TVal
 		var failure = new ValidationFailure(context.PropertyPath, error, value);
 
 		failure.FormattedMessagePlaceholderValues = new Dictionary<string, object>(context.MessageFormatter.PlaceholderValues);
-		failure.ErrorCode = component.ErrorCode ?? ValidatorOptions.Global.ErrorCodeResolver(component.Validator);
+		failure.ErrorCode = component.GetErrorCode(context, value) ?? ValidatorOptions.Global.ErrorCodeResolver(component.Validator);
 
 		failure.Severity = component.SeverityProvider != null
 			? component.SeverityProvider(context, value)

--- a/src/FluentValidation/Internal/RuleComponent.cs
+++ b/src/FluentValidation/Internal/RuleComponent.cs
@@ -207,14 +207,14 @@ public class RuleComponent<T, TProperty> : IRuleComponent<T, TProperty> {
 				_errorMessageFactory = null;
 		}
 
-	/// <summary>
-	/// Gets the error code. If a context is supplied, it will be used to format the code.
-	/// If no context is supplied, the raw unformatted code will be returned.
-	/// </summary>
-	/// <param name="context">The validation context.</param>
-	/// <param name="value">The current property value.</param>
-	/// <returns></returns>
-	public string GetErrorCode(ValidationContext<T> context, TProperty value) {
+		/// <summary>
+		/// Gets the error code. If a context is supplied, it will be used to format the code.
+		/// If no context is supplied, the raw unformatted code will be returned.
+		/// </summary>
+		/// <param name="context">The validation context.</param>
+		/// <param name="value">The current property value.</param>
+		/// <returns></returns>
+		public string GetErrorCode(ValidationContext<T> context, TProperty value) {
 				return _errorCodeFactory?.Invoke(context, value) ?? _errorCode;
 		}
 

--- a/src/FluentValidation/Internal/RuleComponent.cs
+++ b/src/FluentValidation/Internal/RuleComponent.cs
@@ -30,183 +30,209 @@ using Validators;
 /// In a rule definition such as RuleFor(x => x.Name).NotNull().NotEqual("Foo")
 /// the NotNull and the NotEqual are both rule components.
 /// </summary>
-public class RuleComponent<T,TProperty> : IRuleComponent<T,TProperty> {
-	private string _errorMessage;
-	private Func<ValidationContext<T>, TProperty, string> _errorMessageFactory;
-	private Func<ValidationContext<T>, bool> _condition;
-	private Func<ValidationContext<T>, CancellationToken, Task<bool>> _asyncCondition;
-	private readonly IPropertyValidator<T, TProperty> _propertyValidator;
-	private readonly IAsyncPropertyValidator<T, TProperty> _asyncPropertyValidator;
+public class RuleComponent<T, TProperty> : IRuleComponent<T, TProperty> {
+		private string _errorMessage;
+		private Func<ValidationContext<T>, TProperty, string> _errorMessageFactory;
+		private string _errorCode;
+		private Func<ValidationContext<T>, TProperty, string> _errorCodeFactory;
+		private Func<ValidationContext<T>, bool> _condition;
+		private Func<ValidationContext<T>, CancellationToken, Task<bool>> _asyncCondition;
+		private readonly IPropertyValidator<T, TProperty> _propertyValidator;
+		private readonly IAsyncPropertyValidator<T, TProperty> _asyncPropertyValidator;
 
-	internal RuleComponent(IPropertyValidator<T, TProperty> propertyValidator) {
-		_propertyValidator = propertyValidator;
-	}
-
-	internal RuleComponent(IAsyncPropertyValidator<T, TProperty> asyncPropertyValidator, IPropertyValidator<T, TProperty> propertyValidator) {
-		_asyncPropertyValidator = asyncPropertyValidator;
-		_propertyValidator = propertyValidator;
-	}
-
-	/// <inheritdoc />
-	public bool HasCondition => _condition != null;
-
-	/// <inheritdoc />
-	public bool HasAsyncCondition => _asyncCondition != null;
-
-	/// <inheritdoc />
-	public virtual IPropertyValidator Validator
-		=> (IPropertyValidator) _propertyValidator ?? _asyncPropertyValidator;
-
-	private protected virtual bool SupportsAsynchronousValidation
-		=> _asyncPropertyValidator != null;
-
-	private protected virtual bool SupportsSynchronousValidation
-		=> _propertyValidator != null;
-
-	internal async ValueTask<bool> ValidateAsync(ValidationContext<T> context, TProperty value, bool useAsync, CancellationToken cancellation) {
-		if (useAsync) {
-			// If ValidateAsync has been called on the root validator, then always prefer
-			// the asynchronous property validator (if available).
-			if (SupportsAsynchronousValidation) {
-				return await InvokePropertyValidatorAsync(context, value, cancellation);
-			}
-
-			// If it doesn't support Async validation, then this means
-			// the property validator is a Synchronous.
-			// We don't need to explicitly check SupportsSynchronousValidation.
-			return InvokePropertyValidator(context, value);
+		internal RuleComponent(IPropertyValidator<T, TProperty> propertyValidator) {
+				_propertyValidator = propertyValidator;
 		}
 
-		// If Validate has been called on the root validator, then always prefer
-		// the synchronous property validator.
-		if (SupportsSynchronousValidation) {
-			return InvokePropertyValidator(context, value);
+		internal RuleComponent(IAsyncPropertyValidator<T, TProperty> asyncPropertyValidator, IPropertyValidator<T, TProperty> propertyValidator) {
+				_asyncPropertyValidator = asyncPropertyValidator;
+				_propertyValidator = propertyValidator;
 		}
 
-		// Root Validator invoked synchronously, but the property validator
-		// only supports asynchronous invocation.
-		throw new AsyncValidatorInvokedSynchronouslyException();
-	}
+		/// <inheritdoc />
+		public bool HasCondition => _condition != null;
 
-	private protected virtual bool InvokePropertyValidator(ValidationContext<T> context, TProperty value)
-		=> _propertyValidator.IsValid(context, value);
+		/// <inheritdoc />
+		public bool HasAsyncCondition => _asyncCondition != null;
 
-	private protected virtual Task<bool> InvokePropertyValidatorAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation)
-		=> _asyncPropertyValidator.IsValidAsync(context, value, cancellation);
+		/// <inheritdoc />
+		public virtual IPropertyValidator Validator
+			=> (IPropertyValidator)_propertyValidator ?? _asyncPropertyValidator;
+
+		private protected virtual bool SupportsAsynchronousValidation
+			=> _asyncPropertyValidator != null;
+
+		private protected virtual bool SupportsSynchronousValidation
+			=> _propertyValidator != null;
+
+		internal async ValueTask<bool> ValidateAsync(ValidationContext<T> context, TProperty value, bool useAsync, CancellationToken cancellation) {
+				if (useAsync) {
+						// If ValidateAsync has been called on the root validator, then always prefer
+						// the asynchronous property validator (if available).
+						if (SupportsAsynchronousValidation) {
+								return await InvokePropertyValidatorAsync(context, value, cancellation);
+						}
+
+						// If it doesn't support Async validation, then this means
+						// the property validator is a Synchronous.
+						// We don't need to explicitly check SupportsSynchronousValidation.
+						return InvokePropertyValidator(context, value);
+				}
+
+				// If Validate has been called on the root validator, then always prefer
+				// the synchronous property validator.
+				if (SupportsSynchronousValidation) {
+						return InvokePropertyValidator(context, value);
+				}
+
+				// Root Validator invoked synchronously, but the property validator
+				// only supports asynchronous invocation.
+				throw new AsyncValidatorInvokedSynchronouslyException();
+		}
+
+		private protected virtual bool InvokePropertyValidator(ValidationContext<T> context, TProperty value)
+			=> _propertyValidator.IsValid(context, value);
+
+		private protected virtual Task<bool> InvokePropertyValidatorAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation)
+			=> _asyncPropertyValidator.IsValidAsync(context, value, cancellation);
+
+		/// <summary>
+		/// Adds a condition for this validator. If there's already a condition, they're combined together with an AND.
+		/// </summary>
+		/// <param name="condition"></param>
+		public void ApplyCondition(Func<ValidationContext<T>, bool> condition) {
+				if (_condition == null) {
+						_condition = condition;
+				}
+				else {
+						var original = _condition;
+						_condition = ctx => condition(ctx) && original(ctx);
+				}
+		}
+
+		/// <summary>
+		/// Adds a condition for this validator. If there's already a condition, they're combined together with an AND.
+		/// </summary>
+		/// <param name="condition"></param>
+		public void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, Task<bool>> condition) {
+				if (_asyncCondition == null) {
+						_asyncCondition = condition;
+				}
+				else {
+						var original = _asyncCondition;
+						_asyncCondition = async (ctx, ct) => await condition(ctx, ct) && await original(ctx, ct);
+				}
+		}
+
+		internal bool InvokeCondition(ValidationContext<T> context) {
+				if (_condition != null) {
+						return _condition(context);
+				}
+
+				return true;
+		}
+
+		internal async Task<bool> InvokeAsyncCondition(ValidationContext<T> context, CancellationToken token) {
+				if (_asyncCondition != null) {
+						return await _asyncCondition(context, token);
+				}
+
+				return true;
+		}
+
+		/// <summary>
+		/// Function used to retrieve custom state for the validator
+		/// </summary>
+		public Func<ValidationContext<T>, TProperty, object> CustomStateProvider { get; set; }
+
+		/// <summary>
+		/// Function used to retrieve the severity for the validator
+		/// </summary>
+		public Func<ValidationContext<T>, TProperty, Severity> SeverityProvider { get; set; }
+
+		/// <summary>
+		/// Gets the error message. If a context is supplied, it will be used to format the message if it has placeholders.
+		/// If no context is supplied, the raw unformatted message will be returned, containing placeholders.
+		/// </summary>
+		/// <param name="context">The validation context.</param>
+		/// <param name="value">The current property value.</param>
+		/// <returns>Either the formatted or unformatted error message.</returns>
+		public string GetErrorMessage(ValidationContext<T> context, TProperty value) {
+				// Use a custom message if one has been specified.
+				string rawTemplate = _errorMessageFactory?.Invoke(context, value) ?? _errorMessage;
+
+
+				// If no custom message has been supplied, use the default.
+				if (rawTemplate == null) {
+						rawTemplate = Validator.GetDefaultMessageTemplate(GetErrorCode(context, value));
+				}
+
+				if (context == null) {
+						return rawTemplate;
+				}
+
+				return context.MessageFormatter.BuildMessage(rawTemplate);
+		}
+
+		/// <summary>
+		/// Gets the raw unformatted error message. Placeholders will not have been rewritten.
+		/// </summary>
+		/// <returns></returns>
+		public string GetUnformattedErrorMessage() {
+				string message = _errorMessageFactory?.Invoke(null, default) ?? _errorMessage;
+
+				// If no custom message has been supplied, use the default.
+				if (message == null) {
+						message = Validator.GetDefaultMessageTemplate(GetErrorCode(null, default));
+				}
+
+				return message;
+		}
+
+		/// <summary>
+		/// Sets the overridden error message template for this validator.
+		/// </summary>
+		/// <param name="errorMessageFactory">A function for retrieving the error message template.</param>
+		public void SetErrorMessage(Func<ValidationContext<T>, TProperty, string> errorMessageFactory) {
+				_errorMessageFactory = errorMessageFactory;
+				_errorMessage = null;
+		}
+
+		/// <summary>
+		/// Sets the overridden error message template for this validator.
+		/// </summary>
+		/// <param name="errorMessage">The error message to set</param>
+		public void SetErrorMessage(string errorMessage) {
+				_errorMessage = errorMessage;
+				_errorMessageFactory = null;
+		}
 
 	/// <summary>
-	/// Adds a condition for this validator. If there's already a condition, they're combined together with an AND.
-	/// </summary>
-	/// <param name="condition"></param>
-	public void ApplyCondition(Func<ValidationContext<T>, bool> condition) {
-		if (_condition == null) {
-			_condition = condition;
-		}
-		else {
-			var original = _condition;
-			_condition = ctx => condition(ctx) && original(ctx);
-		}
-	}
-
-	/// <summary>
-	/// Adds a condition for this validator. If there's already a condition, they're combined together with an AND.
-	/// </summary>
-	/// <param name="condition"></param>
-	public void ApplyAsyncCondition(Func<ValidationContext<T>, CancellationToken, Task<bool>> condition) {
-		if (_asyncCondition == null) {
-			_asyncCondition = condition;
-		}
-		else {
-			var original = _asyncCondition;
-			_asyncCondition = async (ctx, ct) => await condition(ctx, ct) && await original(ctx, ct);
-		}
-	}
-
-	internal bool InvokeCondition(ValidationContext<T> context) {
-		if (_condition != null) {
-			return _condition(context);
-		}
-
-		return true;
-	}
-
-	internal async Task<bool> InvokeAsyncCondition(ValidationContext<T> context, CancellationToken token) {
-		if (_asyncCondition != null) {
-			return await _asyncCondition(context, token);
-		}
-
-		return true;
-	}
-
-	/// <summary>
-	/// Function used to retrieve custom state for the validator
-	/// </summary>
-	public Func<ValidationContext<T>, TProperty, object> CustomStateProvider { get; set; }
-
-	/// <summary>
-	/// Function used to retrieve the severity for the validator
-	/// </summary>
-	public Func<ValidationContext<T>, TProperty, Severity> SeverityProvider { get; set; }
-
-	/// <summary>
-	/// Retrieves the error code.
-	/// </summary>
-	public string ErrorCode { get; set; }
-
-	/// <summary>
-	/// Gets the error message. If a context is supplied, it will be used to format the message if it has placeholders.
-	/// If no context is supplied, the raw unformatted message will be returned, containing placeholders.
+	/// Gets the error code. If a context is supplied, it will be used to format the code.
+	/// If no context is supplied, the raw unformatted code will be returned.
 	/// </summary>
 	/// <param name="context">The validation context.</param>
 	/// <param name="value">The current property value.</param>
-	/// <returns>Either the formatted or unformatted error message.</returns>
-	public string GetErrorMessage(ValidationContext<T> context, TProperty value) {
-		// Use a custom message if one has been specified.
-		string rawTemplate = _errorMessageFactory?.Invoke(context, value) ?? _errorMessage;
-
-
-		// If no custom message has been supplied, use the default.
-		if (rawTemplate == null) {
-			rawTemplate = Validator.GetDefaultMessageTemplate(ErrorCode);
-		}
-
-		if (context == null) {
-			return rawTemplate;
-		}
-
-		return context.MessageFormatter.BuildMessage(rawTemplate);
-	}
-
-	/// <summary>
-	/// Gets the raw unformatted error message. Placeholders will not have been rewritten.
-	/// </summary>
 	/// <returns></returns>
-	public string GetUnformattedErrorMessage() {
-		string message = _errorMessageFactory?.Invoke(null, default) ?? _errorMessage;
-
-		// If no custom message has been supplied, use the default.
-		if (message == null) {
-			message = Validator.GetDefaultMessageTemplate(ErrorCode);
+	public string GetErrorCode(ValidationContext<T> context, TProperty value) {
+				return _errorCodeFactory?.Invoke(context, value) ?? _errorCode;
 		}
 
-		return message;
-	}
+		/// <summary>
+		/// Sets the overridden error code template for this validator.
+		/// </summary>
+		/// <param name="errorCodeFactory">A function for retrieving the error code template.</param>
+		public void SetErrorCode(Func<ValidationContext<T>, TProperty, string> errorCodeFactory) {
+				_errorCode = null;
+				_errorCodeFactory = errorCodeFactory;
+		}
 
-	/// <summary>
-	/// Sets the overridden error message template for this validator.
-	/// </summary>
-	/// <param name="errorFactory">A function for retrieving the error message template.</param>
-	public void SetErrorMessage(Func<ValidationContext<T>, TProperty, string> errorFactory) {
-		_errorMessageFactory = errorFactory;
-		_errorMessage = null;
-	}
-
-	/// <summary>
-	/// Sets the overridden error message template for this validator.
-	/// </summary>
-	/// <param name="errorMessage">The error message to set</param>
-	public void SetErrorMessage(string errorMessage) {
-		_errorMessage = errorMessage;
-		_errorMessageFactory = null;
-	}
+		/// <summary>
+		/// Sets the overridden error code template for this validator.
+		/// </summary>
+		/// <param name="errorCode">The error code to set</param>
+		public void SetErrorCode(string errorCode) {
+				_errorCode = errorCode;
+				_errorCodeFactory = null;
+		}
 }

--- a/src/FluentValidation/Validators/AsyncPredicateValidator.cs
+++ b/src/FluentValidation/Validators/AsyncPredicateValidator.cs
@@ -38,7 +38,7 @@ public class AsyncPredicateValidator<T,TProperty> : AsyncPropertyValidator<T,TPr
 	/// <param name="predicate"></param>
 	public AsyncPredicateValidator(Func<T, TProperty, ValidationContext<T>, CancellationToken, Task<bool>> predicate) {
 		predicate.Guard("A predicate must be specified.", nameof(predicate));
-		this._predicate = predicate;
+		_predicate = predicate;
 	}
 
 	public override Task<bool> IsValidAsync(ValidationContext<T> context, TProperty value, CancellationToken cancellation) {


### PR DESCRIPTION
I added an overload to the WithErrorCode() method, similar to the WithMessage() method, which accepts a lambda function Func<T, string>.
I needed that to use custom runtime error codes through lambda functions.