### PR TITLE
Simplify guarding

### DIFF
--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -164,9 +164,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="expression">The regular expression to check the value against.</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, string> Matches<T>(this IRuleBuilder<T, string> ruleBuilder,
-		#if NET7_0_OR_GREATER
 		[StringSyntax(StringSyntaxAttribute.Regex)]
-		#endif
 		string expression)
 		=> ruleBuilder.SetValidator(new RegularExpressionValidator<T>(expression));
 
@@ -237,9 +235,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="options">Regex options</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, string> Matches<T>(this IRuleBuilder<T, string> ruleBuilder,
-		#if NET7_0_OR_GREATER
 		[StringSyntax(StringSyntaxAttribute.Regex)]
-		#endif
 	 	string expression, RegexOptions options)
 		=> ruleBuilder.SetValidator(new RegularExpressionValidator<T>(expression, options));
 
@@ -417,7 +413,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="predicate">A lambda expression specifying the predicate</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> Must<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<TProperty, bool> predicate) {
-		predicate.Guard("Cannot pass a null predicate to Must.", nameof(predicate));
+		predicate.Guard("Cannot pass a null predicate to Must.");
 		return ruleBuilder.Must((x, val) => predicate(val));
 	}
 
@@ -433,7 +429,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="predicate">A lambda expression specifying the predicate</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> Must<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, TProperty, bool> predicate) {
-		predicate.Guard("Cannot pass a null predicate to Must.", nameof(predicate));
+		predicate.Guard("Cannot pass a null predicate to Must.");
 		return ruleBuilder.Must((x, val, _) => predicate(x, val));
 	}
 
@@ -449,7 +445,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="predicate">A lambda expression specifying the predicate</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> Must<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, TProperty, ValidationContext<T>, bool> predicate) {
-		predicate.Guard("Cannot pass a null predicate to Must.", nameof(predicate));
+		predicate.Guard("Cannot pass a null predicate to Must.");
 		return ruleBuilder.SetValidator(new PredicateValidator<T,TProperty>((instance, property, propertyValidatorContext) => predicate(instance, property, propertyValidatorContext)));
 	}
 
@@ -464,7 +460,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="predicate">A lambda expression specifying the predicate</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<TProperty, CancellationToken, Task<bool>> predicate) {
-		predicate.Guard("Cannot pass a null predicate to Must.", nameof(predicate));
+		predicate.Guard("Cannot pass a null predicate to Must.");
 
 		return ruleBuilder.MustAsync((x, val, ctx, cancel) => predicate(val, cancel));
 	}
@@ -481,7 +477,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="predicate">A lambda expression specifying the predicate</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, TProperty, CancellationToken, Task<bool>> predicate) {
-		predicate.Guard("Cannot pass a null predicate to Must.", nameof(predicate));
+		predicate.Guard("Cannot pass a null predicate to Must.");
 		return ruleBuilder.MustAsync((x, val, _, cancel) => predicate(x, val, cancel));
 	}
 
@@ -497,7 +493,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="predicate">A lambda expression specifying the predicate</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, TProperty, ValidationContext<T>, CancellationToken, Task<bool>> predicate) {
-		predicate.Guard("Cannot pass a null predicate to Must.", nameof(predicate));
+		predicate.Guard("Cannot pass a null predicate to Must.");
 		return ruleBuilder.SetAsyncValidator(new AsyncPredicateValidator<T,TProperty>(predicate));
 	}
 
