### PR TITLE
ci: update checkout and setup-dotnet actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           10.0.x


### PR DESCRIPTION
Updated actions/checkout from v2 to v4 and actions/setup-dotnet from v2 to v4 to pick up the latest features, performance improvements, and security fixes.

Both actions maintain backward compatibility for basic usage. No breaking changes expected.