### PR TITLE
Update DefaultValidatorExtensions.cs (Added NotNullAndEmpty)

### DIFF
--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -75,7 +75,17 @@ public static partial class DefaultValidatorExtensions {
 	public static IRuleBuilderOptions<T, TProperty> NotNull<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder) {
 		return ruleBuilder.SetValidator(new NotNullValidator<T,TProperty>());
 	}
-
+        /// <summary>
+	/// Defines a 'not null' and 'not empty' validator on the current rule builder.
+	/// Validation will fail if the property is null.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <typeparam name="TProperty"></typeparam>
+	/// <param name="ruleBuilder"></param>
+	/// <returns></returns>
+	public static IRuleBuilderOptions<T, TProperty> NotNullAndEmpty<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder){
+    	   return ruleBuilder.NotNull().NotEmpty();
+	}
 	/// <summary>
 	/// Defines a 'null' validator on the current rule builder.
 	/// Validation will fail if the property is not null.


### PR DESCRIPTION
This commit introduces a new extension method NotNullAndEmpty for the IRuleBuilder in the validation framework. The method provides a convenient way to enforce both 'not null' and 'not empty' validation rules on properties.