### PR TITLE
PropertyPath is incorrect in .When() on RuleForEach

### DIFF
--- a/src/FluentValidation.Tests/ConditionTests.cs
+++ b/src/FluentValidation.Tests/ConditionTests.cs
@@ -252,6 +252,73 @@ public class ConditionTests {
 		result.IsValid.ShouldBeFalse();
 	}
 
+	[Fact]
+	public void Can_access_property_path_in_condition() {
+		string propertyPath = null;
+		var validator = new TestValidator {
+			v => v.RuleFor(x => x.Forename).NotEmpty().When((_, c) => {
+				propertyPath = c.PropertyPath;
+				return true;
+			})
+		};
+
+		validator.Validate(new Person());
+
+		propertyPath.ShouldEqual("Forename");
+	}
+
+	[Fact]
+	public void Can_access_nested_property_path_in_condition() {
+		string propertyPath = null;
+
+		var validator = new TestValidator {
+			v => v.RuleFor(x => x.Address.Country.Name).NotEmpty().When((_, c) => {
+				propertyPath = c.PropertyPath;
+				return true;
+			})
+		};
+
+		validator.Validate(new Person { Address = new Address { Country = new Country { Name = "foo" } } });
+
+		propertyPath.ShouldEqual("Address.Country.Name");
+	}
+
+	[Fact]
+	public void Can_access_collection_item_property_path_in_condition() {
+		string propertyPath = null;
+
+		var validator = new TestValidator {
+			v => v.RuleForEach(x => x.Children)
+				.NotEmpty()
+				.When((_, c) => {
+					propertyPath = c.PropertyPath;
+					return true;
+			})
+		};
+
+		validator.Validate(new Person { Children = new List<Person> { new Person { Forename = "foo" } } });
+		propertyPath.ShouldEqual("Children");
+	}
+
+	[Fact]
+	public void Can_access_property_path_in_child_rules_condition() {
+		string propertyPath = null;
+
+		var validator = new TestValidator {
+			v => v.RuleForEach(x => x.Children)
+				.ChildRules(children => {
+					children.RuleFor(c => c.Forename).NotEmpty()
+						.When((_, c) => {
+							propertyPath = c.PropertyPath;
+							return true;
+						});
+				})
+		};
+
+		validator.Validate(new Person { Children = new List<Person> { new Person { Forename = "foo" } } });
+		propertyPath.ShouldEqual("Children[0].Forename");
+	}
+
 	private class TestConditionValidator : AbstractValidator<Person> {
 		public TestConditionValidator() {
 			RuleFor(x => x.Forename).NotNull().When(x => x.Id == 0);

--- a/src/FluentValidation.Tests/ConditionTests.cs
+++ b/src/FluentValidation.Tests/ConditionTests.cs
@@ -278,7 +278,7 @@ public class ConditionTests {
 			})
 		};
 
-		validator.Validate(new Person { Address = new Address { Country = new Country { Name = "foo" } } });
+		validator.Validate(new Person { Address = new Address { Country = new Country() } });
 
 		propertyPath.ShouldEqual("Address.Country.Name");
 	}
@@ -293,30 +293,42 @@ public class ConditionTests {
 				.When((_, c) => {
 					propertyPath = c.PropertyPath;
 					return true;
-			})
+				})
 		};
 
-		validator.Validate(new Person { Children = new List<Person> { new Person { Forename = "foo" } } });
+		validator.Validate(new Person { Children = new List<Person> { new Person() } });
 		propertyPath.ShouldEqual("Children");
 	}
 
 	[Fact]
 	public void Can_access_property_path_in_child_rules_condition() {
-		string propertyPath = null;
+		var propertyPaths = new List<string>();
 
 		var validator = new TestValidator {
 			v => v.RuleForEach(x => x.Children)
 				.ChildRules(children => {
-					children.RuleFor(c => c.Forename).NotEmpty()
+					children.RuleFor(c => c.Forename)
+						.NotEmpty()
 						.When((_, c) => {
-							propertyPath = c.PropertyPath;
+							propertyPaths.Add(c.PropertyPath);
+							return true;
+						});
+					children.RuleFor(c => c.Surname)
+						.NotEmpty()
+						.When((_, c) => {
+							propertyPaths.Add(c.PropertyPath);
 							return true;
 						});
 				})
 		};
 
-		validator.Validate(new Person { Children = new List<Person> { new Person { Forename = "foo" } } });
-		propertyPath.ShouldEqual("Children[0].Forename");
+		validator.Validate(new Person { Children = new List<Person> { new Person(), new Person() } });
+		propertyPaths.ShouldEqual(new[] {
+			"Children[0].Forename",
+			"Children[0].Surname",
+			"Children[1].Forename",
+			"Children[1].Surname"
+		});
 	}
 
 	private class TestConditionValidator : AbstractValidator<Person> {

--- a/src/FluentValidation.Tests/ValidatorSelectorTests.cs
+++ b/src/FluentValidation.Tests/ValidatorSelectorTests.cs
@@ -193,6 +193,33 @@ public class ValidatorSelectorTests {
 	}
 
 	[Fact]
+	public void Only_validates_child_property_for_collection() {
+		var person = new Person {
+			Address = new Address {
+				Country = new Country()
+			},
+			Orders = new List<Order> {
+				new() {Amount = 5},
+				new() {Amount = 4}
+			}
+		};
+
+		var validator = new InlineValidator<Person>();
+		validator.RuleFor(x => x.Address.Country.Name).NotEmpty();
+		validator.RuleForEach(x => x.Orders).ChildRules(x => {
+			x.RuleFor(y => y.Amount).GreaterThan(6);
+			x.RuleFor(y => y.ProductName).MinimumLength(5);
+		});
+
+		var result = validator.Validate(person, opt => opt.IncludeProperties("Orders[]"));
+		result.Errors.Count.ShouldEqual(2);
+		result.Errors[0].PropertyName.ShouldEqual("Orders[0].Amount");
+		result.Errors[0].ErrorMessage.ShouldEqual("'Amount' must be greater than '6'.");
+		result.Errors[1].PropertyName.ShouldEqual("Orders[1].Amount");
+		result.Errors[1].ErrorMessage.ShouldEqual("'Amount' must be greater than '6'.");
+	}
+
+	[Fact]
 	public void Only_validates_child_property_for_single_item_in_collection() {
 		var person = new Person {
 			Address = new Address {

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -83,6 +83,8 @@ internal partial class CollectionPropertyRule<T, TElement> : RuleBase<T, IEnumer
 			propertyName = InferPropertyName(Expression);
 		}
 
+		context.InitializeForPropertyValidator(propertyName, _displayNameFunc, PropertyName);
+
 		// Ensure that this rule is allowed to run.
 		// The validatselector has the opportunity to veto this before any of the validators execute.
 		if (!context.Selector.CanExecute(this, propertyName, context)) {


### PR DESCRIPTION
I found this bug, but no place to report it. I also fixed it.

Problem: The `When` condition on the collection doesn't have the current property path, but previous or null, if the first condition.

The case which proves it: `Can_access_collection_item_property_path_in_condition`

Root cause: Since in `CollectionPropertyRule` the context is adjusted after the `When` condition is evaluated it contains the previous `PropertyPath`

Solution: Initialize the context, before the first use by external method calls.

Additional tests:
- ConditionTests has new tests that focus on the `PropertyPath` correctness.
- ValidatorSelectorTests has one additional test that focuses on the whole collection. (There were only sub-path tests.) I put the context initialization before the selector, because it also gets the context, but after testing, I realized it only uses the explicit `propertyPath` parameter. Regardless, I left it there.