### PR TITLE
Convert constructors to primary constructors

### DIFF
--- a/src/FluentValidation.DependencyInjectionExtensions/ServiceProviderValidatorFactory.cs
+++ b/src/FluentValidation.DependencyInjectionExtensions/ServiceProviderValidatorFactory.cs
@@ -23,12 +23,7 @@ using System;
 /// Validator factory implementation that uses the asp.net service provider to construct validators.
 /// </summary>
 [Obsolete("IValidatorFactory and its implementors are deprecated and will be removed in a future release. Please use the Service Provider directly (or a DI container). For details see https://github.com/FluentValidation/FluentValidation/issues/1961")]
-public class ServiceProviderValidatorFactory : ValidatorFactoryBase {
-	private readonly IServiceProvider _serviceProvider;
-
-	public ServiceProviderValidatorFactory(IServiceProvider serviceProvider)
-		=> _serviceProvider = serviceProvider;
-
+public class ServiceProviderValidatorFactory(IServiceProvider serviceProvider) : ValidatorFactoryBase {
 	public override IValidator CreateInstance(Type validatorType)
-		=> _serviceProvider.GetService(validatorType) as IValidator;
+		=> serviceProvider.GetService(validatorType) as IValidator;
 }

--- a/src/FluentValidation/Internal/AccessorCache.cs
+++ b/src/FluentValidation/Internal/AccessorCache.cs
@@ -54,18 +54,13 @@ public static class AccessorCache<T> {
 	/// <summary>
 	/// Represents a unique cache key.
 	/// </summary>
-	private class Key {
-		private readonly MemberInfo _memberInfo;
+	private class Key(MemberInfo member, Expression expression, string cachePrefix) {
+		private readonly MemberInfo _memberInfo = member;
 		/// <remarks>
 		/// The expression key ensures that the accessor is not shared between collection and non-collection access.
 		/// Collection and non-collection access must use different accessors or a runtime exception will occur.
 		/// </remarks>
-		private readonly string _expressionKey;
-
-		public Key(MemberInfo member, Expression expression, string cachePrefix) {
-			_memberInfo = member;
-			_expressionKey = cachePrefix != null ? cachePrefix + expression.ToString() : expression.ToString();
-		}
+		private readonly string _expressionKey = cachePrefix != null ? cachePrefix + expression.ToString() : expression.ToString();
 
 		public bool Equals(Key other) {
 			return Equals(_memberInfo, other._memberInfo) && string.Equals(_expressionKey, other._expressionKey);

--- a/src/FluentValidation/Internal/CompositeValidatorSelector.cs
+++ b/src/FluentValidation/Internal/CompositeValidatorSelector.cs
@@ -21,14 +21,8 @@ namespace FluentValidation.Internal;
 using System.Collections.Generic;
 using System.Linq;
 
-internal class CompositeValidatorSelector : IValidatorSelector {
-	private IEnumerable<IValidatorSelector> _selectors;
-
-	public CompositeValidatorSelector(IEnumerable<IValidatorSelector> selectors) {
-		_selectors = selectors;
-	}
-
+internal class CompositeValidatorSelector(IEnumerable<IValidatorSelector> selectors) : IValidatorSelector {
 	public bool CanExecute(IValidationRule rule, string propertyPath, IValidationContext context) {
-		return _selectors.Any(s => s.CanExecute(rule, propertyPath, context));
+		return selectors.Any(s => s.CanExecute(rule, propertyPath, context));
 	}
 }

--- a/src/FluentValidation/Internal/ConditionBuilder.cs
+++ b/src/FluentValidation/Internal/ConditionBuilder.cs
@@ -23,13 +23,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-internal class ConditionBuilder<T> {
-	private TrackingCollection<IValidationRuleInternal<T>> _rules;
-
-	public ConditionBuilder(TrackingCollection<IValidationRuleInternal<T>> rules) {
-		_rules = rules;
-	}
-
+internal class ConditionBuilder<T>(TrackingCollection<IValidationRuleInternal<T>> rules) {
 	/// <summary>
 	/// Defines a condition that applies to several rules
 	/// </summary>
@@ -39,7 +33,7 @@ internal class ConditionBuilder<T> {
 	public IConditionBuilder When(Func<T, ValidationContext<T>, bool> predicate, Action action) {
 		var propertyRules = new List<IValidationRuleInternal<T>>();
 
-		using (_rules.OnItemAdded(propertyRules.Add)) {
+		using (rules.OnItemAdded(propertyRules.Add)) {
 			action();
 		}
 
@@ -76,7 +70,7 @@ internal class ConditionBuilder<T> {
 			rule.ApplySharedCondition(Condition);
 		}
 
-		return new ConditionOtherwiseBuilder<T>(_rules, Condition);
+		return new ConditionOtherwiseBuilder<T>(rules, Condition);
 	}
 
 	/// <summary>
@@ -89,13 +83,7 @@ internal class ConditionBuilder<T> {
 	}
 }
 
-internal class AsyncConditionBuilder<T> {
-	private TrackingCollection<IValidationRuleInternal<T>> _rules;
-
-	public AsyncConditionBuilder(TrackingCollection<IValidationRuleInternal<T>> rules) {
-		_rules = rules;
-	}
-
+internal class AsyncConditionBuilder<T>(TrackingCollection<IValidationRuleInternal<T>> rules) {
 	/// <summary>
 	/// Defines an asynchronous condition that applies to several rules
 	/// </summary>
@@ -105,7 +93,7 @@ internal class AsyncConditionBuilder<T> {
 	public IConditionBuilder WhenAsync(Func<T, ValidationContext<T>, CancellationToken, Task<bool>> predicate, Action action) {
 		var propertyRules = new List<IValidationRuleInternal<T>>();
 
-		using (_rules.OnItemAdded(propertyRules.Add)) {
+		using (rules.OnItemAdded(propertyRules.Add)) {
 			action();
 		}
 
@@ -141,7 +129,7 @@ internal class AsyncConditionBuilder<T> {
 			rule.ApplySharedAsyncCondition(Condition);
 		}
 
-		return new AsyncConditionOtherwiseBuilder<T>(_rules, Condition);
+		return new AsyncConditionOtherwiseBuilder<T>(rules, Condition);
 	}
 
 	/// <summary>
@@ -154,26 +142,19 @@ internal class AsyncConditionBuilder<T> {
 	}
 }
 
-internal class ConditionOtherwiseBuilder<T> : IConditionBuilder {
-	private TrackingCollection<IValidationRuleInternal<T>> _rules;
-	private readonly Func<IValidationContext, bool> _condition;
-
-	public ConditionOtherwiseBuilder(TrackingCollection<IValidationRuleInternal<T>> rules, Func<IValidationContext, bool> condition) {
-		_rules = rules;
-		_condition = condition;
-	}
-
+internal class ConditionOtherwiseBuilder<T>(TrackingCollection<IValidationRuleInternal<T>> rules, Func<IValidationContext, bool> condition)
+	: IConditionBuilder {
 	public virtual void Otherwise(Action action) {
 		var propertyRules = new List<IValidationRuleInternal<T>>();
 
 		Action<IValidationRuleInternal<T>> onRuleAdded = propertyRules.Add;
 
-		using (_rules.OnItemAdded(onRuleAdded)) {
+		using (rules.OnItemAdded(onRuleAdded)) {
 			action();
 		}
 
 		foreach (var rule in propertyRules) {
-			rule.ApplySharedCondition(ctx => !_condition(ctx));
+			rule.ApplySharedCondition(ctx => !condition(ctx));
 		}
 	}
 }

--- a/src/FluentValidation/Internal/MessageBuilderContext.cs
+++ b/src/FluentValidation/Internal/MessageBuilderContext.cs
@@ -14,37 +14,29 @@ public interface IMessageBuilderContext<T, out TProperty> {
 	string GetDefaultMessage();
 }
 
-public class MessageBuilderContext<T,TProperty> : IMessageBuilderContext<T,TProperty> {
-	private ValidationContext<T> _innerContext;
-	private TProperty _value;
-
-	public MessageBuilderContext(ValidationContext<T> innerContext, TProperty value, RuleComponent<T,TProperty> component) {
-		_innerContext = innerContext;
-		_value = value;
-		Component = component;
-	}
-
-	public RuleComponent<T,TProperty> Component { get; }
+public class MessageBuilderContext<T, TProperty>(ValidationContext<T> innerContext, TProperty value, RuleComponent<T, TProperty> component)
+	: IMessageBuilderContext<T, TProperty> {
+	public RuleComponent<T,TProperty> Component { get; } = component;
 
 	IRuleComponent<T, TProperty> IMessageBuilderContext<T, TProperty>.Component => Component;
 
 	public IPropertyValidator PropertyValidator
 		=> Component.Validator;
 
-	public ValidationContext<T> ParentContext => _innerContext;
+	public ValidationContext<T> ParentContext => innerContext;
 
 	// public IValidationRule<T> Rule => _innerContext.Rule;
 
-	public string PropertyName => _innerContext.PropertyPath;
+	public string PropertyName => innerContext.PropertyPath;
 
-	public string DisplayName => _innerContext.DisplayName;
+	public string DisplayName => innerContext.DisplayName;
 
-	public MessageFormatter MessageFormatter => _innerContext.MessageFormatter;
+	public MessageFormatter MessageFormatter => innerContext.MessageFormatter;
 
-	public T InstanceToValidate => _innerContext.InstanceToValidate;
-	public TProperty PropertyValue => _value;
+	public T InstanceToValidate => innerContext.InstanceToValidate;
+	public TProperty PropertyValue => value;
 
 	public string GetDefaultMessage() {
-		return Component.GetErrorMessage(_innerContext, _value);
+		return Component.GetErrorMessage(innerContext, value);
 	}
 }

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -28,12 +28,8 @@ using System.Threading.Tasks;
 /// <summary>
 /// Defines a rule associated with a property.
 /// </summary>
-internal partial class PropertyRule<T, TProperty> : RuleBase<T, TProperty, TProperty>, IValidationRuleInternal<T, TProperty> {
-
-	public PropertyRule(MemberInfo member, Func<T, TProperty> propertyFunc, LambdaExpression expression, Func<CascadeMode> cascadeModeThunk, Type typeToValidate)
-		: base(member, propertyFunc, expression, cascadeModeThunk, typeToValidate) {
-	}
-
+internal partial class PropertyRule<T, TProperty>(MemberInfo member, Func<T, TProperty> propertyFunc, LambdaExpression expression, Func<CascadeMode> cascadeModeThunk, Type typeToValidate)
+	: RuleBase<T, TProperty, TProperty>(member, propertyFunc, expression, cascadeModeThunk, typeToValidate), IValidationRuleInternal<T, TProperty> {
 	/// <summary>
 	/// Creates a new property rule from a lambda expression.
 	/// </summary>

--- a/src/FluentValidation/TestHelper/ValidationTestException.cs
+++ b/src/FluentValidation/TestHelper/ValidationTestException.cs
@@ -23,11 +23,8 @@ using System;
 using System.Collections.Generic;
 using FluentValidation.Results;
 
-public class ValidationTestException : Exception {
+public class ValidationTestException(string message) : Exception(message) {
 	public List<ValidationFailure> Errors { get; }
-
-	public ValidationTestException(string message) : base(message) {
-	}
 
 	public ValidationTestException(string message, List<ValidationFailure> errors) : this(message) {
 		Errors = errors;

--- a/src/FluentValidation/Validators/ExclusiveBetweenValidator.cs
+++ b/src/FluentValidation/Validators/ExclusiveBetweenValidator.cs
@@ -23,12 +23,10 @@ using System.Collections.Generic;
 /// <summary>
 /// Performs range validation where the property value must be between the two specified values (exclusive).
 /// </summary>
-public class ExclusiveBetweenValidator<T, TProperty> : RangeValidator<T, TProperty> {
+public class ExclusiveBetweenValidator<T, TProperty>(TProperty from, TProperty to, IComparer<TProperty> comparer)
+	: RangeValidator<T, TProperty>(from, to, comparer) {
 
 	public override string Name => "ExclusiveBetweenValidator";
-
-	public ExclusiveBetweenValidator(TProperty from, TProperty to, IComparer<TProperty> comparer) : base(from, to, comparer) {
-	}
 
 	protected override bool HasError(TProperty value) {
 		return Compare(value, From) <= 0 || Compare(value, To) >= 0;

--- a/src/FluentValidation/Validators/InclusiveBetweenValidator.cs
+++ b/src/FluentValidation/Validators/InclusiveBetweenValidator.cs
@@ -23,12 +23,10 @@ using System.Collections.Generic;
 /// <summary>
 /// Performs range validation where the property value must be between the two specified values (inclusive).
 /// </summary>
-public class InclusiveBetweenValidator<T, TProperty> : RangeValidator<T, TProperty>, IInclusiveBetweenValidator {
+public class InclusiveBetweenValidator<T, TProperty>(TProperty from, TProperty to, IComparer<TProperty> comparer)
+	: RangeValidator<T, TProperty>(from, to, comparer), IInclusiveBetweenValidator {
 
 	public override string Name => "InclusiveBetweenValidator";
-
-	public InclusiveBetweenValidator(TProperty from, TProperty to, IComparer<TProperty> comparer) : base(from, to, comparer) {
-	}
 
 	protected override bool HasError(TProperty value) {
 		return Compare(value, From) < 0 || Compare(value, To) > 0;


### PR DESCRIPTION
Refactor: Convert constructors to primary constructors

- Replaced traditional constructors with primary constructors for better readability and maintainability.
- Simplified property initialization and reduced boilerplate code.

This change leverages modern C# features to enhance code clarity and reduce redundancy.
