### PR TITLE
Fix spelling typos in code comments and test names

### DIFF
--- a/src/FluentValidation.Tests/CollectionValidatorWithParentTests.cs
+++ b/src/FluentValidation.Tests/CollectionValidatorWithParentTests.cs
@@ -224,7 +224,7 @@ public class CollectionValidatorWithParentTests {
 	}
 
 	[Fact]
-	public void Should_work_with_top_level_collection_validator_and_overriden_name() {
+	public void Should_work_with_top_level_collection_validator_and_overridden_name() {
 		var personValidator = new InlineValidator<Person>();
 		personValidator.RuleFor(x => x.Surname).NotNull();
 

--- a/src/FluentValidation.Tests/ValidateAndThrowTester.cs
+++ b/src/FluentValidation.Tests/ValidateAndThrowTester.cs
@@ -144,7 +144,7 @@ public class ValidateAndThrowTester {
 
 	[Fact]
 	public void ValidationException_provides_correct_message_when_appendDefaultMessage_true() {
-		var userMessage = "exception occured during testing";
+		var userMessage = "exception occurred during testing";
 		var validationFailures = new List<ValidationFailure> {new ValidationFailure("test", "test")};
 		var exception = new ValidationException(validationFailures);
 		var exceptionWithUserMessage = new ValidationException(userMessage, validationFailures, true);
@@ -154,7 +154,7 @@ public class ValidateAndThrowTester {
 
 	[Fact]
 	public void ValidationException_provides_correct_message_when_appendDefaultMessage_false() {
-		var userMessage = "exception occured during testing";
+		var userMessage = "exception occurred during testing";
 		var validationFailures = new List<ValidationFailure> {new ValidationFailure("test", "test")};
 		var exceptionWithUserMessage = new ValidationException(userMessage, validationFailures, false);
 

--- a/src/FluentValidation.Tests/ValidatorSelectorTests.cs
+++ b/src/FluentValidation.Tests/ValidatorSelectorTests.cs
@@ -65,7 +65,7 @@ public class ValidatorSelectorTests {
 	}
 
 	[Fact]
-	public void Validates_nullable_property_with_overriden_name_when_selected() {
+	public void Validates_nullable_property_with_overridden_name_when_selected() {
 
 		var validator = new InlineValidator<TestObject> {
 			v => v.RuleFor(x => x.SomeNullableProperty.Value)

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -76,7 +76,7 @@ internal partial class CollectionPropertyRule<T, TElement> : RuleBase<T, IEnumer
 			displayName = string.Empty;
 		}
 
-		// Construct the full name of the property, taking into account overriden property names and the chain (if we're in a nested validator)
+		// Construct the full name of the property, taking into account overridden property names and the chain (if we're in a nested validator)
 		string propertyName = context.PropertyChain.BuildPropertyPath(PropertyName ?? displayName);
 
 		if (string.IsNullOrEmpty(propertyName)) {
@@ -84,7 +84,7 @@ internal partial class CollectionPropertyRule<T, TElement> : RuleBase<T, IEnumer
 		}
 
 		// Ensure that this rule is allowed to run.
-		// The validatselector has the opportunity to veto this before any of the validators execute.
+		// The validator selector has the opportunity to veto this before any of the validators execute.
 		if (!context.Selector.CanExecute(this, propertyName, context)) {
 			return;
 		}

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -57,11 +57,11 @@ internal partial class PropertyRule<T, TProperty> : RuleBase<T, TProperty, TProp
 			displayName = string.Empty;
 		}
 
-		// Construct the full name of the property, taking into account overriden property names and the chain (if we're in a nested validator)
+		// Construct the full name of the property, taking into account overridden property names and the chain (if we're in a nested validator)
 		string propertyPath = context.PropertyChain.BuildPropertyPath(PropertyName ?? displayName);
 
 		// Ensure that this rule is allowed to run.
-		// The validatselector has the opportunity to veto this before any of the validators execute.
+		// The validator selector has the opportunity to veto this before any of the validators execute.
 		if (!context.Selector.CanExecute(this, propertyPath, context)) {
 			return;
 		}


### PR DESCRIPTION
Corrects a few misspellings found while reading through the codebase.
All changes are limited to code comments and test code — no shipping or
public API, runtime behaviour, or validation messages are affected, so
no new tests are required.

- "overriden" -> "overridden"
    src/FluentValidation/Internal/PropertyRule.cs (comment)
    src/FluentValidation/Internal/CollectionPropertyRule.cs (comment)
    src/FluentValidation.Tests/CollectionValidatorWithParentTests.cs (test name)
    src/FluentValidation.Tests/ValidatorSelectorTests.cs (test name)

- "validatselector" -> "validator selector"
    src/FluentValidation/Internal/PropertyRule.cs (comment)
    src/FluentValidation/Internal/CollectionPropertyRule.cs (comment)

- "occured" -> "occurred"
    src/FluentValidation.Tests/ValidateAndThrowTester.cs (test message strings)