### PR TITLE
Enable IsAotCompatible.

### DIFF
--- a/src/FluentValidation/AssemblyScanner.cs
+++ b/src/FluentValidation/AssemblyScanner.cs
@@ -23,12 +23,14 @@ namespace FluentValidation;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
 /// <summary>
 /// Class that can be used to find all the validators from a collection of types.
 /// </summary>
+[RequiresUnreferencedCode("Types might be removed")]
 public class AssemblyScanner : IEnumerable<AssemblyScanner.AssemblyScanResult> {
 	readonly IEnumerable<Type> _types;
 
@@ -87,7 +89,7 @@ public class AssemblyScanner : IEnumerable<AssemblyScanner.AssemblyScanResult> {
 	}
 
 	/// <summary>
-	/// Performs the specified action to all of the assembly scan results.
+	/// Performs the specified action on all the assembly scan results.
 	/// </summary>
 	public void ForEach(Action<AssemblyScanResult> action) {
 		foreach (var result in this) {

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1093,7 +1093,19 @@ public static partial class DefaultValidatorExtensions {
 	/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
 	/// <returns></returns>
 	public static IRuleBuilderOptions<T, TProperty> IsInEnum<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder)
-		=> ruleBuilder.SetValidator(new EnumValidator<T,TProperty>());
+		where TProperty : struct, Enum
+		=> ruleBuilder.SetValidator(new EnumValidator<T, TProperty>());
+
+	/// <summary>
+	/// Defines a enum value validator on the current rule builder that ensures that the specific value is a valid enum value.
+	/// </summary>
+	/// <typeparam name="T">Type of Enum being validated</typeparam>
+	/// <typeparam name="TProperty">Type of property being validated</typeparam>
+	/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+	/// <returns></returns>
+	public static IRuleBuilderOptions<T, TProperty?> IsInEnum<T, TProperty>(this IRuleBuilder<T, TProperty?> ruleBuilder)
+		where TProperty : struct, Enum
+		=> ruleBuilder.SetValidator(new NullableEnumValidator<T, TProperty>());
 
 	/// <summary>
 	/// Defines a scale precision validator on the current rule builder that ensures a decimal the specified precision and scale.

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -14,6 +14,7 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ContinuousIntegrationBuild Condition="'$(Configuration)'=='Release'">true</ContinuousIntegrationBuild>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup>
     <NoWarn>1591</NoWarn>

--- a/src/FluentValidation/ValidatorFactoryBase.cs
+++ b/src/FluentValidation/ValidatorFactoryBase.cs
@@ -19,11 +19,14 @@
 namespace FluentValidation;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 /// <summary>
 /// Factory for creating validators
 /// </summary>
 [Obsolete("IValidatorFactory and its implementors are deprecated and will be removed in a future release. Please use the Service Provider directly (or a DI container). For details see https://github.com/FluentValidation/FluentValidation/issues/1961")]
+[RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]
+[RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
 public abstract class ValidatorFactoryBase : IValidatorFactory {
 	/// <summary>
 	/// Gets a validator for a type

--- a/src/FluentValidation/Validators/EnumValidator.cs
+++ b/src/FluentValidation/Validators/EnumValidator.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 // Copyright (c) .NET Foundation and contributors.
 //
@@ -21,95 +21,129 @@
 namespace FluentValidation.Validators;
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
-public class EnumValidator<T, TProperty> : PropertyValidator<T, TProperty>, IEnumValidator {
-	private readonly Type _enumType = typeof(TProperty);
+public class EnumValidator<T, TProperty> : PropertyValidator<T, TProperty>, IEnumValidator
+	where TProperty : struct, Enum {
+	private static readonly Func<TProperty, bool> InvalidTypePredicate = static _ => false;
+	private readonly Func<TProperty, bool> _validator = CreateValidator();
 
-	public Type EnumType => _enumType;
+	public Type EnumType => typeof(TProperty);
 
 	public override string Name => "EnumValidator";
 
 	public override bool IsValid(ValidationContext<T> context, TProperty value) {
-		if (value == null) return true;
-
-		var underlyingEnumType = Nullable.GetUnderlyingType(_enumType) ?? _enumType;
-
-		if (!underlyingEnumType.IsEnum) return false;
-
-		if (underlyingEnumType.GetCustomAttribute<FlagsAttribute>() != null) {
-			return IsFlagsEnumDefined(underlyingEnumType, value);
-		}
-
-		return Enum.IsDefined(underlyingEnumType, value);
+		return _validator(value);
 	}
 
-	private static bool IsFlagsEnumDefined(Type enumType, object value) {
-		var typeName = Enum.GetUnderlyingType(enumType).Name;
+	private static bool EvaluateFlagEnumValues<TValue>(TValue propertyValue, TValue[] values)
+		where TValue : IBinaryNumber<TValue> {
+		var mask = default(TValue);
+		foreach (var value in values) {
+			if ((value & propertyValue) != value)
+				continue;
 
-		switch (typeName) {
-			case "Byte": {
-				var typedValue = (byte)value;
-				return EvaluateFlagEnumValues(typedValue, enumType);
-			}
-
-			case "Int16": {
-				var typedValue = (short)value;
-
-				return EvaluateFlagEnumValues(typedValue, enumType);
-			}
-
-			case "Int32": {
-				var typedValue = (int)value;
-
-				return EvaluateFlagEnumValues(typedValue, enumType);
-			}
-
-			case "Int64": {
-				var typedValue = (long)value;
-
-				return EvaluateFlagEnumValues(typedValue, enumType);
-			}
-
-			case "SByte": {
-				var typedValue = (sbyte)value;
-
-				return EvaluateFlagEnumValues(Convert.ToInt64(typedValue), enumType);
-			}
-
-			case "UInt16": {
-				var typedValue = (ushort)value;
-				return EvaluateFlagEnumValues(typedValue, enumType);
-			}
-
-			case "UInt32": {
-				var typedValue = (uint)value;
-				return EvaluateFlagEnumValues(typedValue, enumType);
-			}
-
-			case "UInt64": {
-				var typedValue = (ulong)value;
-				return EvaluateFlagEnumValues((long)typedValue, enumType);
-			}
-
-			default:
-				var message = $"Unexpected typeName of '{typeName}' during flags enum evaluation.";
-				throw new ArgumentOutOfRangeException(nameof(enumType), message);
-		}
-	}
-
-	private static bool EvaluateFlagEnumValues(long value, Type enumType) {
-		long mask = 0;
-		foreach (var enumValue in Enum.GetValues(enumType)) {
-			var enumValueAsInt64 = Convert.ToInt64(enumValue);
-			if ((enumValueAsInt64 & value) == enumValueAsInt64) {
-				mask |= enumValueAsInt64;
-				if (mask == value)
-					return true;
-			}
+			mask |= value;
+			if (mask == propertyValue)
+				return true;
 		}
 
 		return false;
+	}
+
+	internal static Func<TProperty, bool> CreateValidator() {
+		var enumType = typeof(TProperty);
+
+		if (!enumType.IsEnum) {
+			return InvalidTypePredicate;
+		}
+
+		if (enumType.GetCustomAttribute<FlagsAttribute>() is null) {
+			return value => Enum.IsDefined(enumType, value);
+		}
+
+		var values = Enum.GetValuesAsUnderlyingType(enumType);
+		if (values.Length == 0) return InvalidTypePredicate;
+
+		var elementType = values.GetType().GetElementType();
+		if (elementType is null) return InvalidTypePredicate;
+
+		var valueTypeCode = Type.GetTypeCode(elementType);
+
+		return valueTypeCode switch {
+			TypeCode.Char => InvokeEvaluateFlagEnumValues((char[])values),
+			TypeCode.SByte => InvokeEvaluateFlagEnumValues((sbyte[])values),
+			TypeCode.Byte => InvokeEvaluateFlagEnumValues((byte[])values),
+			TypeCode.Int16 => InvokeEvaluateFlagEnumValues((short[])values),
+			TypeCode.UInt16 => InvokeEvaluateFlagEnumValues((ushort[])values),
+			TypeCode.Int32 => InvokeEvaluateFlagEnumValues((int[])values),
+			TypeCode.UInt32 => InvokeEvaluateFlagEnumValues((uint[])values),
+			TypeCode.Int64 => InvokeEvaluateFlagEnumValues((long[])values),
+			TypeCode.UInt64 => InvokeEvaluateFlagEnumValues((ulong[])values),
+			_ => InvalidTypePredicate
+		};
+	}
+
+	private static Func<TProperty, bool> InvokeEvaluateFlagEnumValues<TValue>(TValue[] values)
+		where TValue : struct, IBinaryNumber<TValue> {
+
+		var hasZero = false;
+		var allFlags = default(TValue);
+		foreach (var v in values) {
+			if (v == TValue.Zero) hasZero = true;
+			allFlags |= v;
+		}
+
+		allFlags = ~allFlags;
+
+		var distinctNonZero = values
+			.Distinct()
+			.Where(x => x != TValue.Zero)
+			.ToArray();
+
+		// Sort to favor values that have a superset of bits set, then fall
+		// back to default comparison.
+		Array.Sort(distinctNonZero, (a, b) => {
+			var combined = a & b;
+			if (combined == b) return -1;
+			if (combined == a) return 1;
+
+			return -Comparer<TValue>.Default.Compare(a, b);
+		});
+
+		return propertyValue => {
+			var value = Unsafe.BitCast<TProperty, TValue>(propertyValue);
+
+			// Zero is valid if it's a defined value
+			if (value == TValue.Zero) {
+				return hasZero;
+			}
+
+			// All bits set in value must be set in the defined flags
+			if (allFlags != TValue.Zero && (value & allFlags) != TValue.Zero) {
+				return false;
+			}
+
+			// If value can be constructed by ORing any combination of defined values, it's valid.
+			// This is true if (value | allFlags) == allFlags (already checked above)
+			// But we also want to allow any combination of the defined values, not just the mask
+			// So, we check if all bits in value are covered by the defined values
+			// Additionally, we want to allow only valid combinations (not partial bits)
+			// So, we try to decompose value into a combination of defined values
+			var remaining = value;
+			foreach (var v in distinctNonZero) {
+				if ((value & v) != v) continue;
+
+				remaining &= ~v;
+				if (remaining == TValue.Zero) return true;
+			}
+
+			return false;
+		};
 	}
 
 	protected override string GetDefaultMessageTemplate(string errorCode) {
@@ -117,9 +151,24 @@ public class EnumValidator<T, TProperty> : PropertyValidator<T, TProperty>, IEnu
 	}
 }
 
+public class NullableEnumValidator<T, TProperty> : PropertyValidator<T, TProperty?>, IEnumValidator
+	where TProperty : struct, Enum {
+	private readonly Func<TProperty, bool> _validator = EnumValidator<T, TProperty>.CreateValidator();
+
+	public Type EnumType => typeof(TProperty);
+
+	public override string Name => "NullableEnumValidator";
+
+	public override bool IsValid(ValidationContext<T> context, TProperty? value) {
+		if (!value.HasValue) {
+			return true;
+		}
+
+		return _validator(value.Value);
+	}
+}
 
 public interface IEnumValidator : IPropertyValidator {
-
 	/// <summary>
 	/// Enum type being validated.
 	/// </summary>


### PR DESCRIPTION
Add attributes to items that should not be used in AOT builds.

Rework `EnumValidator` to support AOT builds without causing link errors along the lines of:
```
/_/src/FluentValidation/Validators/EnumValidator.cs(103): AOT analysis error IL3050: FluentValidation.Validators.EnumValidator`2.EvaluateFlagEnumValues(Int64,Type): Using member 'System.Enum.GetValues(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead. [/src/xxxx/xxxx.csproj]
```