### PR TITLE
Remove redundant package references

### DIFF
--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -23,10 +23,6 @@ Full release notes can be found at https://github.com/FluentValidation/FluentVal
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="Zomp.SyncMethodGenerator" Version="1.3.8-beta" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The project targets `net8.0` only, so the following packages are no longer needed:

- **`Microsoft.NETFramework.ReferenceAssemblies`**
- **`System.Threading.Tasks.Extensions`** (conditional on `netstandard2.0`) - no `netstandard2.0` target exists

Also applied minor whitespace/formatting cleanup across the affected project files.