### PR TITLE
Fix ArgumentNullException in TestValidationResult when a failure has a null PropertyName

### DIFF
--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using Xunit;
 using TestHelper;
 using System.Threading.Tasks;
+using Results;
 
 public class ValidatorTesterTester {
 	private TestValidator validator;
@@ -686,6 +687,20 @@ public class ValidatorTesterTester {
 		var result = validator.TestValidate(new Person());
 		result.ShouldHaveValidationErrorFor(x => x);
 		result.ShouldHaveValidationErrorFor("");
+	}
+
+	[Fact]
+	public void Does_not_throw_when_a_failure_has_a_null_property_name() {
+		var validator = new InlineValidator<Person>();
+		validator.RuleFor(x => x).Custom((x, ctx) => ctx.AddFailure(new ValidationFailure(null, "Model-level failure")));
+		validator.RuleFor(x => x.Surname).NotEmpty();
+
+		var result = validator.TestValidate(new Person());
+
+		// Asserting on an unrelated property should not throw just because
+		// another failure in the result has a null PropertyName.
+		result.ShouldHaveValidationErrorFor(x => x.Surname);
+		result.ShouldNotHaveValidationErrorFor(x => x.Forename);
 	}
 
 	[Fact]

--- a/src/FluentValidation/TestHelper/TestValidationResult.cs
+++ b/src/FluentValidation/TestHelper/TestValidationResult.cs
@@ -112,6 +112,6 @@ public class TestValidationResult<T> : ValidationResult {
 	}
 
 	private static string NormalizePropertyName(string propertyName) {
-		return Regex.Replace(propertyName, @"\[.*\]", string.Empty);
+		return propertyName is null ? null : Regex.Replace(propertyName, @"\[.*\]", string.Empty);
 	}
 }


### PR DESCRIPTION
Fixes #2361.

`NormalizePropertyName` in `TestValidationResult` passes `propertyName` straight into `Regex.Replace` without checking for null first. If any failure in the result has a null `PropertyName`, calling `ShouldHaveValidationErrorFor(...)` blows up with an `ArgumentNullException` - even if you're asserting on a totally different property.

One thing worth flagging: I couldn't get the crash to happen with the exact repro in the issue (`RuleFor(x => x).Must(...)`). Turns out `PropertyRule` already defaults unnamed model-level rules to `""` rather than `null`, so that path is fine. The null actually shows up when a `Custom` rule builds its own `ValidationFailure` directly, e.g.:

```csharp
RuleFor(x => x).Custom((x, ctx) => ctx.AddFailure(new ValidationFailure(null, "Order must have items.")));
RuleFor(x => x.CustomerName).NotEmpty();
```

`result.ShouldHaveValidationErrorFor(x => x.CustomerName)` throws on that, same exception as the issue. So the diagnosis was right, just the repro in the issue doesn't actually trigger it - added a test for the case that does.

Fix is a one-liner:

```csharp
private static string NormalizePropertyName(string propertyName) {
    return propertyName is null ? null : Regex.Replace(propertyName, @"\[.*\]", string.Empty);
}
```

Added `Does_not_throw_when_a_failure_has_a_null_property_name` to `ValidatorTesterTester.cs` - fails on main, passes with this change. Full suite still green (869 passed, 1 pre-existing skip).