@@ -635,7 +631,7 @@ public static partial class DefaultValidatorExtensions {
 	public static IRuleBuilderOptions<T, TProperty> LessThan<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder,
 		Expression<Func<T, TProperty>> expression)
 		where TProperty : IComparable<TProperty>, IComparable {
-		expression.Guard("Cannot pass null to LessThan", nameof(expression));
+		expression.Guard("Cannot pass null to LessThan");
 
 		var member = expression.GetMember();
 		var func = AccessorCache<T>.GetCachedAccessor(member, expression);
@@ -656,7 +652,7 @@ public static partial class DefaultValidatorExtensions {
 	public static IRuleBuilderOptions<T, TProperty> LessThan<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder,
 		Expression<Func<T, TProperty?>> expression)
 		where TProperty : struct, IComparable<TProperty>, IComparable {
-		expression.Guard("Cannot pass null to LessThan", nameof(expression));
+		expression.Guard("Cannot pass null to LessThan");
 
 		var member = expression.GetMember();
 		var func = AccessorCache<T>.GetCachedAccessor(member, expression);
@@ -681,7 +677,7 @@ public static partial class DefaultValidatorExtensions {
 	public static IRuleBuilderOptions<T, TProperty?> LessThan<T, TProperty>(this IRuleBuilder<T, TProperty?> ruleBuilder,
 		Expression<Func<T, TProperty>> expression)
 		where TProperty : struct, IComparable<TProperty>, IComparable {
-		expression.Guard("Cannot pass null to LessThan", nameof(expression));
+		expression.Guard("Cannot pass null to LessThan");
 
 		var member = expression.GetMember();
 		var func = AccessorCache<T>.GetCachedAccessor(member, expression);
@@ -703,7 +699,7 @@ public static partial class DefaultValidatorExtensions {
 	public static IRuleBuilderOptions<T, TProperty?> LessThan<T, TProperty>(this IRuleBuilder<T, TProperty?> ruleBuilder,
 		Expression<Func<T, TProperty?>> expression)
 		where TProperty : struct, IComparable<TProperty>, IComparable {
-		expression.Guard("Cannot pass null to LessThan", nameof(expression));
+		expression.Guard("Cannot pass null to LessThan");
 
 		var member = expression.GetMember();
 		var func = AccessorCache<T>.GetCachedAccessor(member, expression);
@@ -1129,7 +1125,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="action"></param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> Custom<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Action<TProperty, ValidationContext<T>> action) {
-		if (action == null) throw new ArgumentNullException(nameof(action));
+		action.GuardNotNull();
 		return (IRuleBuilderOptionsConditions<T, TProperty>)ruleBuilder.Must((parent, value, context) => {
 			action(value, context);
 			return true;
@@ -1145,7 +1141,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="action"></param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> CustomAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<TProperty, ValidationContext<T>, CancellationToken, Task> action) {
-		if (action == null) throw new ArgumentNullException(nameof(action));
+		action.GuardNotNull();
 		return (IRuleBuilderOptionsConditions<T, TProperty>)ruleBuilder.MustAsync(async (parent, value, context, cancel) => {
 			await action(value, context, cancel);
 			return true;
@@ -1202,7 +1198,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <returns></returns>
 	/// <exception cref="ArgumentNullException"></exception>
 	public static IRuleBuilderOptions<T, TProperty> ChildRules<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Action<InlineValidator<TProperty>> action) {
-		if (action == null) throw new ArgumentNullException(nameof(action));
+		action.GuardNotNull();
 		var validator = new ChildRulesContainer<TProperty>();
 		var parentValidator = ((IRuleBuilderInternal<T>) ruleBuilder).ParentValidator;
 
@@ -1239,7 +1235,7 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="validatorConfiguration">Callback for setting up the inheritance validators.</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> SetInheritanceValidator<T,TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Action<PolymorphicValidator<T, TProperty>> validatorConfiguration) {
-		if (validatorConfiguration == null) throw new ArgumentNullException(nameof(validatorConfiguration));
+		validatorConfiguration.GuardNotNull();
 		var validator = new PolymorphicValidator<T, TProperty>();
 		validatorConfiguration(validator);
 		return ruleBuilder.SetAsyncValidator(validator);

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -123,7 +123,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="errorMessage">The error message to use</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithMessage<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string errorMessage) {
-		errorMessage.Guard("A message must be specified when calling WithMessage.", nameof(errorMessage));
+		errorMessage.Guard("A message must be specified when calling WithMessage.");
 		Configurable(rule).Current.SetErrorMessage(errorMessage);
 		return rule;
 	}
@@ -135,7 +135,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="messageProvider">Delegate that will be invoked to retrieve the localized message. </param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithMessage<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, string> messageProvider) {
-		messageProvider.Guard("A messageProvider must be provided.", nameof(messageProvider));
+		messageProvider.Guard("A messageProvider must be provided.");
 		Configurable(rule).Current.SetErrorMessage((ctx, val) => {
 			return messageProvider(ctx == null ? default : ctx.InstanceToValidate);
 		});
@@ -149,7 +149,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="messageProvider">Delegate that will be invoked.Uses_localized_name to retrieve the localized message. </param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithMessage<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, TProperty, string> messageProvider) {
-		messageProvider.Guard("A messageProvider must be provided.", nameof(messageProvider));
+		messageProvider.Guard("A messageProvider must be provided.");
 		Configurable(rule).Current.SetErrorMessage((context, value) => {
 			return messageProvider(context == null ? default : context.InstanceToValidate, value);
 		});
@@ -163,7 +163,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="errorCode">The error code to use</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithErrorCode<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string errorCode) {
-		errorCode.Guard("A error code must be specified when calling WithErrorCode.", nameof(errorCode));
+		errorCode.Guard("A error code must be specified when calling WithErrorCode.");
 		Configurable(rule).Current.ErrorCode = errorCode;
 		return rule;
 	}
@@ -177,7 +177,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> When<T,TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling When.", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling When.");
 		return rule.When((x, ctx) => predicate(x), applyConditionTo);
 	}
 
@@ -190,7 +190,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> When<T,TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling When.", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling When.");
 		return rule.When((x, ctx) => predicate(x), applyConditionTo);
 	}
 
@@ -203,7 +203,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> When<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling When.", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling When.");
 		// Default behaviour for When/Unless as of v1.3 is to apply the condition to all previous validators in the chain.
 		Configurable(rule).ApplyCondition(ctx => predicate(ctx.InstanceToValidate, ValidationContext<T>.GetFromNonGenericContext(ctx)), applyConditionTo);
 		return rule;
@@ -218,7 +218,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> When<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, ValidationContext<T>, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling When.", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling When.");
 		// Default behaviour for When/Unless as of v1.3 is to apply the condition to all previous validators in the chain.
 		Configurable(rule).ApplyCondition(ctx => predicate(ctx.InstanceToValidate, ValidationContext<T>.GetFromNonGenericContext(ctx)), applyConditionTo);
 		return rule;
@@ -233,7 +233,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> Unless<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling Unless", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling Unless");
 		return rule.Unless((x, ctx) => predicate(x), applyConditionTo);
 	}
 
