### PR TITLE
Compile _expressionDebugView on #DEBUG only.

### DIFF
--- a/src/FluentValidation/Internal/AccessorCache.cs
+++ b/src/FluentValidation/Internal/AccessorCache.cs
@@ -32,7 +32,7 @@ public static class AccessorCache<T> {
 			// If the expression doesn't reference a property we don't support
 			// caching it, The only exception is parameter expressions referencing the same object (eg RuleFor(x => x))
 			if (expression.IsParameterExpression() && typeof(T) == typeof(TProperty)) {
-				key = new Key(typeof(T), null, expression, typeof(T).FullName + ":" + cachePrefix);
+				key = new Key(null, expression, typeof(T).FullName + ":" + cachePrefix);
 			}
 			else {
 				// Unsupported expression type. Non cacheable.
@@ -40,7 +40,7 @@ public static class AccessorCache<T> {
 			}
 		}
 		else {
-			key = new Key(typeof(T), member, expression, cachePrefix);
+			key = new Key(member, expression, cachePrefix);
 		}
 #if NET5_0_OR_GREATER
 		return (Func<T,TProperty>)_cache.GetOrAdd(key, static (_, exp) => exp.Compile(), expression);
@@ -54,15 +54,13 @@ public static class AccessorCache<T> {
 	}
 
 	private class Key {
-		private readonly Type _type;
 		private readonly MemberInfo _memberInfo;
 		private readonly string _expressionString;
 #if DEBUG
 		private readonly string _expressionDebugView;
 #endif
 
-		public Key(Type type, MemberInfo member, Expression expression, string cachePrefix) {
-			_type = type;
+		public Key(MemberInfo member, Expression expression, string cachePrefix) {
 			_memberInfo = member;
 			_expressionString = expression.ToString();
 #if DEBUG
@@ -71,7 +69,7 @@ public static class AccessorCache<T> {
 		}
 
 		private bool Equals(Key other) {
-			return _type == other._type && Equals(_memberInfo, other._memberInfo) && string.Equals(_expressionString, other._expressionString);
+			return Equals(_memberInfo, other._memberInfo) && string.Equals(_expressionString, other._expressionString);
 		}
 
 		public override bool Equals(object obj) {
@@ -85,8 +83,7 @@ public static class AccessorCache<T> {
 			unchecked {
 				unchecked
 				{
-					var hashCode = (_type != null ? _type.GetHashCode() : 0);
-					hashCode = (hashCode * 397) ^ (_memberInfo != null ? _memberInfo.GetHashCode() : 0);
+					var hashCode = (_memberInfo != null ? _memberInfo.GetHashCode() : 0);
 					hashCode = (hashCode * 397) ^ (_expressionString != null ? _expressionString.GetHashCode() : 0);
 					return hashCode;
 				}

--- a/src/FluentValidation/Internal/AccessorCache.cs
+++ b/src/FluentValidation/Internal/AccessorCache.cs
@@ -52,15 +52,22 @@ public static class AccessorCache<T> {
 
 	private class Key {
 		private readonly MemberInfo _memberInfo;
+#if DEBUG
 		private readonly string _expressionDebugView;
-
+#endif
 		public Key(MemberInfo member, Expression expression, string cachePrefix) {
 			_memberInfo = member;
+#if DEBUG
 			_expressionDebugView = cachePrefix != null ? cachePrefix + expression.ToString() : expression.ToString();
+#endif
 		}
 
-		protected bool Equals(Key other) {
-			return Equals(_memberInfo, other._memberInfo) && string.Equals(_expressionDebugView, other._expressionDebugView);
+		private bool Equals(Key other) {
+			return Equals(_memberInfo, other._memberInfo)
+#if DEBUG
+			       && string.Equals(_expressionDebugView, other._expressionDebugView)
+#endif
+			       ;
 		}
 
 		public override bool Equals(object obj) {
@@ -72,7 +79,11 @@ public static class AccessorCache<T> {
 
 		public override int GetHashCode() {
 			unchecked {
-				return ((_memberInfo != null ? _memberInfo.GetHashCode() : 0)*397) ^ (_expressionDebugView != null ? _expressionDebugView.GetHashCode() : 0);
+				return ((_memberInfo != null ? _memberInfo.GetHashCode() : 0)*397)
+#if DEBUG
+				       ^ (_expressionDebugView != null ? _expressionDebugView.GetHashCode() : 0)
+#endif
+;
 			}
 		}
 	}


### PR DESCRIPTION
`_expressionDebugView` seems to be for debugging purposes only. `#DEBUG` has been added around it so caching can be reused between collection and non-collection accesses.