### PR TITLE
Fix ValidatorSelectorTests failing under non-English cultures

### DIFF
--- a/src/FluentValidation.Tests/ValidatorSelectorTests.cs
+++ b/src/FluentValidation.Tests/ValidatorSelectorTests.cs
@@ -23,6 +23,9 @@ using Xunit;
 using System.Threading.Tasks;
 
 public class ValidatorSelectorTests {
+	public ValidatorSelectorTests() {
+		CultureScope.SetDefaultCulture();
+	}
 
 	[Fact]
 	public void MemberNameValidatorSelector_returns_true_when_property_name_matches() {


### PR DESCRIPTION
ValidatorSelectorTests asserts against the default (English) validation
messages, for example:

    result.Errors[0].ErrorMessage.ShouldEqual("'Address Country Name' must not be empty.");

Unlike the rest of the test suite, this class does not pin the thread
culture, so these assertions rely on the tes
being English. When the tests run on a machine configured with a
non-English culture, FluentValidation resolv
message instead and the assertions fail. For example, under pt-BR:

    Expected: 'Address Country Name' must not be empty.
    Actual:   'Address Country Name' deve ser informado.

Four tests are affected:
  - Only_validates_doubly_nested_property
  - Only_validates_child_property_for_single_item_in_collection
  - Only_validates_single_child_property_of_
  - Only_validates_single_child_property_of_all_elements_in_nested_collection

Pin the culture in the class constructor via
CultureScope.SetDefaultCulture() helper, matching the pattern already
used elsewhere in the suite (e.g. ValidateAndThrowTester). This is a
test-only change; no product code or behaviour is affected.

Verified by running the FluentValidation.Tests suite on a non-English
(pt-BR) host: the four tests now pass with no regressions.