### PR TITLE
make RuleFor [Pure]

### DIFF
--- a/src/FluentValidation.Tests/ForEachRuleTests.cs
+++ b/src/FluentValidation.Tests/ForEachRuleTests.cs
@@ -159,7 +159,7 @@ public class ForEachRuleTests {
 	[Fact]
 	public void Nested_collection_for_null_property_should_not_throw_null_reference() {
 		var validator = new InlineValidator<Request>();
-		validator.When(r => r.person != null, () => { validator.RuleForEach(x => x.person.NickNames).NotNull(); });
+		validator.When(r => r.person != null, () => { validator.RuleForEach(x => x.person.NickNames); });
 
 		var result = validator.Validate(new Request());
 		result.Errors.Count.ShouldEqual(0);

--- a/src/FluentValidation.Tests/ForEachRuleTests.cs
+++ b/src/FluentValidation.Tests/ForEachRuleTests.cs
@@ -159,7 +159,7 @@ public class ForEachRuleTests {
 	[Fact]
 	public void Nested_collection_for_null_property_should_not_throw_null_reference() {
 		var validator = new InlineValidator<Request>();
-		validator.When(r => r.person != null, () => { validator.RuleForEach(x => x.person.NickNames); });
+		validator.When(r => r.person != null, () => { validator.RuleForEach(x => x.person.NickNames).NotNull(); });
 
 		var result = validator.Validate(new Request());
 		result.Errors.Count.ShouldEqual(0);

--- a/src/FluentValidation/AbstractValidator.cs
+++ b/src/FluentValidation/AbstractValidator.cs
@@ -22,6 +22,7 @@ namespace FluentValidation;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -289,6 +290,7 @@ public abstract class AbstractValidator<T> : IValidator<T>, IEnumerable<IValidat
 	/// <typeparam name="TProperty">The type of property being validated</typeparam>
 	/// <param name="expression">The expression representing the property to validate</param>
 	/// <returns>an IRuleBuilder instance on which validators can be defined</returns>
+	[Pure]
 	public IRuleBuilderInitial<T, TProperty> RuleFor<TProperty>(Expression<Func<T, TProperty>> expression) {
 		expression.Guard("Cannot pass null to RuleFor", nameof(expression));
 		var rule = PropertyRule<T, TProperty>.Create(expression, () => RuleLevelCascadeMode);
@@ -344,6 +346,7 @@ public abstract class AbstractValidator<T> : IValidator<T>, IEnumerable<IValidat
 	/// <typeparam name="TElement">Type of property</typeparam>
 	/// <param name="expression">Expression representing the collection to validate</param>
 	/// <returns>An IRuleBuilder instance on which validators can be defined</returns>
+	[Pure]
 	public IRuleBuilderInitialCollection<T, TElement> RuleForEach<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression) {
 		expression.Guard("Cannot pass null to RuleForEach", nameof(expression));
 		var rule = CollectionPropertyRule<T, TElement>.Create(expression, () => RuleLevelCascadeMode);


### PR DESCRIPTION
thoughts on making RuleFor `[Pure]`.

IDEs can then warn when the returned RuleBuilder is not used.

![image](https://github.com/user-attachments/assets/022dfaa8-a938-4b82-8cef-e44fb022858b)