@@ -246,7 +246,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> Unless<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling Unless", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling Unless");
 		return rule.Unless((x, ctx) => predicate(x), applyConditionTo);
 	}
 
@@ -259,7 +259,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> Unless<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling Unless", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling Unless");
 		return rule.When((x, ctx) => !predicate(x, ctx), applyConditionTo);
 	}
 
@@ -272,7 +272,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> Unless<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, ValidationContext<T>, bool> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling Unless", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling Unless");
 		return rule.When((x, ctx) => !predicate(x, ctx), applyConditionTo);
 	}
 
@@ -285,7 +285,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling WhenAsync.");
 		return rule.WhenAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
 	}
 
@@ -298,7 +298,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling WhenAsync.");
 		return rule.WhenAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
 	}
 
@@ -311,7 +311,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling WhenAsync.");
 		// Default behaviour for When/Unless as of v1.3 is to apply the condition to all previous validators in the chain.
 		Configurable(rule).ApplyAsyncCondition((ctx, ct) => predicate(ctx.InstanceToValidate, ValidationContext<T>.GetFromNonGenericContext(ctx), ct), applyConditionTo);
 		return rule;
@@ -326,7 +326,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> WhenAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling WhenAsync.", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling WhenAsync.");
 		// Default behaviour for When/Unless as of v1.3 is to apply the condition to all previous validators in the chain.
 		Configurable(rule).ApplyAsyncCondition((ctx, ct) => predicate(ctx.InstanceToValidate, ValidationContext<T>.GetFromNonGenericContext(ctx), ct), applyConditionTo);
 		return rule;
@@ -341,7 +341,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling UnlessAsync");
 		return rule.UnlessAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
 	}
 
@@ -354,7 +354,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling UnlessAsync");
 		return rule.UnlessAsync((x, ctx, ct) => predicate(x, ct), applyConditionTo);
 	}
 
@@ -367,7 +367,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling UnlessAsync");
 		return rule.WhenAsync(async (x, ctx, ct) => !await predicate(x, ctx, ct), applyConditionTo);
 	}
 
@@ -380,7 +380,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="applyConditionTo">Whether the condition should be applied to the current rule or all rules in the chain</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptionsConditions<T, TProperty> UnlessAsync<T, TProperty>(this IRuleBuilderOptionsConditions<T, TProperty> rule, Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, ApplyConditionTo applyConditionTo = ApplyConditionTo.AllValidators) {
-		predicate.Guard("A predicate must be specified when calling UnlessAsync", nameof(predicate));
+		predicate.Guard("A predicate must be specified when calling UnlessAsync");
 		return rule.WhenAsync(async (x, ctx, ct) => !await predicate(x, ctx, ct), applyConditionTo);
 	}
 
