### PR TITLE
docs: Clarify RegularExpressionValidator anchoring (newline semantics)

### DIFF
--- a/docs/built-in-validators.md
+++ b/docs/built-in-validators.md
@@ -263,6 +263,14 @@ String format args:
 * `{RegularExpression}` – Regular expression that was not matched
 * `{PropertyPath}` - The full path of the property
 
+Note: If you're used to ASP.NET's `[RegularExpression]` DataAnnotations attribute, be careful not to
+be caught out: FluentValidation does not enforce a whole-string match implicitly, so you need to
+anchor the pattern strictly yourself, e.g. `Matches(@"\A\d{5}\z")`. For example, using
+`Matches(@"^\d{5}$")` will accept `"12345\n"`, which is typically undesired behaviour for single-line
+fields such as API validation. If using [Clientside Validation](aspnet.html#clientside-validation), take into
+consideration that JavaScript doesn't support some .NET regex anchors, so you might need to use a "no character
+follows" negative lookahead or other alternative expression where anchors like `\z` aren't supported.
+
 ## Email Validator
 Ensures that the value of the specified property is a valid email address format.
 

--- a/docs/built-in-validators.md
+++ b/docs/built-in-validators.md
@@ -267,9 +267,7 @@ Note: If you're used to ASP.NET's `[RegularExpression]` DataAnnotations attribut
 be caught out: FluentValidation does not enforce a whole-string match implicitly, so you need to
 anchor the pattern strictly yourself, e.g. `Matches(@"\A\d{5}\z")`. For example, using
 `Matches(@"^\d{5}$")` will accept `"12345\n"`, which is typically undesired behaviour for single-line
-fields such as API validation. If using [Clientside Validation](aspnet.html#clientside-validation), take into
-consideration that JavaScript doesn't support some .NET regex anchors, so you might need to use a "no character
-follows" negative lookahead or other alternative expression where anchors like `\z` aren't supported.
+fields such as API validation.
 
 ## Email Validator
 Ensures that the value of the specified property is a valid email address format.

--- a/src/FluentValidation.Tests/RegularExpressionValidatorTests.cs
+++ b/src/FluentValidation.Tests/RegularExpressionValidatorTests.cs
@@ -30,7 +30,8 @@ public class RegularExpressionValidatorTests {
 	public  RegularExpressionValidatorTests() {
 		CultureScope.SetDefaultCulture();
 		validator = new TestValidator {
-			v => v.RuleFor(x => x.Surname).Matches(@"^\w\d$")
+			// \z (not $) avoids the trailing-newline pitfall — see built-in-validators.md
+			v => v.RuleFor(x => x.Surname).Matches(@"^\w\d\z")
 		};
 
 		validator2 = new TestValidator {
@@ -56,6 +57,20 @@ public class RegularExpressionValidatorTests {
 
 		result = validator.Validate(new Person{Surname = " 5"});
 		result.IsValid.ShouldBeFalse();
+	}
+
+	[Fact]
+	public void When_the_text_has_a_trailing_newline_the_strict_anchor_correctly_fails() {
+		var result = validator.Validate(new Person{Surname = "S3\n"});
+		result.IsValid.ShouldBeFalse();
+	}
+
+	[Fact]
+	public void When_using_dollar_anchor_a_trailing_newline_is_still_considered_a_match() {
+		// By design: unlike \z, $ (and \Z) also match just before a trailing newline.
+		var validator = new TestValidator(v => v.RuleFor(x => x.Surname).Matches(@"^\w\d$"));
+		var result = validator.Validate(new Person{Surname = "S3\n"});
+		result.IsValid.ShouldBeTrue();
 	}
 
 	[Fact]


### PR DESCRIPTION
Small PR to update docs and tests to clarify regex anchor behaviour, especially for anyone migrating from DataAnnotations.

Although this is standard .NET regex behaviour, think this is worth highlighting clearly as it can easily be overlooked by developers (and AI agents reading the docs/tests), leading to potentially incorrect validation being applied for typical single line field validations like the example "surname" test.

(The issue tracker isn't currently accepting new issues, so hope raising this PR without further discussion is ok)