### PR TITLE
feat(PropertyChain): add GetParentChain() to PropertyChain.cs

### DIFF
--- a/src/FluentValidation.Tests/PropertyChainTests.cs
+++ b/src/FluentValidation.Tests/PropertyChainTests.cs
@@ -91,6 +91,34 @@ public class PropertyChainTests {
 		chain.ToString().ShouldEqual("Foo");
 	}
 
+	[Fact]
+	public void GetParentChain_returns_chain_without_last_member() {
+		chain.Add("Parent");
+		chain.AddIndexer(0);
+		chain.Add("Child");
+		chain.Add("Grandchild");
+
+		var trimmed = chain.GetParentChain();
+
+		trimmed.ToString().ShouldEqual("Parent[0].Child");
+	}
+
+	[Fact]
+	public void GetParentChain_returns_empty_chain_when_only_one_member() {
+		chain.Add("Foo");
+
+		var trimmed = chain.GetParentChain();
+
+		trimmed.ToString().ShouldEqual(string.Empty);
+	}
+
+	[Fact]
+	public void GetParentChain_returns_empty_chain_when_chain_is_empty() {
+		var trimmed = chain.GetParentChain();
+
+		trimmed.ToString().ShouldEqual(string.Empty);
+	}
+
 	public class Parent {
 		public Child Child { get; set; }
 	}

--- a/src/FluentValidation/Internal/PropertyChain.cs
+++ b/src/FluentValidation/Internal/PropertyChain.cs
@@ -20,6 +20,7 @@ namespace FluentValidation.Internal;
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -157,6 +158,18 @@ public class PropertyChain {
 		var chain = new PropertyChain(this);
 		chain.Add(propertyName);
 		return chain.ToString();
+	}
+
+	/// <summary>
+	/// Returns a new <see cref="PropertyChain"/> that contains all members except the last one.
+	/// Returns an empty chain if the current chain has zero or one member.
+	/// </summary>
+	public PropertyChain GetParentChain() {
+		if (_memberNames.Count <= 1) {
+			return new PropertyChain();
+		}
+
+		return new PropertyChain(_memberNames.Take(_memberNames.Count - 1));
 	}
 
 	/// <summary>


### PR DESCRIPTION
…to resolve parent property path

Add GetParentChain() to PropertyChain, which returns a new chain containing all members except the last one. This enables identifying all validation errors belonging to a parent property by comparing error property names against the parent chain path.