### PR TITLE
Issue 2211. ScalePrecisionValidator error message clarification.

### DIFF
--- a/docs/built-in-validators.md
+++ b/docs/built-in-validators.md
@@ -454,6 +454,6 @@ Example:
 - When `ignoreTrailingZeros` is `false` then the decimal `123.4500` will be considered to have a precision of 7 and scale of 4
 - When `ignoreTrailingZeros` is `true` then the decimal `123.4500` will be considered to have a precision of 5 and scale of 2. 
 
-Please also note that this method impones certain range of values that will be accepted. For example in case of `.PrecisionScale(3, 1)`, the method will accept values between `-99.9` and `99.9`, inclusive. Which means that integer part is always controlled to contain at most `3 - 1` digits, independently from `ignoreTrailingZeros` parameter.
+Please also note that this method implies certain range of values that will be accepted. For example in case of `.PrecisionScale(3, 1)`, the method will accept values between `-99.9` and `99.9`, inclusive. Which means that integer part is always controlled to contain at most `3 - 1` digits, independently from `ignoreTrailingZeros` parameter.
 
 Note that prior to FluentValidation 11.4, this method was called `ScalePrecision` instead and had its parameters reversed. For more details [see this GitHub issue](https://github.com/FluentValidation/FluentValidation/issues/2030)

--- a/docs/built-in-validators.md
+++ b/docs/built-in-validators.md
@@ -454,4 +454,6 @@ Example:
 - When `ignoreTrailingZeros` is `false` then the decimal `123.4500` will be considered to have a precision of 7 and scale of 4
 - When `ignoreTrailingZeros` is `true` then the decimal `123.4500` will be considered to have a precision of 5 and scale of 2. 
 
-Note that prior to FluentValidation 11.4, this this method was called `ScalePrecision` instead and had its parameters reversed. For more details [see this GitHub issue](https://github.com/FluentValidation/FluentValidation/issues/2030)
+Please also note that this method impones certain range of values that will be accepted. For example in case of `.PrecisionScale(3, 1)`, the method will accept values between `-99.9` and `99.9`, inclusive. Which means that integer part is always controlled to contain at most `3 - 1` digits, independently from `ignoreTrailingZeros` parameter.
+
+Note that prior to FluentValidation 11.4, this method was called `ScalePrecision` instead and had its parameters reversed. For more details [see this GitHub issue](https://github.com/FluentValidation/FluentValidation/issues/2030)

--- a/src/FluentValidation.Tests/ScalePrecisionValidatorTests.cs
+++ b/src/FluentValidation.Tests/ScalePrecisionValidatorTests.cs
@@ -71,31 +71,31 @@ public class ScalePrecisionValidatorTests {
 
 		var result = validator.Validate(new Person { Discount = 123.456778m });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 3 digits and 6 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 9 digits and 6 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 12.3414M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 2 digits and 4 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 6 digits and 4 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 1.344M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 1 digits and 3 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 4 digits and 3 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 156.3M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 3 digits and 1 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 5 digits and 2 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 65.430M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 2 digits and 3 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 5 digits and 3 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 0.003M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 0 digits and 3 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 4 digits and 3 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 0.030303M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 0 digits and 6 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 7 digits and 6 decimals were found.");
 	}
 
 	[Fact]
@@ -104,23 +104,23 @@ public class ScalePrecisionValidatorTests {
 
 		var result = validator.Validate(new Person { NullableDiscount = 123.456778m });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 3 digits and 6 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 9 digits and 6 decimals were found.");
 
 		result = validator.Validate(new Person { NullableDiscount = 12.3414M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 2 digits and 4 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 6 digits and 4 decimals were found.");
 
 		result = validator.Validate(new Person { NullableDiscount = 1.344M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 1 digits and 3 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 4 digits and 3 decimals were found.");
 
 		result = validator.Validate(new Person { NullableDiscount = 156.3M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 3 digits and 1 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 5 digits and 2 decimals were found.");
 
 		result = validator.Validate(new Person { NullableDiscount = 65.430M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 2 digits and 3 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 5 digits and 3 decimals were found.");
 	}
 
 	[Fact]
@@ -146,23 +146,23 @@ public class ScalePrecisionValidatorTests {
 
 		var result = validator.Validate(new Person { Discount = 123.456778m });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 3 digits and 6 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 9 digits and 6 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 0.341M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 0 digits and 3 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 4 digits and 3 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 0.041M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 0 digits and 3 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 4 digits and 3 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 1.34M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 1 digits and 2 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 3 digits and 2 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 1M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 1 digits and 0 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 2 digits in total, with allowance for 2 decimals. 3 digits and 2 decimals were found.");
 	}
 
 	[Fact]
@@ -185,10 +185,10 @@ public class ScalePrecisionValidatorTests {
 
 		var result = validator.Validate(new Person { Discount = 1565.0M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 4 digits and 0 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 6 digits and 2 decimals were found.");
 
 		result = validator.Validate(new Person { Discount = 15.0000000000000000000000001M });
 		result.IsValid.ShouldBeFalse();
-		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 2 digits and 25 decimals were found.");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Discount' must not be more than 4 digits in total, with allowance for 2 decimals. 27 digits and 25 decimals were found.");
 	}
 }

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1097,7 +1097,7 @@ public static partial class DefaultValidatorExtensions {
 		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
 
 	/// <summary>
-	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale. It permits up to <b><see cref="precision"/> - <see cref="scale"/></b> digits to the left of the decimal point and up to <b><see cref="scale"/></b> digits to the right.
+	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale. It permits up to <b><paramref name="precision"/> - <paramref name="scale"/></b> digits to the left of the decimal point and up to <b><paramref name="scale"/></b> digits to the right.
 	/// </summary>
 	/// <typeparam name="T">Type of object being validated</typeparam>
 	/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
@@ -1109,7 +1109,7 @@ public static partial class DefaultValidatorExtensions {
 		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
 
 	/// <summary>
-	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale. It permits up to <b><see cref="precision"/> - <see cref="scale"/></b> digits to the left of the decimal point and up to <b><see cref="scale"/></b> digits to the right.
+	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale. It permits up to <b><paramref name="precision"/> - <paramref name="scale"/></b> digits to the left of the decimal point and up to <b><paramref name="scale"/></b> digits to the right.
 	/// </summary>
 	/// <typeparam name="T">Type of object being validated</typeparam>
 	/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1097,7 +1097,7 @@ public static partial class DefaultValidatorExtensions {
 		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
 
 	/// <summary>
-	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale.
+	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale. It permits up to <b><see cref="precision"/> - <see cref="scale"/></b> digits to the left of the decimal point and up to <b><see cref="scale"/></b> digits to the right.
 	/// </summary>
 	/// <typeparam name="T">Type of object being validated</typeparam>
 	/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
@@ -1109,7 +1109,7 @@ public static partial class DefaultValidatorExtensions {
 		=> ruleBuilder.SetValidator(new ScalePrecisionValidator<T>(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
 
 	/// <summary>
-	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale.
+	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale. It permits up to <b><see cref="precision"/> - <see cref="scale"/></b> digits to the left of the decimal point and up to <b><see cref="scale"/></b> digits to the right.
 	/// </summary>
 	/// <typeparam name="T">Type of object being validated</typeparam>
 	/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>

--- a/src/FluentValidation/Resources/Languages/RussianLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/RussianLanguage.cs
@@ -45,7 +45,7 @@ internal class RussianLanguage {
 		"InclusiveBetweenValidator" => "'{PropertyName}' должно быть в диапазоне от {From} до {To}. Введенное значение: {PropertyValue}.",
 		"ExclusiveBetweenValidator" => "'{PropertyName}' должно быть в диапазоне от {From} до {To} (не включая эти значения). Введенное значение: {PropertyValue}.",
 		"CreditCardValidator" => "'{PropertyName}' неверный номер карты.",
-		"ScalePrecisionValidator" => "'{PropertyName}' должно содержать не более {ExpectedPrecision} цифр всего, в том числе {ExpectedScale} десятичных знака(ов). Введенное значение содержит {Digits} цифр(ы) в целой части и {ActualScale} десятичных знака(ов).",
+		"ScalePrecisionValidator" => "'{PropertyName}' должно содержать не более {ExpectedPrecision} цифр всего, в том числе {ExpectedScale} десятичных знака(ов). Введенное значение содержит {Digits} цифр(ы) и {ActualScale} десятичных знака(ов).",
 		"EmptyValidator" => "'{PropertyName}' должно быть пустым.",
 		"NullValidator" => "'{PropertyName}' должно быть пустым.",
 		"EnumValidator" => "'{PropertyName}' содержит недопустимое значение '{PropertyValue}'.",

--- a/src/FluentValidation/Validators/ScalePrecisionValidator.cs
+++ b/src/FluentValidation/Validators/ScalePrecisionValidator.cs
@@ -30,6 +30,9 @@ using System;
 /// Scale would be the number of digits to the right of the decimal point.
 /// Precision would be the number of digits. This number includes both the left and the right sides of the decimal point.
 ///
+/// It implies certain range of values that will be accepted by the validator.
+/// It permits up to Precision - Scale digits to the left of the decimal point and up to Scale digits to the right.
+///
 /// It can be configured to use the effective scale and precision
 /// (i.e. ignore trailing zeros) if required.
 ///


### PR DESCRIPTION
As described in issue #2211, clarified `PrecisionScale` validator behaviour in docs. Provided a workaround to avoid self contradictory error messages. Also noted inconsistent russian translation of error message in confront to other translations.