### PR TITLE
fix: reject an inverted range when the comparer returns a negative other than -1

### DIFF
--- a/src/FluentValidation.Tests/ExclusiveBetweenValidatorTests.cs
+++ b/src/FluentValidation.Tests/ExclusiveBetweenValidatorTests.cs
@@ -128,6 +128,12 @@ public class ExclusiveBetweenValidatorTests {
 	}
 
 	[Fact]
+	public void When_the_to_is_smaller_than_the_from_then_the_validator_should_throw_for_chars() {
+		// char.CompareTo returns the difference ('a' vs 'c' is -2), not just -1.
+		Assert.Throws<ArgumentOutOfRangeException>(() => RangeValidatorFactory.CreateExclusiveBetween<Person, char>('c', 'a'));
+	}
+
+	[Fact]
 	public void When_the_validator_fails_the_error_message_should_be_set_for_strings() {
 		var validator = new TestValidator(v => v.RuleFor(x => x.Surname).ExclusiveBetween("bbb", "zzz"));
 		var result = validator.Validate(new Person { Surname = "aaa" });

--- a/src/FluentValidation.Tests/InclusiveBetweenValidatorTests.cs
+++ b/src/FluentValidation.Tests/InclusiveBetweenValidatorTests.cs
@@ -123,6 +123,12 @@ public class InclusiveBetweenValidatorTests {
 	}
 
 	[Fact]
+	public void When_the_to_is_smaller_than_the_from_then_the_validator_should_throw_for_chars() {
+		// char.CompareTo returns the difference ('a' vs 'c' is -2), not just -1.
+		Assert.Throws<ArgumentOutOfRangeException>(() => RangeValidatorFactory.CreateInclusiveBetween<Person, char>('c', 'a'));
+	}
+
+	[Fact]
 	public void When_the_validator_fails_the_error_message_should_be_set_for_strings() {
 		var validator = new TestValidator(v => v.RuleFor(x => x.Surname).InclusiveBetween("bbb", "zzz"));
 		var result = validator.Validate(new Person { Surname = "aaa" });

--- a/src/FluentValidation/Validators/RangeValidator.cs
+++ b/src/FluentValidation/Validators/RangeValidator.cs
@@ -34,7 +34,8 @@ public abstract class RangeValidator<T, TProperty> : PropertyValidator<T, TPrope
 
 		_explicitComparer = comparer;
 
-		if (comparer.Compare(to, from) == -1) {
+		// IComparer<T> only guarantees the sign, not the magnitude.
+		if (comparer.Compare(to, from) < 0) {
 			throw new ArgumentOutOfRangeException(nameof(to), "To should be larger than from.");
 		}
 	}


### PR DESCRIPTION

## Problem

`RangeValidator<T, TProperty>` (used by `InclusiveBetween` / `ExclusiveBetween`) guards
against an inverted range in its constructor:

```csharp
if (comparer.Compare(to, from) == -1) {
    throw new ArgumentOutOfRangeException(nameof(to), "To should be larger than from.");
}
```

The check compares the result against the literal `-1`. However, the
`IComparer<T>.Compare` / `IComparable<T>.CompareTo` contract only guarantees the *sign*
of the result: any value less than zero means "less than". It does not guarantee `-1`.

As a result the guard silently fails for legitimate comparers that return other negative
magnitudes:

* `char` bounds. `char.CompareTo` returns the arithmetic difference, e.g.
  `'a'.CompareTo('c') == -2`. So `InclusiveBetween('c', 'a')` (an inverted range) is
  accepted instead of throwing, producing a validator that can never pass.
* Custom `IComparer<T>` implementations passed to the `InclusiveBetween` /
  `ExclusiveBetween` overloads. Returning `x - y` (a very common pattern) yields
  magnitudes other than 1.
* Culture-sensitive `string` comparisons can also return magnitudes other than 1.

This is inconsistent with the existing behaviour for `int` (`InclusiveBetween(10, 1)`
throws, because `int.CompareTo` happens to return `-1`) and defeats the guard's stated
intent of rejecting `to < from`.

## Fix

Compare against `< 0` instead of `== -1`, matching the documented comparer contract.

`src/FluentValidation/Validators/RangeValidator.cs`

## Tests

Added `char`-bound counterparts to the existing "to is smaller than from should throw"
tests in both `InclusiveBetweenValidatorTests` and `ExclusiveBetweenValidatorTests`.

Before the fix both new tests fail (no exception thrown); after the fix they pass. All
45 tests across the two between-validator suites pass, with no regressions.

## Build / test gate

* SDK: .NET 10.0.400 (via `global.json` roll-forward), library TFM `net8.0`.
* `dotnet build src/FluentValidation/FluentValidation.csproj -c Release` -> 0 errors.
* `dotnet test ... --filter "FullyQualifiedName~should_throw_for_chars"`:
  fails (2/2) before the fix, passes (2/2) after.
* `dotnet test ... --filter "FullyQualifiedName~BetweenValidatorTests"` -> 45 passed.
