### PR TITLE
Add Tamil (ta) Language

### DIFF
--- a/src/FluentValidation.Tests/LanguageManagerTests.cs
+++ b/src/FluentValidation.Tests/LanguageManagerTests.cs
@@ -27,6 +27,15 @@ public class LanguageManagerTests {
 	}
 
 	[Theory]
+	[InlineData("ta")]
+	public void Gets_translation_for_tamil_culture(string cultureName) {
+		using (new CultureScope(cultureName)) {
+			var msg = _languages.GetString("NotNullValidator");
+			msg.ShouldEqual("'{PropertyName}' காலியாக இருக்கக்கூடாது.");
+		}
+	}
+
+	[Theory]
 	[InlineData("sr")]
 	[InlineData("sr-Cyrl")]
 	[InlineData("sr-Cyrl-RS")]

--- a/src/FluentValidation/Resources/LanguageManager.cs
+++ b/src/FluentValidation/Resources/LanguageManager.cs
@@ -95,6 +95,7 @@ public class LanguageManager : ILanguageManager {
 			UzbekCyrillicLanguage.Culture => UzbekCyrillicLanguage.GetTranslation(key),
 			CatalanLanguage.Culture => CatalanLanguage.GetTranslation(key),
 			TajikLanguage.Culture => TajikLanguage.GetTranslation(key),
+			TamilLanguage.Culture => TamilLanguage.GetTranslation(key),
 			TeluguLanguage.Culture => TeluguLanguage.GetTranslation(key),
 			_ => null,
 		};

--- a/src/FluentValidation/Resources/Languages/TamilLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/TamilLanguage.cs
@@ -1,0 +1,60 @@
+﻿#region License
+
+// Copyright (c) .NET Foundation and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/FluentValidation/FluentValidation
+
+#endregion
+
+#pragma warning disable 618
+
+namespace FluentValidation.Resources;
+
+internal class TamilLanguage {
+	public const string Culture = "ta";
+
+	public static string GetTranslation(string key) => key switch {
+		"EmailValidator" => "'{PropertyName}' ஒரு செல்லுபடியான மின்னஞ்சல் முகவரி அல்ல.",
+		"GreaterThanOrEqualValidator" => "'{PropertyName}' '{ComparisonValue}'-ஐ விட அதிகமாக அல்லது சமமாக இருக்க வேண்டும்.",
+		"GreaterThanValidator" => "'{PropertyName}' '{ComparisonValue}'-ஐ விட அதிகமாக இருக்க வேண்டும்.",
+		"LengthValidator" => "'{PropertyName}' {MinLength} மற்றும் {MaxLength} எழுத்துகளுக்கு இடையில் இருக்க வேண்டும். நீங்கள் {TotalLength} எழுத்துகள் உள்ளீடு செய்துள்ளீர்கள்.",
+		"MinimumLengthValidator" => "'{PropertyName}' இன் நீளம் குறைந்தது {MinLength} எழுத்துகள் இருக்க வேண்டும். நீங்கள் {TotalLength} எழுத்துகள் உள்ளீடு செய்துள்ளீர்கள்.",
+		"MaximumLengthValidator" => "'{PropertyName}' இன் நீளம் அதிகபட்சம் {MaxLength} எழுத்துகள் இருக்க வேண்டும். நீங்கள் {TotalLength} எழுத்துகள் உள்ளீடு செய்துள்ளீர்கள்.",
+		"LessThanOrEqualValidator" => "'{PropertyName}' '{ComparisonValue}'-ஐ விட குறைவாக அல்லது சமமாக இருக்க வேண்டும்.",
+		"LessThanValidator" => "'{PropertyName}' '{ComparisonValue}'-ஐ விட குறைவாக இருக்க வேண்டும்.",
+		"NotEmptyValidator" => "'{PropertyName}' காலியாக இருக்கக்கூடாது.",
+		"NotEqualValidator" => "'{PropertyName}' '{ComparisonValue}'-இற்குச் சமமாக இருக்கக்கூடாது.",
+		"NotNullValidator" => "'{PropertyName}' காலியாக இருக்கக்கூடாது.",
+		"PredicateValidator" => "'{PropertyName}'க்கு குறிப்பிடப்பட்ட நிபந்தனை பூர்த்தி செய்யவில்லை.",
+		"AsyncPredicateValidator" => "'{PropertyName}'க்கு குறிப்பிடப்பட்ட நிபந்தனை பூர்த்தி செய்யவில்லை.",
+		"RegularExpressionValidator" => "'{PropertyName}' சரியான வடிவத்தில் இல்லை.",
+		"EqualValidator" => "'{PropertyName}' '{ComparisonValue}'-இற்குச் சமமாக இருக்க வேண்டும்.",
+		"ExactLengthValidator" => "'{PropertyName}' {MaxLength} எழுத்துகள் நீளமாக இருக்க வேண்டும். நீங்கள் {TotalLength} எழுத்துகள் உள்ளீடு செய்துள்ளீர்கள்.",
+		"InclusiveBetweenValidator" => "'{PropertyName}' {From} மற்றும் {To} இடையில் இருக்க வேண்டும். நீங்கள் {PropertyValue} உள்ளீடு செய்துள்ளீர்கள்.",
+		"ExclusiveBetweenValidator" => "'{PropertyName}' {From} மற்றும் {To} இடையே (விலக்கப்பட) இருக்க வேண்டும். நீங்கள் {PropertyValue} உள்ளீடு செய்துள்ளீர்கள்.",
+		"CreditCardValidator" => "'{PropertyName}' ஒரு செல்லுபடியான கிரெடிட் கார்டு எண் அல்ல.",
+		"ScalePrecisionValidator" => "'{PropertyName}' {ExpectedPrecision} இலக்கங்களை மொத்தமாக (அதில் {ExpectedScale} தசம இலக்கங்கள்) மீறக்கூடாது. {Digits} இலக்கங்கள் மற்றும் {ActualScale} தசமங்கள் உள்ளன.",
+		"EmptyValidator" => "'{PropertyName}' காலியாக இருக்க வேண்டும்.",
+		"NullValidator" => "'{PropertyName}' காலியாக இருக்க வேண்டும்.",
+		"EnumValidator" => "'{PropertyName}' இன் மதிப்பானது '{PropertyValue}'-ஐ உள்ளடக்கவில்லை.",
+		// Additional fallback messages
+		"Length_Simple" => "'{PropertyName}' {MinLength} மற்றும் {MaxLength} எழுத்துகளுக்கு இடையில் இருக்க வேண்டும்.",
+		"MinimumLength_Simple" => "'{PropertyName}' குறைந்தது {MinLength} எழுத்துகள் இருக்க வேண்டும்.",
+		"MaximumLength_Simple" => "'{PropertyName}' அதிகபட்சம் {MaxLength} எழுத்துகள் இருக்க வேண்டும்.",
+		"ExactLength_Simple" => "'{PropertyName}' {MaxLength} எழுத்துகள் நீளமாக இருக்க வேண்டும்.",
+		"InclusiveBetween_Simple" => "'{PropertyName}' {From} மற்றும் {To} இடையில் இருக்க வேண்டும்.",
+		_ => null,
+	};
+}


### PR DESCRIPTION
## I have been added a new language which is tamil language. So that I and others can use it in the projects. 
- 75+ million Tamil speakers worldwide
- Official language in India, Sri Lanka, and Singapore
- Tamil Nadu is India’s 2nd largest IT hub, home to thousands of .NET developers
- Despite its global relevance, Tamil localization is currently missing in FluentValidation, even though many other .NET libraries already support it (e.g., ASP.NET Core, DataAnnotations, etc.)
