### PR TITLE
Update localization.md

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -4,6 +4,11 @@ Out of the box, FluentValidation provides translations for the default validatio
 
 You can also use the `WithMessage` and `WithLocalizedMessage` methods to specify a localized error message for a single validation rule.
 
+```eval_rst
+.. note::
+  You may need to add "<InvariantGlobalization>false</InvariantGlobalization>" to your project's .csproj file, inside the <PropertyGroup></PropertyGroup> section.
+```
+
 ### WithMessage
 If you are using Visual Studio's built in support for `.resx` files and their strongly-typed wrappers, then you can localize a message by calling the overload of `WithMessage` that accepts a lambda expression:
 


### PR DESCRIPTION
When <InvariantGlobalization></InvariantGlobalization> is set to true and using ValidatorOptions.Global.LanguageManager.Culture = new System.Globalization.CultureInfo("en-US"); or other CultureInfo codes, the application throws exception "Unhandled exception. System.Globalization.CultureNotFoundException: Only the invariant culture is supported in globalization-invariant mode. See https://aka.ms/GlobalizationInvariantMode for more information. (Parameter 'name') en-US is an invalid culture identifier." Changing <InvariantGlobalization></InvariantGlobalization> to true solves the problem.