### PR TITLE
docs(ValidationFailure): Nullable annotations

### DIFF
--- a/src/FluentValidation/Results/ValidationFailure.cs
+++ b/src/FluentValidation/Results/ValidationFailure.cs
@@ -21,18 +21,13 @@ namespace FluentValidation.Results;
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 /// <summary>
 /// Defines a validation failure
 /// </summary>
 [Serializable]
 public class ValidationFailure {
-
-	/// <summary>
-	/// Creates a new validation failure.
-	/// </summary>
-	public ValidationFailure() {
-
-	}
 
 	/// <summary>
 	/// Creates a new validation failure.
@@ -44,7 +39,7 @@ public class ValidationFailure {
 	/// <summary>
 	/// Creates a new ValidationFailure.
 	/// </summary>
-	public ValidationFailure(string propertyName, string errorMessage, object attemptedValue) {
+	public ValidationFailure(string propertyName, string errorMessage, object? attemptedValue) {
 		PropertyName = propertyName;
 		ErrorMessage = errorMessage;
 		AttemptedValue = attemptedValue;
@@ -63,12 +58,12 @@ public class ValidationFailure {
 	/// <summary>
 	/// The property value that caused the failure.
 	/// </summary>
-	public object AttemptedValue { get; set; }
+	public object? AttemptedValue { get; set; }
 
 	/// <summary>
 	/// Custom state associated with the failure.
 	/// </summary>
-	public object CustomState { get; set; }
+	public object? CustomState { get; set; }
 
 	/// <summary>
 	/// Custom severity level associated with the failure.
@@ -78,12 +73,12 @@ public class ValidationFailure {
 	/// <summary>
 	/// Gets or sets the error code.
 	/// </summary>
-	public string ErrorCode { get; set; }
+	public string? ErrorCode { get; set; }
 
 	/// <summary>
 	/// Gets or sets the formatted message placeholder values.
 	/// </summary>
-	public Dictionary<string, object> FormattedMessagePlaceholderValues { get; set; }
+	public Dictionary<string, object>? FormattedMessagePlaceholderValues { get; set; }
 
 	/// <summary>
 	/// Creates a textual representation of the failure.


### PR DESCRIPTION
Encountered an issue when collecting validation failures as you can have nullable property values which even tho is obvious was not highlighted by the nullable annotations for the property. Making this class nullable aware (at least partially, I believe `AttemptedValue` is the most accessed property which can be null).

Had to remove the default constructor since `PropertyName` can never be null, in theory `ErrorMessage` could be if overloaded with null but this would require propagating the nullable annotation upstream.