@@ -392,7 +392,7 @@ public static class DefaultValidatorOptions {
 	/// <returns></returns>
 	public static IRuleBuilderInitialCollection<T, TCollectionElement> Where<T, TCollectionElement>(this IRuleBuilderInitialCollection<T, TCollectionElement> rule, Func<TCollectionElement, bool> predicate) {
 		// This overload supports RuleFor().SetCollectionValidator() (which returns IRuleBuilderOptions<T, IEnumerable<TElement>>)
-		predicate.Guard("Cannot pass null to Where.", nameof(predicate));
+		predicate.Guard("Cannot pass null to Where.");
 		Configurable(rule).Filter = predicate;
 		return rule;
 	}
@@ -404,7 +404,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="predicate">The condition</param>
 	/// <returns></returns>
 	public static IRuleBuilderInitialCollection<T, TCollectionElement> WhereAsync<T, TCollectionElement>(this IRuleBuilderInitialCollection<T, TCollectionElement> rule, Func<TCollectionElement, Task<bool>> predicate) {
-		predicate.Guard("Cannot pass null to Where.", nameof(predicate));
+		predicate.Guard("Cannot pass null to Where.");
 		// TODO: 12.x add AsyncFilter to ICollectionRule<T,TElement> to remove the cast.
 		var collectionRule = (CollectionPropertyRule<T, TCollectionElement>) Configurable(rule);
 		collectionRule.AsyncFilter = predicate;
@@ -418,7 +418,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="overridePropertyName">The property name to use</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithName<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string overridePropertyName) {
-		overridePropertyName.Guard("A property name must be specified when calling WithName.", nameof(overridePropertyName));
+		overridePropertyName.Guard("A property name must be specified when calling WithName.");
 		Configurable(rule).SetDisplayName(overridePropertyName);
 		return rule;
 	}
@@ -430,7 +430,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="nameProvider">Func used to retrieve the property's display name</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithName<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, string> nameProvider) {
-		nameProvider.Guard("A nameProvider WithName.", nameof(nameProvider));
+		nameProvider.Guard("A nameProvider WithName.");
 		// Must use null propagation here.
 		// The MVC clientside validation will try and retrieve the name, but won't
 		// be able to to so if we've used this overload of WithName.
@@ -450,7 +450,7 @@ public static class DefaultValidatorOptions {
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> OverridePropertyName<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string propertyName) {
 		// Allow string.Empty as this could be a model-level rule.
-		if (propertyName == null) throw new ArgumentNullException(nameof(propertyName), "A property name must be specified when calling OverridePropertyName.");
+		if (propertyName is null) throw new ArgumentNullException(nameof(propertyName), "A property name must be specified when calling OverridePropertyName.");
 		Configurable(rule).PropertyName = propertyName;
 		return rule;
 	}
@@ -463,9 +463,8 @@ public static class DefaultValidatorOptions {
 	/// <param name="expr">An expression referencing another property</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> OverridePropertyName<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Expression<Func<T, object>> expr) {
-		if (expr == null) throw new ArgumentNullException(nameof(expr));
-		var member = expr.GetMember();
-		if (member == null) throw new NotSupportedException("Must supply a MemberExpression when calling OverridePropertyName");
+		var member = expr.GuardNotNull().GetMember();
+		if (member is null) throw new NotSupportedException("Must supply a MemberExpression when calling OverridePropertyName");
 		return rule.OverridePropertyName(member.Name);
 	}
 
@@ -478,7 +477,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="stateProvider"></param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithState<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, object> stateProvider) {
-		stateProvider.Guard("A lambda expression must be passed to WithState", nameof(stateProvider));
+		stateProvider.Guard("A lambda expression must be passed to WithState");
 		var wrapper = new Func<ValidationContext<T>, TProperty, object>((ctx, _) => stateProvider(ctx.InstanceToValidate));
 		Configurable(rule).Current.CustomStateProvider = wrapper;
 		return rule;
@@ -493,7 +492,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="stateProvider"></param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithState<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, TProperty, object> stateProvider) {
-		stateProvider.Guard("A lambda expression must be passed to WithState", nameof(stateProvider));
+		stateProvider.Guard("A lambda expression must be passed to WithState");
 
 		var wrapper = new Func<ValidationContext<T>, TProperty, object>((ctx, val) => {
 			return stateProvider(ctx.InstanceToValidate, val);
@@ -512,7 +511,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="stateProvider"></param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithState<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, TProperty, ValidationContext<T>, object> stateProvider) {
-		stateProvider.Guard("A lambda expression must be passed to WithState", nameof(stateProvider));
+		stateProvider.Guard("A lambda expression must be passed to WithState");
 
 		var wrapper = new Func<ValidationContext<T>, TProperty, object>((ctx, val) => {
 			return stateProvider(ctx.InstanceToValidate, val, ctx);
@@ -544,7 +543,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="severityProvider"></param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, Severity> severityProvider) {
-		severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
+		severityProvider.Guard("A lambda expression must be passed to WithSeverity");
 
 		Severity SeverityProvider(ValidationContext<T> ctx, TProperty value) {
 			return severityProvider(ctx.InstanceToValidate);
@@ -563,7 +562,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="severityProvider"></param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, TProperty, Severity> severityProvider) {
-		severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
+		severityProvider.Guard("A lambda expression must be passed to WithSeverity");
 
 		Severity SeverityProvider(ValidationContext<T> ctx, TProperty value) {
 			return severityProvider(ctx.InstanceToValidate, value);
@@ -582,7 +581,7 @@ public static class DefaultValidatorOptions {
 	/// <param name="severityProvider"></param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, TProperty, ValidationContext<T>, Severity> severityProvider) {
-		severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
+		severityProvider.Guard("A lambda expression must be passed to WithSeverity");
 
 		Severity SeverityProvider(ValidationContext<T> ctx, TProperty value) {
 			return severityProvider(ctx.InstanceToValidate, value, ctx);
@@ -600,7 +599,7 @@ public static class DefaultValidatorOptions {
 	/// <returns></returns>
 	public static IRuleBuilderInitialCollection<T, TCollectionElement> OverrideIndexer<T, TCollectionElement>(this IRuleBuilderInitialCollection<T, TCollectionElement> rule, Func<T, IEnumerable<TCollectionElement>, TCollectionElement, int, string> callback) {
 		// This overload supports RuleFor().SetCollectionValidator() (which returns IRuleBuilderOptions<T, IEnumerable<TElement>>)
-		callback.Guard("Cannot pass null to OverrideIndexer.", nameof(callback));
+		callback.Guard("Cannot pass null to OverrideIndexer.");
 		Configurable(rule).IndexBuilder = callback;
 		return rule;
 	}

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -23,6 +23,10 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/FluentValidation/IValidationContext.cs
+++ b/src/FluentValidation/IValidationContext.cs
@@ -122,7 +122,7 @@ public class ValidationContext<T> : IValidationContext, IHasFailures {
 	/// <param name="instanceToValidate">The instance to validate</param>
 	/// <param name="options">Callback that allows extra options to be configured.</param>
 	public static ValidationContext<T> CreateWithOptions(T instanceToValidate, Action<ValidationStrategy<T>> options) {
-		if (options == null) throw new ArgumentNullException(nameof(options));
+		options.GuardNotNull();
 		var strategy = new ValidationStrategy<T>();
 		options(strategy);
 		return strategy.BuildContext(instanceToValidate);
@@ -202,7 +202,7 @@ public class ValidationContext<T> : IValidationContext, IHasFailures {
 	/// <exception cref="ArgumentNullException"></exception>
 	/// <exception cref="NotSupportedException"></exception>
 	public static ValidationContext<T> GetFromNonGenericContext(IValidationContext context) {
-		if (context == null) throw new ArgumentNullException(nameof(context));
+		context.GuardNotNull();
 
 		// Already of the correct type.
 		if (context is ValidationContext<T> c) {
@@ -279,7 +279,7 @@ public class ValidationContext<T> : IValidationContext, IHasFailures {
 	/// <param name="failure">The failure to add.</param>
 	/// <exception cref="ArgumentNullException"></exception>
 	public void AddFailure(ValidationFailure failure) {
-		if (failure == null) throw new ArgumentNullException(nameof(failure), "A failure must be specified when calling AddFailure");
+		if (failure is null) throw new ArgumentNullException(nameof(failure), "A failure must be specified when calling AddFailure");
 		Failures.Add(failure);
 	}
 
@@ -289,7 +289,7 @@ public class ValidationContext<T> : IValidationContext, IHasFailures {
 	/// <param name="propertyName">The property name</param>
 	/// <param name="errorMessage">The error message</param>
 	public void AddFailure(string propertyName, string errorMessage) {
-		errorMessage.Guard("An error message must be specified when calling AddFailure.", nameof(errorMessage));
+		errorMessage.Guard("An error message must be specified when calling AddFailure.");
 		errorMessage = MessageFormatter.BuildMessage(errorMessage);
 		AddFailure(new ValidationFailure(PropertyChain.BuildPropertyPath(propertyName ?? string.Empty), errorMessage));
 	}
@@ -300,7 +300,7 @@ public class ValidationContext<T> : IValidationContext, IHasFailures {
 	/// </summary>
 	/// <param name="errorMessage">The error message</param>
 	public void AddFailure(string errorMessage) {
-		errorMessage.Guard("An error message must be specified when calling AddFailure.", nameof(errorMessage));
+		errorMessage.Guard("An error message must be specified when calling AddFailure.");
 		errorMessage = MessageFormatter.BuildMessage(errorMessage);
 		AddFailure(new ValidationFailure(PropertyPath, errorMessage));
 	}

--- a/src/FluentValidation/Internal/ExtensionsInternal.cs
+++ b/src/FluentValidation/Internal/ExtensionsInternal.cs
@@ -16,23 +16,29 @@
 // The latest version of this file can be found at https://github.com/FluentValidation/FluentValidation
 #endregion
 
+#nullable enable
+
 namespace FluentValidation.Internal;
 
+using Resources;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Text;
-using Resources;
-
 internal static class ExtensionsInternal {
-	internal static void Guard(this object obj, string message, string paramName) {
-		if (obj == null) {
+
+	internal static T GuardNotNull<T>(this T? obj, [CallerArgumentExpression(nameof(obj))] string? paramName = null)
+		=> obj ?? throw new ArgumentNullException(paramName);
+
+	internal static void Guard(this object? obj, string message, [CallerArgumentExpression(nameof(obj))] string? paramName = null) {
+		if (obj is null) {
 			throw new ArgumentNullException(paramName, message);
 		}
 	}
 
-	internal static void Guard(this string str, string message, string paramName) {
-		if (str == null) {
+	internal static void Guard(this string? str, string message, [CallerArgumentExpression(nameof(str))] string? paramName = null) {
+		if (str is null) {
 			throw new ArgumentNullException(paramName, message);
 		}
 
@@ -57,8 +63,8 @@ internal static class ExtensionsInternal {
 	/// Pascal case strings with periods delimiting the upper case letters,
 	/// such as "Address.Line1", will have the periods removed.
 	/// </remarks>
-	internal static string SplitPascalCase(this string input) {
-		if (string.IsNullOrEmpty(input))
+	internal static string? SplitPascalCase(this string? input) {
+		if (input is not { Length: > 0 })
 			return input;
 
 		var retVal = new StringBuilder(input.Length + 5);
@@ -81,11 +87,9 @@ internal static class ExtensionsInternal {
 		return retVal.ToString().Trim();
 	}
 
-	internal static T GetOrAdd<T>(this IDictionary<string, object> dict, string key, Func<T> value) {
-		if (dict.TryGetValue(key, out var tmp)) {
-			if (tmp is T result) {
+	internal static T GetOrAdd<T>(this IDictionary<string, object> dict, string key, Func<T> value) where T : notnull {
+		if (dict.TryGetValue(key, out var tmp) && tmp is T result) {
 				return result;
-			}
 		}
 
 		var val = value();

--- a/src/FluentValidation/Internal/RuleBuilder.cs
+++ b/src/FluentValidation/Internal/RuleBuilder.cs
@@ -50,13 +50,12 @@ internal class RuleBuilder<T, TProperty> : IRuleBuilderOptions<T, TProperty>, IR
 	}
 
 	public IRuleBuilderOptions<T, TProperty> SetValidator(IPropertyValidator<T, TProperty> validator) {
-		if (validator == null) throw new ArgumentNullException(nameof(validator));
-		Rule.AddValidator(validator);
+		Rule.AddValidator(validator.GuardNotNull());
 		return this;
 	}
 
 	public IRuleBuilderOptions<T, TProperty> SetAsyncValidator(IAsyncPropertyValidator<T, TProperty> validator) {
-		if (validator == null) throw new ArgumentNullException(nameof(validator));
+		validator.GuardNotNull();
 		// See if the async validator supports synchronous execution too.
 		IPropertyValidator<T, TProperty> fallback = validator as IPropertyValidator<T, TProperty>;
 		Rule.AddAsyncValidator(validator, fallback);
@@ -64,7 +63,7 @@ internal class RuleBuilder<T, TProperty> : IRuleBuilderOptions<T, TProperty>, IR
 	}
 
 	public IRuleBuilderOptions<T, TProperty> SetValidator(IValidator<TProperty> validator, params string[] ruleSets) {
-		validator.Guard("Cannot pass a null validator to SetValidator", nameof(validator));
+		validator.Guard("Cannot pass a null validator to SetValidator");
 		var adaptor = new ChildValidatorAdaptor<T,TProperty>(validator, validator.GetType()) {
 			RuleSets = ruleSets
 		};
@@ -74,7 +73,7 @@ internal class RuleBuilder<T, TProperty> : IRuleBuilderOptions<T, TProperty>, IR
 	}
 
 	public IRuleBuilderOptions<T, TProperty> SetValidator<TValidator>(Func<T, TValidator> validatorProvider, params string[] ruleSets) where TValidator : IValidator<TProperty> {
-		validatorProvider.Guard("Cannot pass a null validatorProvider to SetValidator", nameof(validatorProvider));
+		validatorProvider.Guard("Cannot pass a null validatorProvider to SetValidator");
 		var adaptor = new ChildValidatorAdaptor<T,TProperty>((context, _) => validatorProvider(context.InstanceToValidate), typeof (TValidator)) {
 			RuleSets = ruleSets
 		};
@@ -84,7 +83,7 @@ internal class RuleBuilder<T, TProperty> : IRuleBuilderOptions<T, TProperty>, IR
 	}
 
 	public IRuleBuilderOptions<T, TProperty> SetValidator<TValidator>(Func<T, TProperty, TValidator> validatorProvider, params string[] ruleSets) where TValidator : IValidator<TProperty> {
-		validatorProvider.Guard("Cannot pass a null validatorProvider to SetValidator", nameof(validatorProvider));
+		validatorProvider.Guard("Cannot pass a null validatorProvider to SetValidator");
 		var adaptor = new ChildValidatorAdaptor<T,TProperty>((context, val) => validatorProvider(context.InstanceToValidate, val), typeof (TValidator)) {
 			RuleSets = ruleSets
 		};

--- a/src/FluentValidation/Internal/ValidationStrategy.cs
+++ b/src/FluentValidation/Internal/ValidationStrategy.cs
@@ -109,8 +109,7 @@ public class ValidationStrategy<T> {
 	/// <param name="selector">The custom selector to use</param>
 	/// <returns></returns>
 	public ValidationStrategy<T> UseCustomSelector(IValidatorSelector selector) {
-		if (selector == null) throw new ArgumentNullException(nameof(selector));
-		_customSelector = selector;
+		_customSelector = selector.GuardNotNull();
 		return this;
 	}
 

--- a/src/FluentValidation/ValidationException.cs
+++ b/src/FluentValidation/ValidationException.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using Results;
 using System.Linq;
 using System.Runtime.Serialization;
+using FluentValidation.Internal;
 
 /// <summary>
 /// An exception that represents failed validation
@@ -86,9 +87,7 @@ public class ValidationException : Exception {
 	[Obsolete(DiagnosticId = "SYSLIB0051")]
 #endif
 	public override void GetObjectData(SerializationInfo info, StreamingContext context) {
-		if (info == null) throw new ArgumentNullException("info");
-
-		info.AddValue("errors", Errors);
+		info.GuardNotNull().AddValue("errors", Errors);
 		base.GetObjectData(info, context);
 	}
 }

--- a/src/FluentValidation/Validators/AsyncPredicateValidator.cs
+++ b/src/FluentValidation/Validators/AsyncPredicateValidator.cs
@@ -36,7 +36,7 @@ public class AsyncPredicateValidator<T,TProperty> : AsyncPropertyValidator<T,TPr
 	/// </summary>
 	/// <param name="predicate"></param>
 	public AsyncPredicateValidator(Func<T, TProperty, ValidationContext<T>, CancellationToken, Task<bool>> predicate) {
-		predicate.Guard("A predicate must be specified.", nameof(predicate));
+		predicate.Guard("A predicate must be specified.");
 		this._predicate = predicate;
 	}
 

--- a/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
+++ b/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
@@ -86,7 +86,7 @@ public class ChildValidatorAdaptor<T,TProperty> : NoopPropertyValidator<T,TPrope
 	}
 
 	public virtual IValidator GetValidator(ValidationContext<T> context, TProperty value) {
-		context.Guard("Cannot pass a null context to GetValidator", nameof(context));
+		context.Guard("Cannot pass a null context to GetValidator");
 
 		return _validatorProvider != null ? _validatorProvider(context, value) : _validator;
 	}

--- a/src/FluentValidation/Validators/PolymorphicValidator.cs
+++ b/src/FluentValidation/Validators/PolymorphicValidator.cs
@@ -44,7 +44,7 @@ public class PolymorphicValidator<T, TProperty> : ChildValidatorAdaptor<T, TProp
 	/// <typeparam name="TDerived"></typeparam>
 	/// <returns></returns>
 	public PolymorphicValidator<T, TProperty> Add<TDerived>(IValidator<TDerived> derivedValidator, params string[] ruleSets) where TDerived : TProperty {
-		if (derivedValidator == null) throw new ArgumentNullException(nameof(derivedValidator));
+		derivedValidator.GuardNotNull();
 		_derivedValidators[typeof(TDerived)] = new DerivedValidatorFactory(derivedValidator, ruleSets);
 		return this;
 	}
@@ -57,7 +57,7 @@ public class PolymorphicValidator<T, TProperty> : ChildValidatorAdaptor<T, TProp
 	/// <param name="ruleSets">Optionally specify rulesets to execute. If set, rules not in these rulesets will not be run</param>
 	/// <returns></returns>
 	public PolymorphicValidator<T, TProperty> Add<TDerived>(Func<T, IValidator<TDerived>> validatorFactory, params string[] ruleSets) where TDerived : TProperty {
-		if (validatorFactory == null) throw new ArgumentNullException(nameof(validatorFactory));
+		validatorFactory.GuardNotNull();
 		_derivedValidators[typeof(TDerived)] = new DerivedValidatorFactory((context, _) => validatorFactory(context.InstanceToValidate), ruleSets);
 		return this;
 	}
@@ -70,7 +70,7 @@ public class PolymorphicValidator<T, TProperty> : ChildValidatorAdaptor<T, TProp
 	/// <param name="ruleSets">Optionally specify rulesets to execute. If set, rules not in these rulesets will not be run</param>
 	/// <returns></returns>
 	public PolymorphicValidator<T, TProperty> Add<TDerived>(Func<T, TDerived, IValidator<TDerived>> validatorFactory, params string[] ruleSets) where TDerived : TProperty {
-		if (validatorFactory == null) throw new ArgumentNullException(nameof(validatorFactory));
+		validatorFactory.GuardNotNull();
 		_derivedValidators[typeof(TDerived)] = new DerivedValidatorFactory((context, value) => validatorFactory(context.InstanceToValidate, (TDerived)value), ruleSets);
 		return this;
 	}
@@ -86,8 +86,8 @@ public class PolymorphicValidator<T, TProperty> : ChildValidatorAdaptor<T, TProp
 	/// <param name="ruleSets">Optionally specify rulesets to execute. If set, rules not in these rulesets will not be run</param>
 	/// <returns></returns>
 	protected PolymorphicValidator<T, TProperty> Add(Type subclassType, IValidator validator, params string[] ruleSets) {
-		if (subclassType == null) throw new ArgumentNullException(nameof(subclassType));
-		if (validator == null) throw new ArgumentNullException(nameof(validator));
+		subclassType.GuardNotNull();
+		validator.GuardNotNull();
 		if (!validator.CanValidateInstancesOfType(subclassType)) {
 			throw new InvalidOperationException($"Validator {validator.GetType().Name} can't validate instances of type {subclassType.Name}");
 		}

--- a/src/FluentValidation/Validators/PredicateValidator.cs
+++ b/src/FluentValidation/Validators/PredicateValidator.cs
@@ -28,7 +28,7 @@ public class PredicateValidator<T,TProperty> : PropertyValidator<T,TProperty>, I
 	public override string Name => "PredicateValidator";
 
 	public PredicateValidator(Predicate predicate) {
-		predicate.Guard("A predicate must be specified.", nameof(predicate));
+		predicate.Guard("A predicate must be specified.");
 		this._predicate = predicate;
 	}
 

--- a/src/FluentValidation/Validators/StringEnumValidator.cs
+++ b/src/FluentValidation/Validators/StringEnumValidator.cs
@@ -18,6 +18,7 @@
 
 namespace FluentValidation.Validators;
 
+using FluentValidation.Internal;
 using System;
 using System.Linq;
 
@@ -28,7 +29,7 @@ public class StringEnumValidator<T> : PropertyValidator<T, string> {
 	public override string Name => "StringEnumValidator";
 
 	public StringEnumValidator(Type enumType, bool caseSensitive) {
-		if (enumType == null) throw new ArgumentNullException(nameof(enumType));
+		enumType.GuardNotNull();
 
 		CheckTypeIsEnum(enumType);
 


### PR DESCRIPTION
By using `[CallerArgumentExpression]` (available for .NET standard via [PolySharp](https://github.com/Sergio0694/PolySharp)), and the introduction of `GuardNotNull` the plumbing needed to defend against null dereferences has hopefully improved.